### PR TITLE
Toolbar explorer

### DIFF
--- a/demo/controllers/toolbarMenuController.ts
+++ b/demo/controllers/toolbarMenuController.ts
@@ -23,7 +23,6 @@ export default class ToolbarMenuController {
         'function-call': target.getAttribute('data-function'),
         'function-data': JSON.parse(target.getAttribute('data-function-data'))
       };
-      console.log(elementData);
     };
 
   }

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -44,18 +44,13 @@
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	__webpack_require__(15);
-	module.exports = __webpack_require__(17);
+	__webpack_require__(14);
+	module.exports = __webpack_require__(16);
 
 
 /***/ },
 /* 1 */,
-/* 2 */
-/***/ function(module, exports) {
-
-	module.exports = angular;
-
-/***/ },
+/* 2 */,
 /* 3 */,
 /* 4 */,
 /* 5 */,
@@ -67,22 +62,21 @@
 /* 11 */,
 /* 12 */,
 /* 13 */,
-/* 14 */,
-/* 15 */
+/* 14 */
 /***/ function(module, exports) {
 
 	// removed by extract-text-webpack-plugin
 
 /***/ },
-/* 16 */,
-/* 17 */
+/* 15 */,
+/* 16 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(angular) {"use strict";
+	"use strict";
 	///<reference path="tsd.d.ts"/>
-	var services_1 = __webpack_require__(18);
-	var components_1 = __webpack_require__(21);
-	var filters_1 = __webpack_require__(32);
+	var services_1 = __webpack_require__(17);
+	var components_1 = __webpack_require__(20);
+	var filters_1 = __webpack_require__(30);
 	var miqStaticAssets;
 	(function (miqStaticAssets) {
 	    miqStaticAssets.app = angular.module('miqStaticAssets', ['ui.bootstrap', 'ui.bootstrap.tabs', 'rx', 'ngSanitize']);
@@ -91,15 +85,14 @@
 	    filters_1.default(miqStaticAssets.app);
 	})(miqStaticAssets || (miqStaticAssets = {}));
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)))
 
 /***/ },
-/* 18 */
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var endpointsService_1 = __webpack_require__(19);
-	var toolbarSettingsService_1 = __webpack_require__(20);
+	var endpointsService_1 = __webpack_require__(18);
+	var toolbarSettingsService_1 = __webpack_require__(19);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.service('MiQEndpointsService', endpointsService_1.default);
@@ -108,7 +101,7 @@
 
 
 /***/ },
-/* 19 */
+/* 18 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -136,7 +129,7 @@
 
 
 /***/ },
-/* 20 */
+/* 19 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -245,11 +238,11 @@
 
 
 /***/ },
-/* 21 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbar_menu_1 = __webpack_require__(22);
+	var toolbar_menu_1 = __webpack_require__(21);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    toolbar_menu_1.default(module);
@@ -257,14 +250,14 @@
 
 
 /***/ },
-/* 22 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarComponent_1 = __webpack_require__(23);
-	var toolbarButtonDirective_1 = __webpack_require__(25);
-	var toolbarListComponent_1 = __webpack_require__(27);
-	var toolbarViewComponent_1 = __webpack_require__(29);
+	var toolbarComponent_1 = __webpack_require__(22);
+	var toolbarButtonDirective_1 = __webpack_require__(24);
+	var toolbarListComponent_1 = __webpack_require__(26);
+	var toolbarViewComponent_1 = __webpack_require__(28);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.component('miqToolbarMenu', new toolbarComponent_1.default);
@@ -275,11 +268,11 @@
 
 
 /***/ },
-/* 23 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarType_1 = __webpack_require__(31);
+	var toolbarType_1 = __webpack_require__(32);
 	/**
 	 * @memberof miqStaticAssets
 	 * @ngdoc controller
@@ -358,7 +351,7 @@
 	     * @returns {string}
 	     */
 	    ToolbarController.prototype.getToolbarListType = function () {
-	        return toolbarType_1.default.BUTTON_SELECT.toString();
+	        return toolbarType_1.ToolbarType.BUTTON_SELECT;
 	    };
 	    /**
 	     * Helper method for getting string value of {@link ToolbarType.BUTTON}
@@ -367,7 +360,7 @@
 	     * @returns {string}
 	     */
 	    ToolbarController.prototype.getButtonType = function () {
-	        return toolbarType_1.default.BUTTON.toString();
+	        return toolbarType_1.ToolbarType.BUTTON;
 	    };
 	    /**
 	     * Helper method for getting string value of {@link ToolbarType.CUSTOM}
@@ -376,7 +369,7 @@
 	     * @returns {string}
 	     */
 	    ToolbarController.prototype.getCustomType = function () {
-	        return toolbarType_1.default.CUSTOM.toString();
+	        return toolbarType_1.ToolbarType.CUSTOM;
 	    };
 	    /**
 	     * Private static function for decoding html.
@@ -398,7 +391,7 @@
 	     * @returns {boolean} true|false if it's item with custom html.
 	     */
 	    ToolbarController.isCustom = function (item) {
-	        return item.name && item.name === toolbarType_1.default.CUSTOM.toString();
+	        return item.name && item.name === toolbarType_1.ToolbarType.CUSTOM;
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type and if this type is button or select.
@@ -414,7 +407,7 @@
 	            ToolbarController.isButtonTwoState(item));
 	    };
 	    ToolbarController.isButtonTwoState = function (item) {
-	        return item.type === toolbarType_1.default.BUTTON_TWO_STATE.toString();
+	        return item.type === toolbarType_1.ToolbarType.BUTTON_TWO_STATE;
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type is buttonSelect.
@@ -424,7 +417,7 @@
 	     * @returns {boolean} true|false if it's item with type equals to `"buttonSelect"`.
 	     */
 	    ToolbarController.isButtonSelect = function (item) {
-	        return item.type === toolbarType_1.default.BUTTON_SELECT.toString();
+	        return item.type === toolbarType_1.ToolbarType.BUTTON_SELECT;
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type is button.
@@ -434,7 +427,7 @@
 	     * @returns {boolean} true|false if it's item with type equals to `"button"`.
 	     */
 	    ToolbarController.isButton = function (item) {
-	        return item.type === toolbarType_1.default.BUTTON.toString();
+	        return item.type === toolbarType_1.ToolbarType.BUTTON;
 	    };
 	    return ToolbarController;
 	}());
@@ -481,7 +474,7 @@
 	var Toolbar = (function () {
 	    function Toolbar() {
 	        this.replace = true;
-	        this.template = __webpack_require__(24);
+	        this.template = __webpack_require__(23);
 	        this.controller = ToolbarController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -497,13 +490,13 @@
 
 
 /***/ },
-/* 24 */
+/* 23 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n    <div class=\"form-group miq-toolbar-group\"\n         ng-repeat=\"toolbarItem in vm.toolbarItems\"\n         ng-if=\"vm.hasContent(toolbarItem)\">\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: vm.getButtonType()}:true\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filterByStateAndView\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-repeat=\"item in toolbarItem | filter: {type: vm.getToolbarListType()}\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-repeat=\"item in toolbarItem | filter: {name: 'custom'}\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </div>\n    <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                      on-item-click=\"vm.onViewClick({item: item})\"\n                      class=\"miq-view-list\">\n    </miq-toolbar-view>\n</div>\n"
 
 /***/ },
-/* 25 */
+/* 24 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -526,7 +519,7 @@
 	var ToolbarButton = (function () {
 	    function ToolbarButton() {
 	        this.replace = true;
-	        this.template = __webpack_require__(26);
+	        this.template = __webpack_require__(25);
 	        this.scope = {
 	            toolbarButton: '<',
 	            onItemClick: '&'
@@ -544,13 +537,13 @@
 
 
 /***/ },
-/* 26 */
+/* 25 */
 /***/ function(module, exports) {
 
 	module.exports = "<button title=\"{{toolbarButton.title}}\"\n        data-explorer=\"{{item.explorer}}\"\n        data-confirm-tb=\"{{item.confirm}}\"\n        id=\"{{toolbarButton.id}}\"\n        name=\"{{toolbarButton.name}}\"\n        type=\"button\"\n        class=\"btn btn-default\"\n        data-click=\"{{toolbarButton.id}}\"\n        data-url=\"{{toolbarButton.url}}\"\n        data-url_parms=\"{{toolbarButton.url_parms}}\"\n        ng-class=\"{active: toolbarButton.selected, disabled: !toolbarButton.enabled}\"\n        ng-hide=\"toolbarButton.hidden\"\n        ng-click=\"onItemClick({item: toolbarButton, $event: $event})\">\n  <i class=\"{{toolbarButton.icon}}\" style=\"\"></i>&nbsp;\n</button>\n"
 
 /***/ },
-/* 27 */
+/* 26 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -588,7 +581,7 @@
 	var ToolbarList = (function () {
 	    function ToolbarList() {
 	        this.replace = true;
-	        this.template = __webpack_require__(28);
+	        this.template = __webpack_require__(27);
 	        this.controller = ToolbarListController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -603,13 +596,13 @@
 
 
 /***/ },
-/* 28 */
+/* 27 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"btn-group\" dropdown>\n  <button type=\"button\" dropdown-toggle class=\"btn dropdown-toggle btn-default\"\n          ng-class=\"{disabled: !vm.toolbarList.enabled}\" title=\"{{vm.toolbarList.title}}\">\n    <i class=\"{{vm.toolbarList.icon}}\" style=\"margin-right: 5px;\" ng-if=\"vm.toolbarList.icon\"></i>\n    {{vm.toolbarList.text}}\n    <span class=\"caret\"></span>\n  </button>\n  <ul class=\"dropdown-menu\" role=\"menu\">\n    <li ng-repeat=\"item in vm.toolbarList.items track by $index\" ng-class=\"{disabled: !item.enabled}\">\n      <a ng-if=\"item.type !== 'separator'\"\n         href=\"\"\n         data-explorer=\"{{item.explorer}}\"\n         data-confirm-tb=\"{{item.confirm}}\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         data-function=\"{{item.data.function}}\"\n         data-function-data=\"{{item.data['function-data']}}\"\n         data-target=\"{{item.data.target}}\"\n         data-toggle=\"{{item.data.toggle}}\"\n         data-click=\"{{item.id}}\"\n         name=\"{{item.id}}\"\n         id=\"{{item.id}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         data-url=\"{{item.url}}\">\n        <i ng-if=\"item.icon\" class=\"{{item.icon}}\"></i>\n        {{item.text}}\n      </a>\n      <div ng-if=\"item.type === 'separator'\" class=\"divider \" role=\"presentation\"></div>\n    </li>\n    <!---->\n  </ul>\n</div>\n"
 
 /***/ },
-/* 29 */
+/* 28 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -644,7 +637,7 @@
 	var ToolbarView = (function () {
 	    function ToolbarView() {
 	        this.replace = false;
-	        this.template = __webpack_require__(30);
+	        this.template = __webpack_require__(29);
 	        this.controller = ToolbarViewController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -659,79 +652,17 @@
 
 
 /***/ },
-/* 30 */
+/* 29 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"toolbar-pf-view-selector form-group\">\n  <ul class=\"list-inline\">\n    <li ng-repeat=\"item in vm.toolbarViews\" ng-class=\"{active: item.selected}\">\n      <a href=\"javascript:void(0)\"\n         title=\"{{item.title}}\"\n         id=\"{{item.id}}\"\n         data-url=\"{{item.url}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         ng-click=\"vm.onItemClick({item: item})\"\n         name=\"{{item.name}}\">\n        <i class=\"{{item.icon}}\" style=\"\"></i>\n      </a>\n    </li>\n  </ul>\n</div>\n"
 
 /***/ },
-/* 31 */
-/***/ function(module, exports) {
-
-	"use strict";
-	/**
-	 * Enum for toolbar types. It holds string value of item's type, so accessing these values can be called as:
-	 * ```Javascript
-	 * ToolbarType.BUTTON.toString();
-	 * ```
-	 * To string method will return string representation of enum type.
-	 * @memberof miqStaticAssets
-	 * @ngdoc enum
-	 * @name ToolbarType
-	 */
-	var ToolbarType = (function () {
-	    function ToolbarType(value) {
-	        this.value = value;
-	    }
-	    /**
-	     * It will return string value of selected toolbar type.
-	     * @memberof ToolbarType
-	     * @function toString
-	     * @returns {string} value of toolbar type.
-	     */
-	    ToolbarType.prototype.toString = function () {
-	        return this.value;
-	    };
-	    /**
-	     * Toolbar type BUTTON, string: `button`.
-	     * @memberof ToolbarType
-	     * @function BUTTON
-	     * @type {ToolbarType}
-	     */
-	    ToolbarType.BUTTON = new ToolbarType('button');
-	    /**
-	     * Toolbar type BUTTON_TWO_STATE, string: `buttonTwoState`.
-	     * @memberof ToolbarType
-	     * @function BUTTON_TWO_STATE
-	     * @type {ToolbarType}
-	     */
-	    ToolbarType.BUTTON_TWO_STATE = new ToolbarType('buttonTwoState');
-	    /**
-	     * Toolbar type BUTTON_SELECT, string: `buttonSelect`.
-	     * @memberof ToolbarType
-	     * @function BUTTON_SELECT
-	     * @type {ToolbarType}
-	     */
-	    ToolbarType.BUTTON_SELECT = new ToolbarType('buttonSelect');
-	    /**
-	     * Toolbar type CUSTOM, string: `custom`.
-	     * @memberof ToolbarType
-	     * @function CUSTOM
-	     * @type {ToolbarType}
-	     */
-	    ToolbarType.CUSTOM = new ToolbarType('custom');
-	    return ToolbarType;
-	}());
-	Object.defineProperty(exports, "__esModule", { value: true });
-	exports.default = ToolbarType;
-
-
-/***/ },
-/* 32 */
+/* 30 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var stateAndView_1 = __webpack_require__(33);
+	var stateAndView_1 = __webpack_require__(31);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.filter('filterByStateAndView', stateAndView_1.default.filter);
@@ -739,11 +670,11 @@
 
 
 /***/ },
-/* 33 */
+/* 31 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarType_1 = __webpack_require__(31);
+	var toolbarType_1 = __webpack_require__(32);
 	/**
 	 * @memberof miqStaticAssets
 	 * @ngdoc filter
@@ -753,8 +684,8 @@
 	    function StateAndViewFilter() {
 	    }
 	    /**
-	     * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id can't start with
-	     * `view_`.
+	     * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id
+	     * can't start with `view_`.
 	     * @memberof StateAndView
 	     * @function filter
 	     * @returns {function(any): any}
@@ -762,7 +693,7 @@
 	    StateAndViewFilter.filter = function () {
 	        return function (toolbarItems) {
 	            return toolbarItems.filter(function (toolbarItem) {
-	                return toolbarItem.type === toolbarType_1.default.BUTTON_TWO_STATE.toString() && toolbarItem.id.indexOf('view_') === -1;
+	                return toolbarItem.type === toolbarType_1.ToolbarType.BUTTON_TWO_STATE && toolbarItem.id.indexOf('view_') === -1;
 	            });
 	        };
 	    };
@@ -770,6 +701,41 @@
 	}());
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = StateAndViewFilter;
+
+
+/***/ },
+/* 32 */
+/***/ function(module, exports) {
+
+	"use strict";
+	/**
+	 * Enum for toolbar types. It holds string value of item's type.
+	 * @memberof miqStaticAssets
+	 * @ngdoc enum
+	 * @name ToolbarType
+	 */
+	exports.ToolbarType = {
+	    /**
+	     * Button type: `button`
+	     * @type {string}
+	     */
+	    BUTTON: 'button',
+	    /**
+	     * Button two state type: `buttonTwoState`
+	     * @type {string}
+	     */
+	    BUTTON_TWO_STATE: 'buttonTwoState',
+	    /**
+	     * Button select type: `buttonSelect`
+	     * @type {string}
+	     */
+	    BUTTON_SELECT: 'buttonSelect',
+	    /**
+	     * Custom type: `custom`
+	     * @type {string}
+	     */
+	    CUSTOM: 'custom',
+	};
 
 
 /***/ }

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -44,13 +44,18 @@
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	__webpack_require__(14);
-	module.exports = __webpack_require__(16);
+	__webpack_require__(15);
+	module.exports = __webpack_require__(17);
 
 
 /***/ },
 /* 1 */,
-/* 2 */,
+/* 2 */
+/***/ function(module, exports) {
+
+	module.exports = angular;
+
+/***/ },
 /* 3 */,
 /* 4 */,
 /* 5 */,
@@ -62,35 +67,39 @@
 /* 11 */,
 /* 12 */,
 /* 13 */,
-/* 14 */
+/* 14 */,
+/* 15 */
 /***/ function(module, exports) {
 
 	// removed by extract-text-webpack-plugin
 
 /***/ },
-/* 15 */,
-/* 16 */
+/* 16 */,
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
-	"use strict";
+	/* WEBPACK VAR INJECTION */(function(angular) {"use strict";
 	///<reference path="tsd.d.ts"/>
-	var services_1 = __webpack_require__(17);
-	var components_1 = __webpack_require__(20);
+	var services_1 = __webpack_require__(18);
+	var components_1 = __webpack_require__(21);
+	var filters_1 = __webpack_require__(32);
 	var miqStaticAssets;
 	(function (miqStaticAssets) {
 	    miqStaticAssets.app = angular.module('miqStaticAssets', ['ui.bootstrap', 'ui.bootstrap.tabs', 'rx', 'ngSanitize']);
 	    services_1.default(miqStaticAssets.app);
 	    components_1.default(miqStaticAssets.app);
+	    filters_1.default(miqStaticAssets.app);
 	})(miqStaticAssets || (miqStaticAssets = {}));
 
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(2)))
 
 /***/ },
-/* 17 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var endpointsService_1 = __webpack_require__(18);
-	var toolbarSettingsService_1 = __webpack_require__(19);
+	var endpointsService_1 = __webpack_require__(19);
+	var toolbarSettingsService_1 = __webpack_require__(20);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.service('MiQEndpointsService', endpointsService_1.default);
@@ -99,7 +108,7 @@
 
 
 /***/ },
-/* 18 */
+/* 19 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -127,7 +136,7 @@
 
 
 /***/ },
-/* 19 */
+/* 20 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -236,11 +245,11 @@
 
 
 /***/ },
-/* 20 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbar_menu_1 = __webpack_require__(21);
+	var toolbar_menu_1 = __webpack_require__(22);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    toolbar_menu_1.default(module);
@@ -248,14 +257,14 @@
 
 
 /***/ },
-/* 21 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarComponent_1 = __webpack_require__(22);
-	var toolbarButtonDirective_1 = __webpack_require__(24);
-	var toolbarListComponent_1 = __webpack_require__(26);
-	var toolbarViewComponent_1 = __webpack_require__(28);
+	var toolbarComponent_1 = __webpack_require__(23);
+	var toolbarButtonDirective_1 = __webpack_require__(25);
+	var toolbarListComponent_1 = __webpack_require__(27);
+	var toolbarViewComponent_1 = __webpack_require__(29);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.component('miqToolbarMenu', new toolbarComponent_1.default);
@@ -266,10 +275,11 @@
 
 
 /***/ },
-/* 22 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
+	var toolbarType_1 = __webpack_require__(31);
 	/**
 	 * @memberof miqStaticAssets
 	 * @ngdoc controller
@@ -342,6 +352,33 @@
 	        return this.$sce.trustAsHtml(escapedString);
 	    };
 	    /**
+	     * Helper method for getting string value of {@link ToolbarType.BUTTON_SELECT}
+	     * @memberof ToolbarController
+	     * @function getToolbarListType
+	     * @returns {string}
+	     */
+	    ToolbarController.prototype.getToolbarListType = function () {
+	        return toolbarType_1.default.BUTTON_SELECT.toString();
+	    };
+	    /**
+	     * Helper method for getting string value of {@link ToolbarType.BUTTON}
+	     * @memberof ToolbarController
+	     * @function getToolbarListType
+	     * @returns {string}
+	     */
+	    ToolbarController.prototype.getButtonType = function () {
+	        return toolbarType_1.default.BUTTON.toString();
+	    };
+	    /**
+	     * Helper method for getting string value of {@link ToolbarType.CUSTOM}
+	     * @memberof ToolbarController
+	     * @function getToolbarListType
+	     * @returns {string}
+	     */
+	    ToolbarController.prototype.getCustomType = function () {
+	        return toolbarType_1.default.CUSTOM.toString();
+	    };
+	    /**
 	     * Private static function for decoding html.
 	     * @memberof ToolbarController
 	     * @function htmlDecode
@@ -361,7 +398,7 @@
 	     * @returns {boolean} true|false if it's item with custom html.
 	     */
 	    ToolbarController.isCustom = function (item) {
-	        return item.name && item.name === 'custom';
+	        return item.name && item.name === toolbarType_1.default.CUSTOM.toString();
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type and if this type is button or select.
@@ -377,7 +414,7 @@
 	            ToolbarController.isButtonTwoState(item));
 	    };
 	    ToolbarController.isButtonTwoState = function (item) {
-	        return item.type === 'buttonTwoState';
+	        return item.type === toolbarType_1.default.BUTTON_TWO_STATE.toString();
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type is buttonSelect.
@@ -387,7 +424,7 @@
 	     * @returns {boolean} true|false if it's item with type equals to `"buttonSelect"`.
 	     */
 	    ToolbarController.isButtonSelect = function (item) {
-	        return item.type === 'buttonSelect';
+	        return item.type === toolbarType_1.default.BUTTON_SELECT.toString();
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type is button.
@@ -397,7 +434,7 @@
 	     * @returns {boolean} true|false if it's item with type equals to `"button"`.
 	     */
 	    ToolbarController.isButton = function (item) {
-	        return item.type === 'button';
+	        return item.type === toolbarType_1.default.BUTTON.toString();
 	    };
 	    return ToolbarController;
 	}());
@@ -444,7 +481,7 @@
 	var Toolbar = (function () {
 	    function Toolbar() {
 	        this.replace = true;
-	        this.template = __webpack_require__(23);
+	        this.template = __webpack_require__(24);
 	        this.controller = ToolbarController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -460,13 +497,13 @@
 
 
 /***/ },
-/* 23 */
+/* 24 */
 /***/ function(module, exports) {
 
-	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n    <div class=\"form-group miq-toolbar-group\"\n         ng-repeat=\"toolbarItem in vm.toolbarItems\"\n         ng-if=\"vm.hasContent(toolbarItem)\">\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: 'button'}:true\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: 'buttonTwoState'}:true | filter: {id: '!view'}\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-repeat=\"item in toolbarItem | filter: {type: 'buttonSelect'}\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-repeat=\"item in toolbarItem | filter: {name: 'custom'}\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </div>\n    <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                      on-item-click=\"vm.onViewClick({item: item})\"\n                      class=\"miq-view-list\">\n    </miq-toolbar-view>\n</div>\n\n\n<!--<button data-url_parms=\"?compare_task=same&amp;id=\" data-url=\"compare_miq_same\" title=\"Attributes with same values\" id=\"compare_same\" data-click=\"compare_same\" name=\"compare_same\" type=\"button\" class=\"btn btn-default\"><i class=\"product product-compare_same fa-lg\" style=\"\"></i>&nbsp;</button>-->\n"
+	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n    <div class=\"form-group miq-toolbar-group\"\n         ng-repeat=\"toolbarItem in vm.toolbarItems\"\n         ng-if=\"vm.hasContent(toolbarItem)\">\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: vm.getButtonType()}:true\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filterByStateAndView\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-repeat=\"item in toolbarItem | filter: {type: vm.getToolbarListType()}\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-repeat=\"item in toolbarItem | filter: {name: 'custom'}\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </div>\n    <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                      on-item-click=\"vm.onViewClick({item: item})\"\n                      class=\"miq-view-list\">\n    </miq-toolbar-view>\n</div>\n"
 
 /***/ },
-/* 24 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -489,7 +526,7 @@
 	var ToolbarButton = (function () {
 	    function ToolbarButton() {
 	        this.replace = true;
-	        this.template = __webpack_require__(25);
+	        this.template = __webpack_require__(26);
 	        this.scope = {
 	            toolbarButton: '<',
 	            onItemClick: '&'
@@ -507,13 +544,13 @@
 
 
 /***/ },
-/* 25 */
+/* 26 */
 /***/ function(module, exports) {
 
 	module.exports = "<button title=\"{{toolbarButton.title}}\"\n        data-explorer=\"{{item.explorer}}\"\n        data-confirm-tb=\"{{item.confirm}}\"\n        id=\"{{toolbarButton.id}}\"\n        name=\"{{toolbarButton.name}}\"\n        type=\"button\"\n        class=\"btn btn-default\"\n        data-click=\"{{toolbarButton.id}}\"\n        data-url=\"{{toolbarButton.url}}\"\n        data-url_parms=\"{{toolbarButton.url_parms}}\"\n        ng-class=\"{active: toolbarButton.selected, disabled: !toolbarButton.enabled}\"\n        ng-hide=\"toolbarButton.hidden\"\n        ng-click=\"onItemClick({item: toolbarButton, $event: $event})\">\n  <i class=\"{{toolbarButton.icon}}\" style=\"\"></i>&nbsp;\n</button>\n"
 
 /***/ },
-/* 26 */
+/* 27 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -551,7 +588,7 @@
 	var ToolbarList = (function () {
 	    function ToolbarList() {
 	        this.replace = true;
-	        this.template = __webpack_require__(27);
+	        this.template = __webpack_require__(28);
 	        this.controller = ToolbarListController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -566,13 +603,13 @@
 
 
 /***/ },
-/* 27 */
+/* 28 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"btn-group\" dropdown>\n  <button type=\"button\" dropdown-toggle class=\"btn dropdown-toggle btn-default\"\n          ng-class=\"{disabled: !vm.toolbarList.enabled}\" title=\"{{vm.toolbarList.title}}\">\n    <i class=\"{{vm.toolbarList.icon}}\" style=\"margin-right: 5px;\" ng-if=\"vm.toolbarList.icon\"></i>\n    {{vm.toolbarList.text}}\n    <span class=\"caret\"></span>\n  </button>\n  <ul class=\"dropdown-menu\" role=\"menu\">\n    <li ng-repeat=\"item in vm.toolbarList.items track by $index\" ng-class=\"{disabled: !item.enabled}\">\n      <a ng-if=\"item.type !== 'separator'\"\n         href=\"\"\n         data-explorer=\"{{item.explorer}}\"\n         data-confirm-tb=\"{{item.confirm}}\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         data-function=\"{{item.data.function}}\"\n         data-function-data=\"{{item.data['function-data']}}\"\n         data-target=\"{{item.data.target}}\"\n         data-toggle=\"{{item.data.toggle}}\"\n         data-click=\"{{item.id}}\"\n         name=\"{{item.id}}\"\n         id=\"{{item.id}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         data-url=\"{{item.url}}\">\n        <i ng-if=\"item.icon\" class=\"{{item.icon}}\"></i>\n        {{item.text}}\n      </a>\n      <div ng-if=\"item.type === 'separator'\" class=\"divider \" role=\"presentation\"></div>\n    </li>\n    <!---->\n  </ul>\n</div>\n"
 
 /***/ },
-/* 28 */
+/* 29 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -607,7 +644,7 @@
 	var ToolbarView = (function () {
 	    function ToolbarView() {
 	        this.replace = false;
-	        this.template = __webpack_require__(29);
+	        this.template = __webpack_require__(30);
 	        this.controller = ToolbarViewController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -622,10 +659,118 @@
 
 
 /***/ },
-/* 29 */
+/* 30 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"toolbar-pf-view-selector form-group\">\n  <ul class=\"list-inline\">\n    <li ng-repeat=\"item in vm.toolbarViews\" ng-class=\"{active: item.selected}\">\n      <a href=\"javascript:void(0)\"\n         title=\"{{item.title}}\"\n         id=\"{{item.id}}\"\n         data-url=\"{{item.url}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         ng-click=\"vm.onItemClick({item: item})\"\n         name=\"{{item.name}}\">\n        <i class=\"{{item.icon}}\" style=\"\"></i>\n      </a>\n    </li>\n  </ul>\n</div>\n"
+
+/***/ },
+/* 31 */
+/***/ function(module, exports) {
+
+	"use strict";
+	/**
+	 * Enum for toolbar types. It holds string value of item's type, so accessing these values can be called as:
+	 * ```Javascript
+	 * ToolbarType.BUTTON.toString();
+	 * ```
+	 * To string method will return string representation of enum type.
+	 * @memberof miqStaticAssets
+	 * @ngdoc enum
+	 * @name ToolbarType
+	 */
+	var ToolbarType = (function () {
+	    function ToolbarType(value) {
+	        this.value = value;
+	    }
+	    /**
+	     * It will return string value of selected toolbar type.
+	     * @memberof ToolbarType
+	     * @function toString
+	     * @returns {string} value of toolbar type.
+	     */
+	    ToolbarType.prototype.toString = function () {
+	        return this.value;
+	    };
+	    /**
+	     * Toolbar type BUTTON, string: `button`.
+	     * @memberof ToolbarType
+	     * @function BUTTON
+	     * @type {ToolbarType}
+	     */
+	    ToolbarType.BUTTON = new ToolbarType('button');
+	    /**
+	     * Toolbar type BUTTON_TWO_STATE, string: `buttonTwoState`.
+	     * @memberof ToolbarType
+	     * @function BUTTON_TWO_STATE
+	     * @type {ToolbarType}
+	     */
+	    ToolbarType.BUTTON_TWO_STATE = new ToolbarType('buttonTwoState');
+	    /**
+	     * Toolbar type BUTTON_SELECT, string: `buttonSelect`.
+	     * @memberof ToolbarType
+	     * @function BUTTON_SELECT
+	     * @type {ToolbarType}
+	     */
+	    ToolbarType.BUTTON_SELECT = new ToolbarType('buttonSelect');
+	    /**
+	     * Toolbar type CUSTOM, string: `custom`.
+	     * @memberof ToolbarType
+	     * @function CUSTOM
+	     * @type {ToolbarType}
+	     */
+	    ToolbarType.CUSTOM = new ToolbarType('custom');
+	    return ToolbarType;
+	}());
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = ToolbarType;
+
+
+/***/ },
+/* 32 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var stateAndView_1 = __webpack_require__(33);
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = function (module) {
+	    module.filter('filterByStateAndView', stateAndView_1.default.filter);
+	};
+
+
+/***/ },
+/* 33 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var toolbarType_1 = __webpack_require__(31);
+	/**
+	 * @memberof miqStaticAssets
+	 * @ngdoc filter
+	 * @name StateAndViewFilter
+	 */
+	var StateAndViewFilter = (function () {
+	    function StateAndViewFilter() {
+	    }
+	    /**
+	     * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id can't start with
+	     * `view_`.
+	     * @memberof StateAndView
+	     * @function filter
+	     * @returns {function(any): any}
+	     */
+	    StateAndViewFilter.filter = function () {
+	        return function (toolbarItems) {
+	            return toolbarItems.filter(function (toolbarItem) {
+	                return toolbarItem.type === toolbarType_1.default.BUTTON_TWO_STATE.toString() && toolbarItem.id.indexOf('view_') === -1;
+	            });
+	        };
+	    };
+	    return StateAndViewFilter;
+	}());
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = StateAndViewFilter;
+
 
 /***/ }
 /******/ ]);

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -373,7 +373,11 @@
 	     * @returns {boolean} true|false if it's item with button or button select type.
 	     */
 	    ToolbarController.isButtonOrSelect = function (item) {
-	        return item.type && ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item);
+	        return item.type && (ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item) ||
+	            ToolbarController.isButtonTwoState(item));
+	    };
+	    ToolbarController.isButtonTwoState = function (item) {
+	        return item.type === 'buttonTwoState';
 	    };
 	    /**
 	     * Private static function for checking if toolbar item type is buttonSelect.
@@ -459,7 +463,7 @@
 /* 23 */
 /***/ function(module, exports) {
 
-	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n    <div class=\"form-group miq-toolbar-group\"\n         ng-repeat=\"toolbarItem in vm.toolbarItems\"\n         ng-if=\"vm.hasContent(toolbarItem)\">\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: 'button'}:true\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-repeat=\"item in toolbarItem | filter: {type: 'buttonSelect'}\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-repeat=\"item in toolbarItem | filter: {name: 'custom'}\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </div>\n    <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                      on-item-click=\"vm.onViewClick({item: item})\"\n                      class=\"miq-view-list\">\n    </miq-toolbar-view>\n</div>\n"
+	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n    <div class=\"form-group miq-toolbar-group\"\n         ng-repeat=\"toolbarItem in vm.toolbarItems\"\n         ng-if=\"vm.hasContent(toolbarItem)\">\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: 'button'}:true\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-button ng-repeat=\"item in toolbarItem | filter: {type: 'buttonTwoState'}:true | filter: {id: '!view'}\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-repeat=\"item in toolbarItem | filter: {type: 'buttonSelect'}\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-repeat=\"item in toolbarItem | filter: {name: 'custom'}\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </div>\n    <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                      on-item-click=\"vm.onViewClick({item: item})\"\n                      class=\"miq-view-list\">\n    </miq-toolbar-view>\n</div>\n\n\n<!--<button data-url_parms=\"?compare_task=same&amp;id=\" data-url=\"compare_miq_same\" title=\"Attributes with same values\" id=\"compare_same\" data-click=\"compare_same\" name=\"compare_same\" type=\"button\" class=\"btn btn-default\"><i class=\"product product-compare_same fa-lg\" style=\"\"></i>&nbsp;</button>-->\n"
 
 /***/ },
 /* 24 */
@@ -506,7 +510,7 @@
 /* 25 */
 /***/ function(module, exports) {
 
-	module.exports = "<button title=\"{{toolbarButton.title}}\"\n        id=\"{{toolbarButton.id}}\"\n        name=\"{{toolbarButton.name}}\"\n        type=\"button\"\n        class=\"btn btn-default\"\n        data-click=\"{{toolbarButton.id}}\"\n        data-url=\"{{toolbarButton.url}}\"\n        data-url_parms=\"{{toolbarButton.url_parms}}\"\n        ng-click=\"onItemClick({item: toolbarButton, $event: $event})\">\n  <i class=\"{{toolbarButton.icon}}\" style=\"\"></i>&nbsp;\n</button>\n"
+	module.exports = "<button title=\"{{toolbarButton.title}}\"\n        data-explorer=\"{{item.explorer}}\"\n        data-confirm-tb=\"{{item.confirm}}\"\n        id=\"{{toolbarButton.id}}\"\n        name=\"{{toolbarButton.name}}\"\n        type=\"button\"\n        class=\"btn btn-default\"\n        data-click=\"{{toolbarButton.id}}\"\n        data-url=\"{{toolbarButton.url}}\"\n        data-url_parms=\"{{toolbarButton.url_parms}}\"\n        ng-class=\"{active: toolbarButton.selected, disabled: !toolbarButton.enabled}\"\n        ng-hide=\"toolbarButton.hidden\"\n        ng-click=\"onItemClick({item: toolbarButton, $event: $event})\">\n  <i class=\"{{toolbarButton.icon}}\" style=\"\"></i>&nbsp;\n</button>\n"
 
 /***/ },
 /* 26 */
@@ -565,7 +569,7 @@
 /* 27 */
 /***/ function(module, exports) {
 
-	module.exports = "<div class=\"btn-group\" dropdown>\n  <button type=\"button\" dropdown-toggle class=\"btn dropdown-toggle btn-default\"\n          ng-class=\"{disabled: !vm.toolbarList.enabled}\" title=\"{{vm.toolbarList.title}}\">\n    <i class=\"{{vm.toolbarList.icon}}\" style=\"margin-right: 5px;\" ng-if=\"vm.toolbarList.icon\"></i>\n    {{vm.toolbarList.text}}\n    <span class=\"caret\"></span>\n  </button>\n  <ul class=\"dropdown-menu\" role=\"menu\">\n    <li ng-repeat=\"item in vm.toolbarList.items track by $index\" ng-class=\"{disabled: !item.enabled}\">\n      <a href=\"\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         data-function=\"{{item.data.function}}\"\n         data-function-data=\"{{item.data['function-data']}}\"\n         data-target=\"{{item.data.target}}\"\n         data-toggle=\"{{item.data.toggle}}\"\n         data-click=\"{{item.id}}\"\n         name=\"{{item.id}}\"\n         id=\"{{item.id}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         data-url=\"{{item.url}}\">\n        <i ng-if=\"item.icon\" class=\"{{item.icon}}\"></i>\n        {{item.text}}\n      </a>\n    </li>\n  </ul>\n</div>\n"
+	module.exports = "<div class=\"btn-group\" dropdown>\n  <button type=\"button\" dropdown-toggle class=\"btn dropdown-toggle btn-default\"\n          ng-class=\"{disabled: !vm.toolbarList.enabled}\" title=\"{{vm.toolbarList.title}}\">\n    <i class=\"{{vm.toolbarList.icon}}\" style=\"margin-right: 5px;\" ng-if=\"vm.toolbarList.icon\"></i>\n    {{vm.toolbarList.text}}\n    <span class=\"caret\"></span>\n  </button>\n  <ul class=\"dropdown-menu\" role=\"menu\">\n    <li ng-repeat=\"item in vm.toolbarList.items track by $index\" ng-class=\"{disabled: !item.enabled}\">\n      <a ng-if=\"item.type !== 'separator'\"\n         href=\"\"\n         data-explorer=\"{{item.explorer}}\"\n         data-confirm-tb=\"{{item.confirm}}\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         data-function=\"{{item.data.function}}\"\n         data-function-data=\"{{item.data['function-data']}}\"\n         data-target=\"{{item.data.target}}\"\n         data-toggle=\"{{item.data.toggle}}\"\n         data-click=\"{{item.id}}\"\n         name=\"{{item.id}}\"\n         id=\"{{item.id}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         data-url=\"{{item.url}}\">\n        <i ng-if=\"item.icon\" class=\"{{item.icon}}\"></i>\n        {{item.text}}\n      </a>\n      <div ng-if=\"item.type === 'separator'\" class=\"divider \" role=\"presentation\"></div>\n    </li>\n    <!---->\n  </ul>\n</div>\n"
 
 /***/ },
 /* 28 */

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -5,7 +5,7 @@
   "opts": {
     "template": "node_modules/angular-jsdoc/angular-template",
     "destination": "dist/docs",
-    "readme": "README.adoc",
+    "readme": "README.md",
     "recourse": true
   },
   "plugins": [

--- a/src/components/toolbar-menu/toolbar-button.html
+++ b/src/components/toolbar-menu/toolbar-button.html
@@ -1,4 +1,6 @@
 <button title="{{toolbarButton.title}}"
+        data-explorer="{{item.explorer}}"
+        data-confirm-tb="{{item.confirm}}"
         id="{{toolbarButton.id}}"
         name="{{toolbarButton.name}}"
         type="button"
@@ -6,6 +8,8 @@
         data-click="{{toolbarButton.id}}"
         data-url="{{toolbarButton.url}}"
         data-url_parms="{{toolbarButton.url_parms}}"
+        ng-class="{active: toolbarButton.selected, disabled: !toolbarButton.enabled}"
+        ng-hide="toolbarButton.hidden"
         ng-click="onItemClick({item: toolbarButton, $event: $event})">
   <i class="{{toolbarButton.icon}}" style=""></i>&nbsp;
 </button>

--- a/src/components/toolbar-menu/toolbar-list.html
+++ b/src/components/toolbar-menu/toolbar-list.html
@@ -7,7 +7,10 @@
   </button>
   <ul class="dropdown-menu" role="menu">
     <li ng-repeat="item in vm.toolbarList.items track by $index" ng-class="{disabled: !item.enabled}">
-      <a href=""
+      <a ng-if="item.type !== 'separator'"
+         href=""
+         data-explorer="{{item.explorer}}"
+         data-confirm-tb="{{item.confirm}}"
          ng-click="vm.onItemClick({item: item, $event: $event})"
          data-function="{{item.data.function}}"
          data-function-data="{{item.data['function-data']}}"
@@ -21,6 +24,8 @@
         <i ng-if="item.icon" class="{{item.icon}}"></i>
         {{item.text}}
       </a>
+      <div ng-if="item.type === 'separator'" class="divider " role="presentation"></div>
     </li>
+    <!---->
   </ul>
 </div>

--- a/src/components/toolbar-menu/toolbar-menu.html
+++ b/src/components/toolbar-menu/toolbar-menu.html
@@ -6,6 +6,10 @@
                           toolbar-button="item"
                           on-item-click="vm.onItemClick(item, $event)">
       </miq-toolbar-button>
+      <miq-toolbar-button ng-repeat="item in toolbarItem | filter: {type: 'buttonTwoState'}:true | filter: {id: '!view'}"
+                          toolbar-button="item"
+                          on-item-click="vm.onItemClick(item, $event)">
+      </miq-toolbar-button>
       <miq-toolbar-list ng-repeat="item in toolbarItem | filter: {type: 'buttonSelect'}"
                         toolbar-list="item"
                         on-item-click="vm.onItemClick(item, $event)">
@@ -19,3 +23,6 @@
                       class="miq-view-list">
     </miq-toolbar-view>
 </div>
+
+
+<!--<button data-url_parms="?compare_task=same&amp;id=" data-url="compare_miq_same" title="Attributes with same values" id="compare_same" data-click="compare_same" name="compare_same" type="button" class="btn btn-default"><i class="product product-compare_same fa-lg" style=""></i>&nbsp;</button>-->

--- a/src/components/toolbar-menu/toolbar-menu.html
+++ b/src/components/toolbar-menu/toolbar-menu.html
@@ -2,15 +2,15 @@
     <div class="form-group miq-toolbar-group"
          ng-repeat="toolbarItem in vm.toolbarItems"
          ng-if="vm.hasContent(toolbarItem)">
-      <miq-toolbar-button ng-repeat="item in toolbarItem | filter: {type: 'button'}:true"
+      <miq-toolbar-button ng-repeat="item in toolbarItem | filter: {type: vm.getButtonType()}:true"
                           toolbar-button="item"
                           on-item-click="vm.onItemClick(item, $event)">
       </miq-toolbar-button>
-      <miq-toolbar-button ng-repeat="item in toolbarItem | filter: {type: 'buttonTwoState'}:true | filter: {id: '!view'}"
+      <miq-toolbar-button ng-repeat="item in toolbarItem | filterByStateAndView"
                           toolbar-button="item"
                           on-item-click="vm.onItemClick(item, $event)">
       </miq-toolbar-button>
-      <miq-toolbar-list ng-repeat="item in toolbarItem | filter: {type: 'buttonSelect'}"
+      <miq-toolbar-list ng-repeat="item in toolbarItem | filter: {type: vm.getToolbarListType()}"
                         toolbar-list="item"
                         on-item-click="vm.onItemClick(item, $event)">
       </miq-toolbar-list>
@@ -23,6 +23,3 @@
                       class="miq-view-list">
     </miq-toolbar-view>
 </div>
-
-
-<!--<button data-url_parms="?compare_task=same&amp;id=" data-url="compare_miq_same" title="Attributes with same values" id="compare_same" data-click="compare_same" name="compare_same" type="button" class="btn btn-default"><i class="product product-compare_same fa-lg" style=""></i>&nbsp;</button>-->

--- a/src/components/toolbar-menu/toolbarComponent.ts
+++ b/src/components/toolbar-menu/toolbarComponent.ts
@@ -1,4 +1,6 @@
 import {IToolbarItem} from '../../interfaces/toolbar';
+import ToolbarType from '../../interfaces/toolbarType';
+
 /**
  * @memberof miqStaticAssets
  * @ngdoc controller
@@ -73,6 +75,36 @@ export class ToolbarController {
   }
 
   /**
+   * Helper method for getting string value of {@link ToolbarType.BUTTON_SELECT}
+   * @memberof ToolbarController
+   * @function getToolbarListType
+   * @returns {string}
+   */
+  public getToolbarListType(): string {
+    return ToolbarType.BUTTON_SELECT.toString();
+  }
+
+  /**
+   * Helper method for getting string value of {@link ToolbarType.BUTTON}
+   * @memberof ToolbarController
+   * @function getToolbarListType
+   * @returns {string}
+   */
+  public getButtonType(): string {
+    return ToolbarType.BUTTON.toString();
+  }
+
+  /**
+   * Helper method for getting string value of {@link ToolbarType.CUSTOM}
+   * @memberof ToolbarController
+   * @function getToolbarListType
+   * @returns {string}
+   */
+  public getCustomType(): string {
+    return ToolbarType.CUSTOM.toString();
+  }
+
+  /**
    * Private static function for decoding html.
    * @memberof ToolbarController
    * @function htmlDecode
@@ -93,7 +125,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with custom html.
    */
   private static isCustom(item: IToolbarItem): boolean {
-    return item.name && item.name === 'custom';
+    return item.name && item.name === ToolbarType.CUSTOM.toString();
   }
 
   /**
@@ -111,7 +143,7 @@ export class ToolbarController {
   }
 
   private static isButtonTwoState(item: IToolbarItem): boolean {
-    return item.type === 'buttonTwoState';
+    return item.type === ToolbarType.BUTTON_TWO_STATE.toString();
   }
 
   /**
@@ -122,7 +154,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with type equals to `"buttonSelect"`.
    */
   private static isButtonSelect(item: IToolbarItem): boolean {
-    return item.type === 'buttonSelect';
+    return item.type === ToolbarType.BUTTON_SELECT.toString();
   }
 
   /**
@@ -133,7 +165,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with type equals to `"button"`.
    */
   private static isButton(item): boolean {
-    return item.type === 'button';
+    return item.type === ToolbarType.BUTTON.toString();
   }
 }
 

--- a/src/components/toolbar-menu/toolbarComponent.ts
+++ b/src/components/toolbar-menu/toolbarComponent.ts
@@ -1,5 +1,5 @@
 import {IToolbarItem} from '../../interfaces/toolbar';
-import ToolbarType from '../../interfaces/toolbarType';
+import {ToolbarType} from '../../interfaces/toolbarType';
 
 /**
  * @memberof miqStaticAssets
@@ -81,7 +81,7 @@ export class ToolbarController {
    * @returns {string}
    */
   public getToolbarListType(): string {
-    return ToolbarType.BUTTON_SELECT.toString();
+    return ToolbarType.BUTTON_SELECT;
   }
 
   /**
@@ -91,7 +91,7 @@ export class ToolbarController {
    * @returns {string}
    */
   public getButtonType(): string {
-    return ToolbarType.BUTTON.toString();
+    return ToolbarType.BUTTON;
   }
 
   /**
@@ -101,7 +101,7 @@ export class ToolbarController {
    * @returns {string}
    */
   public getCustomType(): string {
-    return ToolbarType.CUSTOM.toString();
+    return ToolbarType.CUSTOM;
   }
 
   /**
@@ -125,7 +125,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with custom html.
    */
   private static isCustom(item: IToolbarItem): boolean {
-    return item.name && item.name === ToolbarType.CUSTOM.toString();
+    return item.name && item.name === ToolbarType.CUSTOM;
   }
 
   /**
@@ -143,7 +143,7 @@ export class ToolbarController {
   }
 
   private static isButtonTwoState(item: IToolbarItem): boolean {
-    return item.type === ToolbarType.BUTTON_TWO_STATE.toString();
+    return item.type === ToolbarType.BUTTON_TWO_STATE;
   }
 
   /**
@@ -154,7 +154,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with type equals to `"buttonSelect"`.
    */
   private static isButtonSelect(item: IToolbarItem): boolean {
-    return item.type === ToolbarType.BUTTON_SELECT.toString();
+    return item.type === ToolbarType.BUTTON_SELECT;
   }
 
   /**
@@ -165,7 +165,7 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with type equals to `"button"`.
    */
   private static isButton(item): boolean {
-    return item.type === ToolbarType.BUTTON.toString();
+    return item.type === ToolbarType.BUTTON;
   }
 }
 

--- a/src/components/toolbar-menu/toolbarComponent.ts
+++ b/src/components/toolbar-menu/toolbarComponent.ts
@@ -106,7 +106,12 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with button or button select type.
    */
   private static isButtonOrSelect(item: IToolbarItem): boolean {
-    return item.type && ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item);
+    return item.type && (ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item) ||
+      ToolbarController.isButtonTwoState(item));
+  }
+
+  private static isButtonTwoState(item: IToolbarItem): boolean {
+    return item.type === 'buttonTwoState';
   }
 
   /**

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -1,0 +1,5 @@
+import StateAndViewFilter from './stateAndView';
+
+export default (module: ng.IModule) => {
+  module.filter('filterByStateAndView', StateAndViewFilter.filter);
+};

--- a/src/filters/stateAndView.ts
+++ b/src/filters/stateAndView.ts
@@ -1,0 +1,24 @@
+import {IToolbarItem} from '../interfaces/toolbar';
+import ToolbarType from '../interfaces/toolbarType';
+
+/**
+ * @memberof miqStaticAssets
+ * @ngdoc filter
+ * @name StateAndViewFilter
+ */
+export default class StateAndViewFilter {
+  /**
+   * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id can't start with
+   * `view_`.
+   * @memberof StateAndView
+   * @function filter
+   * @returns {function(any): any}
+   */
+  public static filter() {
+    return (toolbarItems: Array<IToolbarItem>): any => {
+      return toolbarItems.filter((toolbarItem: IToolbarItem) => {
+        return toolbarItem.type === ToolbarType.BUTTON_TWO_STATE.toString() && toolbarItem.id.indexOf('view_') === -1;
+      });
+    };
+  }
+}

--- a/src/filters/stateAndView.ts
+++ b/src/filters/stateAndView.ts
@@ -1,5 +1,5 @@
 import {IToolbarItem} from '../interfaces/toolbar';
-import ToolbarType from '../interfaces/toolbarType';
+import {ToolbarType} from '../interfaces/toolbarType';
 
 /**
  * @memberof miqStaticAssets
@@ -8,8 +8,8 @@ import ToolbarType from '../interfaces/toolbarType';
  */
 export default class StateAndViewFilter {
   /**
-   * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id can't start with
-   * `view_`.
+   * Filter items based on type and id. Type has to be {@link miqStaticAssets.ToolbarType.BUTTON_TWO_STATE} and id
+   * can't start with `view_`.
    * @memberof StateAndView
    * @function filter
    * @returns {function(any): any}
@@ -17,7 +17,7 @@ export default class StateAndViewFilter {
   public static filter() {
     return (toolbarItems: Array<IToolbarItem>): any => {
       return toolbarItems.filter((toolbarItem: IToolbarItem) => {
-        return toolbarItem.type === ToolbarType.BUTTON_TWO_STATE.toString() && toolbarItem.id.indexOf('view_') === -1;
+        return toolbarItem.type === ToolbarType.BUTTON_TWO_STATE && toolbarItem.id.indexOf('view_') === -1;
       });
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 ///<reference path="tsd.d.ts"/>
 import services from './services';
 import components from './components';
+import filters from './filters';
+
 module miqStaticAssets {
   export const app = angular.module('miqStaticAssets', ['ui.bootstrap', 'ui.bootstrap.tabs', 'rx', 'ngSanitize']);
   services(app);
   components(app);
+  filters(app);
 }

--- a/src/interfaces/toolbarType.ts
+++ b/src/interfaces/toolbarType.ts
@@ -1,56 +1,29 @@
 /**
- * Enum for toolbar types. It holds string value of item's type, so accessing these values can be called as:
- * ```Javascript
- * ToolbarType.BUTTON.toString();
- * ```
- * To string method will return string representation of enum type.
+ * Enum for toolbar types. It holds string value of item's type.
  * @memberof miqStaticAssets
  * @ngdoc enum
  * @name ToolbarType
  */
-export default class ToolbarType {
-
+export const ToolbarType  = {
   /**
-   * Toolbar type BUTTON, string: `button`.
-   * @memberof ToolbarType
-   * @function BUTTON
-   * @type {ToolbarType}
+   * Button type: `button`
+   * @type {string}
    */
-  public static BUTTON = new ToolbarType('button');
-
+  BUTTON: 'button',
   /**
-   * Toolbar type BUTTON_TWO_STATE, string: `buttonTwoState`.
-   * @memberof ToolbarType
-   * @function BUTTON_TWO_STATE
-   * @type {ToolbarType}
+   * Button two state type: `buttonTwoState`
+   * @type {string}
    */
-  public static BUTTON_TWO_STATE = new ToolbarType('buttonTwoState');
-
+  BUTTON_TWO_STATE: 'buttonTwoState',
   /**
-   * Toolbar type BUTTON_SELECT, string: `buttonSelect`.
-   * @memberof ToolbarType
-   * @function BUTTON_SELECT
-   * @type {ToolbarType}
+   * Button select type: `buttonSelect`
+   * @type {string}
    */
-  public static BUTTON_SELECT = new ToolbarType('buttonSelect');
-
+  BUTTON_SELECT: 'buttonSelect',
   /**
-   * Toolbar type CUSTOM, string: `custom`.
-   * @memberof ToolbarType
-   * @function CUSTOM
-   * @type {ToolbarType}
+   * Custom type: `custom`
+   * @type {string}
    */
-  public static CUSTOM = new ToolbarType('custom');
+  CUSTOM: 'custom',
+};
 
-  constructor(public value: string) {}
-
-  /**
-   * It will return string value of selected toolbar type.
-   * @memberof ToolbarType
-   * @function toString
-   * @returns {string} value of toolbar type.
-   */
-  public toString(): string {
-    return this.value;
-  }
-}

--- a/src/interfaces/toolbarType.ts
+++ b/src/interfaces/toolbarType.ts
@@ -1,0 +1,56 @@
+/**
+ * Enum for toolbar types. It holds string value of item's type, so accessing these values can be called as:
+ * ```Javascript
+ * ToolbarType.BUTTON.toString();
+ * ```
+ * To string method will return string representation of enum type.
+ * @memberof miqStaticAssets
+ * @ngdoc enum
+ * @name ToolbarType
+ */
+export default class ToolbarType {
+
+  /**
+   * Toolbar type BUTTON, string: `button`.
+   * @memberof ToolbarType
+   * @function BUTTON
+   * @type {ToolbarType}
+   */
+  public static BUTTON = new ToolbarType('button');
+
+  /**
+   * Toolbar type BUTTON_TWO_STATE, string: `buttonTwoState`.
+   * @memberof ToolbarType
+   * @function BUTTON_TWO_STATE
+   * @type {ToolbarType}
+   */
+  public static BUTTON_TWO_STATE = new ToolbarType('buttonTwoState');
+
+  /**
+   * Toolbar type BUTTON_SELECT, string: `buttonSelect`.
+   * @memberof ToolbarType
+   * @function BUTTON_SELECT
+   * @type {ToolbarType}
+   */
+  public static BUTTON_SELECT = new ToolbarType('buttonSelect');
+
+  /**
+   * Toolbar type CUSTOM, string: `custom`.
+   * @memberof ToolbarType
+   * @function CUSTOM
+   * @type {ToolbarType}
+   */
+  public static CUSTOM = new ToolbarType('custom');
+
+  constructor(public value: string) {}
+
+  /**
+   * It will return string value of selected toolbar type.
+   * @memberof ToolbarType
+   * @function toString
+   * @returns {string} value of toolbar type.
+   */
+  public toString(): string {
+    return this.value;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+"use strict";
 const settings = require('./application-settings.js');
 const webpack = require('webpack'),
   path = require('path'),


### PR DESCRIPTION
Explorer's toolbar contains two state buttons, so we have to enable these buttons and show them properly on toolbar.
These two state buttons uses `miq-button` component and set's specific classes (activate, disabled). We have to filter out `view` items from these two state buttons since they use same toolbarItem type.

New separators inside dropdown buttons.

Enable strict mode in webpack so the `npm` commands will not throw errors [Strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).