### PR TITLE
Reset countSelected after new toolbar object

### DIFF
--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -167,6 +167,7 @@
 	     * @returns {{items: Array<Array<IToolbarItem>>, dataViews: Array<IToolbarItem>}}
 	       */
 	    ToolbarSettingsService.prototype.generateToolbarObject = function (toolbarObject) {
+	        this.countSelected = 0;
 	        this.items = this.separateItems(toolbarObject.filter(function (item) { return !!item; }));
 	        this.dataViews = this.filterViews();
 	        return {

--- a/src/services/toolbarSettingsService.ts
+++ b/src/services/toolbarSettingsService.ts
@@ -36,6 +36,7 @@ export default class ToolbarSettingsService {
    * @returns {{items: Array<Array<IToolbarItem>>, dataViews: Array<IToolbarItem>}}
      */
   public generateToolbarObject(toolbarObject: Array<Array<IToolbarItem>>): IToolbarSettings {
+    this.countSelected = 0;
     this.items = this.separateItems(toolbarObject.filter(item => !!item));
     this.dataViews = this.filterViews();
     return {


### PR DESCRIPTION
When new toolbar is created we have to reset counter for number of selected items.