### PR TITLE
Add travis build file with build script

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+npm install
+npm t

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+dist: trusty
+language: node_js
+node_js:
+  - '5'
+
+npm:
+  - '3'
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - 'npm install -g typings bower webpack karma typescript'
+
+script: ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ cache:
 before_install:
   - 'npm install -g typings bower webpack karma typescript'
 
-script: ./build.sh
+script: ./.build.sh


### PR DESCRIPTION
New travis build config file, we now just have to enable travis builds for ui-components.

This travis build is trivial, specifies node and npm versions, before running build script it will install necessary dependencies.

Build script will just install this application and runs tests for it.