### PR TITLE
ToolbarView - update html to match patternfly 3.10

### DIFF
--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -44,8 +44,8 @@
 /* 0 */
 /***/ function(module, exports, __webpack_require__) {
 
-	__webpack_require__(18);
-	module.exports = __webpack_require__(20);
+	__webpack_require__(14);
+	module.exports = __webpack_require__(16);
 
 
 /***/ },
@@ -62,24 +62,20 @@
 /* 11 */,
 /* 12 */,
 /* 13 */,
-/* 14 */,
-/* 15 */,
-/* 16 */,
-/* 17 */,
-/* 18 */
+/* 14 */
 /***/ function(module, exports) {
 
 	// removed by extract-text-webpack-plugin
 
 /***/ },
-/* 19 */,
-/* 20 */
+/* 15 */,
+/* 16 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
 	///<reference path="tsd.d.ts"/>
-	var services_1 = __webpack_require__(21);
-	var components_1 = __webpack_require__(26);
+	var services_1 = __webpack_require__(17);
+	var components_1 = __webpack_require__(21);
 	var miqStaticAssets;
 	(function (miqStaticAssets) {
 	    miqStaticAssets.app = angular.module('miqStaticAssets', ['rx', 'ngSanitize']);
@@ -89,12 +85,12 @@
 
 
 /***/ },
-/* 21 */
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var endpointsService_1 = __webpack_require__(22);
-	var toolbarSettingsService_1 = __webpack_require__(23);
+	var endpointsService_1 = __webpack_require__(18);
+	var toolbarSettingsService_1 = __webpack_require__(19);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.service('MiQEndpointsService', endpointsService_1.default);
@@ -103,7 +99,7 @@
 
 
 /***/ },
-/* 22 */
+/* 18 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -131,11 +127,11 @@
 
 
 /***/ },
-/* 23 */
+/* 19 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarType_1 = __webpack_require__(24);
+	var toolbarType_1 = __webpack_require__(20);
 	var ToolbarSettingsService = (function () {
 	    /*@ngInject*/
 	    ToolbarSettingsService.$inject = ["$http", "MiQEndpointsService"];
@@ -255,7 +251,7 @@
 
 
 /***/ },
-/* 24 */
+/* 20 */
 /***/ function(module, exports) {
 
 	"use strict";
@@ -295,12 +291,11 @@
 
 
 /***/ },
-/* 25 */,
-/* 26 */
+/* 21 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbar_menu_1 = __webpack_require__(27);
+	var toolbar_menu_1 = __webpack_require__(22);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    toolbar_menu_1.default(module);
@@ -308,14 +303,14 @@
 
 
 /***/ },
-/* 27 */
+/* 22 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarComponent_1 = __webpack_require__(28);
-	var toolbarButtonDirective_1 = __webpack_require__(30);
-	var toolbarListComponent_1 = __webpack_require__(32);
-	var toolbarViewComponent_1 = __webpack_require__(34);
+	var toolbarComponent_1 = __webpack_require__(23);
+	var toolbarButtonDirective_1 = __webpack_require__(25);
+	var toolbarListComponent_1 = __webpack_require__(27);
+	var toolbarViewComponent_1 = __webpack_require__(29);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.component('miqToolbarMenu', new toolbarComponent_1.default);
@@ -326,11 +321,11 @@
 
 
 /***/ },
-/* 28 */
+/* 23 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var toolbarType_1 = __webpack_require__(24);
+	var toolbarType_1 = __webpack_require__(20);
 	/**
 	 * @memberof miqStaticAssets
 	 * @ngdoc controller
@@ -535,7 +530,7 @@
 	var Toolbar = (function () {
 	    function Toolbar() {
 	        this.replace = true;
-	        this.template = __webpack_require__(29);
+	        this.template = __webpack_require__(24);
 	        this.controller = ToolbarController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -551,13 +546,13 @@
 
 
 /***/ },
-/* 29 */
+/* 24 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"toolbar-pf-actions miq-toolbar-actions\">\n  <div class=\"form-group miq-toolbar-group\"\n       ng-repeat=\"toolbarItem in vm.toolbarItems\"\n       ng-if=\"vm.hasContent(toolbarItem)\">\n    <ng-repeat ng-repeat=\"item in toolbarItem \">\n      <miq-toolbar-button ng-if=\"item.type === vm.getButtonType()\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-button ng-if=\"item.type === vm.getButtonTwoState() && item.id.indexOf('view_') === -1\"\n                          toolbar-button=\"item\"\n                          on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-button>\n      <miq-toolbar-list ng-if=\"item.type === vm.getToolbarListType() && item.items.length > 0\"\n                        toolbar-list=\"item\"\n                        on-item-click=\"vm.onItemClick(item, $event)\">\n      </miq-toolbar-list>\n      <div ng-if=\"item.name == 'custom' && item.args && item.args.html\"\n           ng-bind-html=\"vm.trustAsHtml(item.args.html)\"\n           class=\"miq-custom-html\"></div>\n    </ng-repeat>\n  </div>\n  <miq-toolbar-view toolbar-views=\"vm.toolbarViews\"\n                    on-item-click=\"vm.onViewClick({item: item, $event: $event})\"\n                    class=\"miq-view-list\">\n  </miq-toolbar-view>\n</div>\n"
 
 /***/ },
-/* 30 */
+/* 25 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -580,7 +575,7 @@
 	var ToolbarButton = (function () {
 	    function ToolbarButton() {
 	        this.replace = true;
-	        this.template = __webpack_require__(31);
+	        this.template = __webpack_require__(26);
 	        this.scope = {
 	            toolbarButton: '<',
 	            onItemClick: '&'
@@ -598,13 +593,13 @@
 
 
 /***/ },
-/* 31 */
+/* 26 */
 /***/ function(module, exports) {
 
 	module.exports = "<button title=\"{{toolbarButton.title}}\"\n        data-explorer=\"{{toolbarButton.explorer}}\"\n        data-confirm-tb=\"{{toolbarButton.confirm}}\"\n        id=\"{{toolbarButton.id}}\"\n        name=\"{{toolbarButton.name}}\"\n        type=\"button\"\n        class=\"btn btn-default\"\n        data-click=\"{{toolbarButton.id}}\"\n        data-url=\"{{toolbarButton.url}}\"\n        data-url_parms=\"{{toolbarButton.url_parms}}\"\n        ng-class=\"{active: toolbarButton.selected, disabled: !toolbarButton.enabled}\"\n        ng-hide=\"toolbarButton.hidden\"\n        ng-click=\"onItemClick({item: toolbarButton, $event: $event})\">\n  <i ng-if=\"toolbarButton.icon\" class=\"{{toolbarButton.icon}}\" style=\"\"></i>\n  <img ng-if=\"toolbarButton.img_url && !toolbarButton.icon\" ng-src=\"{{toolbarButton.img_url}}\"\n       data-enabled=\"{{toolbarButton.img_url}}\"\n       data-disabled=\"{{toolbarButton.img_url}}\">\n  {{toolbarButton.text}}\n</button>\n"
 
 /***/ },
-/* 32 */
+/* 27 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -665,7 +660,7 @@
 	var ToolbarList = (function () {
 	    function ToolbarList() {
 	        this.replace = true;
-	        this.template = __webpack_require__(33);
+	        this.template = __webpack_require__(28);
 	        this.controller = ToolbarListController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -680,13 +675,13 @@
 
 
 /***/ },
-/* 33 */
+/* 28 */
 /***/ function(module, exports) {
 
 	module.exports = "<div class=\"btn-group\" dropdown ng-if=\"vm.isEmpty\">\n  <button type=\"button\" dropdown-toggle class=\"btn dropdown-toggle btn-default\"\n          ng-class=\"{disabled: !vm.toolbarList.enabled}\" title=\"{{vm.toolbarList.title}}\">\n    <i class=\"{{vm.toolbarList.icon}}\" style=\"margin-right: 5px;\" ng-if=\"vm.toolbarList.icon\"></i>\n    {{vm.toolbarList.text}}\n    <span class=\"caret\"></span>\n  </button>\n  <ul class=\"dropdown-menu\" role=\"menu\">\n    <li ng-repeat=\"item in vm.toolbarList.items track by $index\" ng-class=\"{disabled: !item.enabled}\">\n      <a ng-if=\"item.type !== 'separator'\"\n         ng-hide=\"item.hidden\"\n         href=\"\"\n         title=\"{{item.title}}\"\n         data-explorer=\"{{item.explorer}}\"\n         data-confirm-tb=\"{{item.confirm}}\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         data-function=\"{{item.data.function}}\"\n         data-function-data=\"{{item.data['function-data']}}\"\n         data-target=\"{{item.data.target}}\"\n         data-toggle=\"{{item.data.toggle}}\"\n         data-click=\"{{item.id}}\"\n         name=\"{{item.id}}\"\n         id=\"{{item.id}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         data-url=\"{{item.url}}\">\n        <i ng-if=\"item.icon\" class=\"{{item.icon}}\"></i>\n        <img ng-if=\"item.img_url && !item.icon\" ng-src=\"{{item.img_url}}\"\n             data-enabled=\"{{item.img_url}}\"\n             data-disabled=\"{{item.img_url}}\">\n        {{item.text}}\n      </a>\n      <div ng-if=\"item.type === 'separator'\" class=\"divider \" role=\"presentation\" ng-hide=\"item.hidden\"></div>\n    </li>\n  </ul>\n</div>\n"
 
 /***/ },
-/* 34 */
+/* 29 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -721,7 +716,7 @@
 	var ToolbarView = (function () {
 	    function ToolbarView() {
 	        this.replace = false;
-	        this.template = __webpack_require__(35);
+	        this.template = __webpack_require__(30);
 	        this.controller = ToolbarViewController;
 	        this.controllerAs = 'vm';
 	        this.bindings = {
@@ -736,10 +731,10 @@
 
 
 /***/ },
-/* 35 */
+/* 30 */
 /***/ function(module, exports) {
 
-	module.exports = "<div class=\"toolbar-pf-view-selector pull-right form-group\">\n  <ul class=\"list-inline\">\n    <li ng-repeat=\"item in vm.toolbarViews\" ng-class=\"{active: item.selected}\">\n      <a href=\"javascript:void(0)\"\n         title=\"{{item.title}}\"\n         id=\"{{item.id}}\"\n         data-url=\"{{item.url}}\"\n         data-url_parms=\"{{item.url_parms}}\"\n         ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n         name=\"{{item.name}}\">\n        <i class=\"{{item.icon}}\" style=\"\"></i>\n      </a>\n    </li>\n  </ul>\n</div>\n"
+	module.exports = "<div class=\"toolbar-pf-view-selector pull-right form-group\">\n  <button class=\"btn btn-link\"\n          ng-repeat=\"item in vm.toolbarViews\"\n          ng-class=\"{active: item.selected}\"\n          title=\"{{item.title}}\"\n          id=\"{{item.id}}\"\n          data-url=\"{{item.url}}\"\n          data-url_parms=\"{{item.url_parms}}\"\n          ng-click=\"vm.onItemClick({item: item, $event: $event})\"\n          name=\"{{item.name}}\">\n    <i class=\"{{item.icon}}\" style=\"\"></i>\n  </button>\n</div>\n"
 
 /***/ }
 /******/ ]);

--- a/src/components/toolbar-menu/toolbar-view.html
+++ b/src/components/toolbar-menu/toolbar-view.html
@@ -1,15 +1,13 @@
 <div class="toolbar-pf-view-selector pull-right form-group">
-  <ul class="list-inline">
-    <li ng-repeat="item in vm.toolbarViews" ng-class="{active: item.selected}">
-      <a href="javascript:void(0)"
-         title="{{item.title}}"
-         id="{{item.id}}"
-         data-url="{{item.url}}"
-         data-url_parms="{{item.url_parms}}"
-         ng-click="vm.onItemClick({item: item, $event: $event})"
-         name="{{item.name}}">
-        <i class="{{item.icon}}" style=""></i>
-      </a>
-    </li>
-  </ul>
+  <button class="btn btn-link"
+          ng-repeat="item in vm.toolbarViews"
+          ng-class="{active: item.selected}"
+          title="{{item.title}}"
+          id="{{item.id}}"
+          data-url="{{item.url}}"
+          data-url_parms="{{item.url_parms}}"
+          ng-click="vm.onItemClick({item: item, $event: $event})"
+          name="{{item.name}}">
+    <i class="{{item.icon}}" style=""></i>
+  </button>
 </div>

--- a/src/components/toolbar-menu/toolbarViewComponent.spec.ts
+++ b/src/components/toolbar-menu/toolbarViewComponent.spec.ts
@@ -39,19 +39,18 @@ describe('ToolbarButton test', () =>  {
 
     it('should create 3 views', () => {
       const contentElement = angular.element(compiledElement.html());
-      expect(contentElement.find('li').length).toBe(3);
+      expect(contentElement.find('button').length).toBe(3);
     });
 
     it('each view should have correct settings', () => {
-      angular.forEach(compiledElement.find('li'), (element, key) => {
-        let liElem = angular.element(element);
-        let linkElem = angular.element(liElem.html());
-        expect(liElem.hasClass('active')).toBe(!!scope.toolbarViews[key].selected);
-        expect(linkElem.attr('title')).toBe(scope.toolbarViews[key].title);
-        expect(linkElem.attr('id')).toBe(scope.toolbarViews[key].id);
-        expect(linkElem.attr('data-url')).toBe(scope.toolbarViews[key].url);
-        expect(linkElem.attr('data-url_parms')).toBe(scope.toolbarViews[key].url_parms);
-        expect(linkElem.attr('name')).toBe(scope.toolbarViews[key].name);
+      angular.forEach(compiledElement.find('button'), (element, key) => {
+        let btnElem = angular.element(element);
+        expect(btnElem.hasClass('active')).toBe(!!scope.toolbarViews[key].selected);
+        expect(btnElem.attr('title')).toBe(scope.toolbarViews[key].title);
+        expect(btnElem.attr('id')).toBe(scope.toolbarViews[key].id);
+        expect(btnElem.attr('data-url')).toBe(scope.toolbarViews[key].url);
+        expect(btnElem.attr('data-url_parms')).toBe(scope.toolbarViews[key].url_parms);
+        expect(btnElem.attr('name')).toBe(scope.toolbarViews[key].name);
       });
     });
   });


### PR DESCRIPTION
Without this, all the view toolbar items are blue, all the time, as of ManageIQ/manageiq#11020

Updated the view toolbar to match https://www.patternfly.org/pattern-library/content-views/list-view/

Cc: @karelhala, @skateman, @martinpovolny 

You can test by doing `bower install manageiq-ui-components=himdel/ui-components#fix-pf-310` under `manageiq/`