### PR TITLE
Use the current Node.js version 6.x in our dev build environment. 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,7 @@ https://www.youtube.com/watch?list=PLOETEcp3DkCq788xapkP_OU-78jhTf68j&v=AMwjDibF
 
 == Development Environment
 
-You need to have installed https://docs.npmjs.com/getting-started/installing-node[Node.js >= 5 and npm >= 3] on
+You need to have installed https://docs.npmjs.com/getting-started/installing-node[Node.js >= 6  and npm >= 3] on
 your system.
 
 Install these node packages globally in the system

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-components",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "UI components for ManageIQ project",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   "authors": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 5.1.0",
+    "node": ">= 6.0.0",
     "npm": ">= 3.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This so we can utilize the latest ES6 in our build process without using Babel for transpiler for webpack builds in infrastructure. 

_NOTE: this only relevant to dev build and doesn't effect the runtime js components generated._

Version 5 is already deprecated and version 6.3.1 is the current version. Version 4 will be replaced with version 6 on Long Term Support(LTS) in October. The [LTS schedule](https://github.com/nodejs/LTS) is as follows:

![nodejs_lts__node_js_foundation_long-term_support_working_group](https://cloud.githubusercontent.com/assets/1312165/17388183/4b5b9c9e-59af-11e6-8098-959c13532b4c.jpg)
