### PR TITLE
Sort component

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ tsmft -r
 ```
 
 This formats the code according to the tslint rules.
+
+#### Documentation
+
+If you want to see documentation for each component, controller, filter, etc. run
+```
+npm run-script build-docs
+```
+This will generate docs from JS docs and after running `npm start` this documentation will be available on `localhost:4000/docs`

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -729,12 +729,8 @@
 
 	"use strict";
 	///<reference path="../tsd.d.ts"/>
-<<<<<<< 012a9698092a6a1700b72e22e9e3ca4d5ee923c5
 	var services_1 = __webpack_require__(36);
-=======
-	var services_1 = __webpack_require__(32);
-	var components_1 = __webpack_require__(34);
->>>>>>> Add sort component to common module
+	var components_1 = __webpack_require__(38);
 	var common;
 	(function (common) {
 	    common.app = angular.module('miqStaticAssets.common', []);
@@ -784,11 +780,11 @@
 
 
 /***/ },
-/* 34 */
+/* 38 */
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	var sortItemsComponent_1 = __webpack_require__(35);
+	var sortItemsComponent_1 = __webpack_require__(39);
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = function (module) {
 	    module.component('miqSortItems', new sortItemsComponent_1.default);
@@ -796,7 +792,7 @@
 
 
 /***/ },
-/* 35 */
+/* 39 */
 /***/ function(module, exports) {
 
 	"use strict";

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -825,14 +825,14 @@
 	        }
 	    };
 	    /**
-	     * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`, it's text as
-	     * actual Id and same applies to `title`.
+	     * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`,
+	     * it's text as actual Id and same applies to `title`.
 	     * @memberof SortItemsController
 	     * @function setSortItem
 	     */
 	    SortItemsController.prototype.setSortItem = function () {
 	        this.options.currentField = {
-	            colId: this.headers.indexOf(this.sortObject.sortObject),
+	            colId: _.findIndex(this.headers, this.sortObject.sortObject),
 	            id: this.sortObject.sortObject.text.toLowerCase(),
 	            title: this.sortObject.sortObject.text
 	        };

--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -729,11 +729,17 @@
 
 	"use strict";
 	///<reference path="../tsd.d.ts"/>
+<<<<<<< 012a9698092a6a1700b72e22e9e3ca4d5ee923c5
 	var services_1 = __webpack_require__(36);
+=======
+	var services_1 = __webpack_require__(32);
+	var components_1 = __webpack_require__(34);
+>>>>>>> Add sort component to common module
 	var common;
 	(function (common) {
 	    common.app = angular.module('miqStaticAssets.common', []);
 	    services_1.default(common.app);
+	    components_1.default(common.app);
 	})(common || (common = {}));
 
 
@@ -775,6 +781,141 @@
 	}());
 	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = EndpointsService;
+
+
+/***/ },
+/* 34 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var sortItemsComponent_1 = __webpack_require__(35);
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = function (module) {
+	    module.component('miqSortItems', new sortItemsComponent_1.default);
+	};
+
+
+/***/ },
+/* 35 */
+/***/ function(module, exports) {
+
+	"use strict";
+	/**
+	 * Controller for sort items component, it filters headers to fit config object of `pf-sort`.
+	 * @memberof miqStaticAssets.common
+	 * @ngdoc controller
+	 * @name SortItemsController
+	 */
+	var SortItemsController = (function () {
+	    function SortItemsController() {
+	        this.initOptions();
+	    }
+	    /**
+	     * Angular's method for checking one way data bounded properties changes.
+	     * @memberof SortItemsController
+	     * @function $onChanges
+	     * @param changesObj {Object} angular changes object.
+	     */
+	    SortItemsController.prototype.$onChanges = function (changesObj) {
+	        if (changesObj.headers) {
+	            this.fillFields();
+	            if (this.sortObject) {
+	                this.setSortItem();
+	            }
+	        }
+	    };
+	    /**
+	     * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`, it's text as
+	     * actual Id and same applies to `title`.
+	     * @memberof SortItemsController
+	     * @function setSortItem
+	     */
+	    SortItemsController.prototype.setSortItem = function () {
+	        this.options.currentField = {
+	            colId: this.headers.indexOf(this.sortObject.sortObject),
+	            id: this.sortObject.sortObject.text.toLowerCase(),
+	            title: this.sortObject.sortObject.text
+	        };
+	        this.options.isAscending = this.sortObject.isAscending;
+	    };
+	    /**
+	     * Public method which is called after constructing this controller. It will set default values for config object,
+	     * along side with sort method.
+	     * @memberof SortItemsController
+	     * @function initOptions
+	     */
+	    SortItemsController.prototype.initOptions = function () {
+	        var _this = this;
+	        this.options = {
+	            fields: [],
+	            onSortChange: function (item, isAscending) { return _this.onSort({ sortObject: item, isAscending: isAscending }); },
+	            currentField: {}
+	        };
+	    };
+	    /**
+	     * Private method which will filter out and transform headers to config object. This function will filter out all
+	     * columns which has `is_narrow` and no `text` is set fot them. Also it will use each header key as `colId`,
+	     * text as `id` and again text as `title`.
+	     * @memberof SortItemsController
+	     * @function fillFields
+	     */
+	    SortItemsController.prototype.fillFields = function () {
+	        var _this = this;
+	        _.each(this.headers, function (oneCol, key) {
+	            if (!oneCol.hasOwnProperty('is_narrow') && oneCol.hasOwnProperty('text')) {
+	                _this.options.fields.push({
+	                    colId: key,
+	                    id: oneCol.text.toLowerCase(),
+	                    title: oneCol.text
+	                });
+	            }
+	        });
+	    };
+	    return SortItemsController;
+	}());
+	exports.SortItemsController = SortItemsController;
+	/**
+	 * @description
+	 *    Component for showing sort component. See {@link miqStaticAssets.common.SortItemsController} on how functions
+	 *    and properties are handled, This component requires `pf-sort` (see
+	 *    <a href="http://angular-patternfly.rhcloud.com/#/api/patternfly.sort.directive:pfSort">patternfly's
+	 *    implemetnation</a>) component to be part of application scope.
+	 *    If you do not provide such component no sort will be show. `pf-sort` requires `config` property which consists of:
+	 *    ```javascript
+	 *    config = {
+	 *      fields: [],
+	 *      onSortChange: (item: any, isAscending: boolean) => void,
+	 *      currentField: {}
+	 *    }
+	 *    ```
+	 * @memberof miqStaticAssets.common
+	 * @ngdoc component
+	 * @name miqSortItems
+	 * @attr {Expression} onSort function which is called after sorting has changed.
+	 * @attr {Object} headers items which will be present in sort chooser.
+	 * @attr {Object} sortObject object which is currently sorted by.
+	 * @example
+	 * <miq-sort-items on-sort="ctrl.onSort(sortObject, isAscending)"
+	 *                 headers="ctrl.headers"
+	 *                 sort-object="ctrl.currentSortObject">
+	 * </miq-sort-items>
+	 */
+	var SortItems = (function () {
+	    function SortItems() {
+	        this.replace = true;
+	        this.template = "<div pf-sort config=\"vm.options\"></div>";
+	        this.controller = SortItemsController;
+	        this.controllerAs = 'vm';
+	        this.bindings = {
+	            onSort: '&',
+	            headers: '<',
+	            sortObject: '<'
+	        };
+	    }
+	    return SortItems;
+	}());
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = SortItems;
 
 
 /***/ }

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -2,4 +2,4 @@ import SortItems from './sortItemsComponent';
 
 export default (module: ng.IModule) => {
   module.component('miqSortItems', new SortItems);
-}
+};

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -1,0 +1,5 @@
+import SortItems from './sortItemsComponent';
+
+export default (module: ng.IModule) => {
+  module.component('miqSortItems', new SortItems);
+}

--- a/src/common/components/sortItemsComponent.spec.ts
+++ b/src/common/components/sortItemsComponent.spec.ts
@@ -1,0 +1,62 @@
+import SortItems from './sortItemsComponent';
+import {SortItemsController} from './sortItemsComponent';
+
+describe('Sort items test', () =>  {
+  let headers = [{is_narrow: true}, {col_id: 2, text: 'something'}, {col_id: 3, text: 'something2'}];
+  it('should create component', () => {
+    let sortItems = new SortItems;
+    expect(sortItems).toBeDefined();
+  });
+
+  describe('controller', () => {
+    let sortItemsCtrl;
+
+    beforeEach(() => {
+      angular.mock.module('miqStaticAssets.toolbar');
+      angular.mock.inject(() => {
+        sortItemsCtrl = new SortItemsController();
+      });
+    });
+
+    it('should init options', () => {
+      expect(sortItemsCtrl.options.fields.length).toBe(0);
+      expect(sortItemsCtrl.options.currentField).toBeDefined();
+      expect(sortItemsCtrl.options.hasOwnProperty('onSortChange')).toBeTruthy();
+    });
+
+    it('should set sort item', () => {
+      sortItemsCtrl.headers = headers;
+      sortItemsCtrl.sortObject = {sortObject: {col_id: 3, text: 'something2'}, isAscending: true};
+      sortItemsCtrl.setSortItem();
+      expect(sortItemsCtrl.options.currentField.colId).toBe(2);
+      expect(sortItemsCtrl.options.currentField.id).toBe(sortItemsCtrl.sortObject.sortObject.text);
+      expect(sortItemsCtrl.options.currentField.title).toBe(sortItemsCtrl.sortObject.sortObject.text);
+    });
+  });
+
+  describe('component', () => {
+    let scope, compile, compiledElement;
+
+    beforeEach(() => {
+      angular.mock.module('miqStaticAssets.common');
+      angular.mock.inject(($rootScope, $compile: ng.ICompileService) => {
+        scope = $rootScope.$new();
+        compile = $compile;
+      });
+
+      scope.headers = headers;
+      compiledElement = compile(
+        angular.element(
+          `<miq-sort-items on-sort="onSort(sortObject, isAscending)"
+                           headers="headers"
+                           sort-object="currentSortObject"></miq-sort-items>`
+        ))(scope);
+      scope.$digest();
+    });
+
+    it('should compile component', () => {
+      expect(compiledElement.html()).toContain('pf-sort');
+      expect(compiledElement.html()).toContain('config="vm.options"');
+    });
+  });
+});

--- a/src/common/components/sortItemsComponent.spec.ts
+++ b/src/common/components/sortItemsComponent.spec.ts
@@ -12,7 +12,6 @@ describe('Sort items test', () =>  {
     let sortItemsCtrl;
 
     beforeEach(() => {
-      angular.mock.module('miqStaticAssets.toolbar');
       angular.mock.inject(() => {
         sortItemsCtrl = new SortItemsController();
       });

--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -1,0 +1,116 @@
+/**
+ * Controller for sort items component, it filters headers to fit config object of `pf-sort`.
+ * @memberof miqStaticAssets.common
+ * @ngdoc controller
+ * @name SortItemsController
+ */
+export class SortItemsController {
+  public headers: any;
+  public options: any;
+  public sortObject: any;
+  public onSort: (args: {sortObject: any, isAscending: boolean}) => void;
+
+  constructor() {
+    this.initOptions();
+  }
+
+  /**
+   * Angular's method for checking one way data bounded properties changes.
+   * @memberof SortItemsController
+   * @function $onChanges
+   * @param changesObj {Object} angular changes object.
+   */
+  public $onChanges(changesObj: any) {
+    if (changesObj.headers) {
+      this.fillFields();
+      if (this.sortObject) {
+        this.setSortItem();
+      }
+    }
+  }
+
+  /**
+   * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`, it's text as
+   * actual Id and same applies to `title`.
+   * @memberof SortItemsController
+   * @function setSortItem
+   */
+  public setSortItem() {
+    this.options.currentField = {
+      colId: this.headers.indexOf(this.sortObject.sortObject),
+      id: this.sortObject.sortObject.text.toLowerCase(),
+      title: this.sortObject.sortObject.text
+    };
+    this.options.isAscending = this.sortObject.isAscending;
+  }
+
+  /**
+   * Public method which is called after constructing this controller. It will set default values for config object,
+   * along side with sort method.
+   * @memberof SortItemsController
+   * @function initOptions
+   */
+  public initOptions() {
+    this.options = {
+      fields: [],
+      onSortChange: (item: any, isAscending: boolean) => this.onSort({sortObject: item, isAscending: isAscending}),
+      currentField: {}
+    };
+  }
+
+  /**
+   * Private method which will filter out and transform headers to config object. This function will filter out all
+   * columns which has `is_narrow` and no `text` is set fot them. Also it will use each header key as `colId`,
+   * text as `id` and again text as `title`.
+   * @memberof SortItemsController
+   * @function fillFields
+   */
+  private fillFields() {
+    _.each(this.headers, (oneCol, key) => {
+      if (!oneCol.hasOwnProperty('is_narrow') && oneCol.hasOwnProperty('text')) {
+        this.options.fields.push({
+          colId: key,
+          id: oneCol.text.toLowerCase(),
+          title: oneCol.text
+        });
+      }
+    });
+  }
+}
+/**
+ * @description
+ *    Component for showing sort component. See {@link miqStaticAssets.common.SortItemsController} on how functions
+ *    and properties are handled, This component requires `pf-sort` (see
+ *    <a href="http://angular-patternfly.rhcloud.com/#/api/patternfly.sort.directive:pfSort">patternfly's
+ *    implemetnation</a>) component to be part of application scope.
+ *    If you do not provide such component no sort will be show. `pf-sort` requires `config` property which consists of:
+ *    ```javascript
+ *    config = {
+ *      fields: [],
+ *      onSortChange: (item: any, isAscending: boolean) => void,
+ *      currentField: {}
+ *    }
+ *    ```
+ * @memberof miqStaticAssets.common
+ * @ngdoc component
+ * @name miqSortItems
+ * @attr {Expression} onSort function which is called after sorting has changed.
+ * @attr {Object} headers items which will be present in sort chooser.
+ * @attr {Object} sortObject object which is currently sorted by.
+ * @example
+ * <miq-sort-items on-sort="ctrl.onSort(sortObject, isAscending)"
+ *                 headers="ctrl.headers"
+ *                 sort-object="ctrl.currentSortObject">
+ * </miq-sort-items>
+ */
+export default class SortItems implements ng.IComponentOptions {
+  public replace: boolean = true;
+  public template = `<div pf-sort config="vm.options"></div>`;
+  public controller = SortItemsController;
+  public controllerAs = 'vm';
+  public bindings: any = {
+    onSort: '&',
+    headers: '<',
+    sortObject: '<'
+  };
+}

--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -30,14 +30,14 @@ export class SortItemsController {
   }
 
   /**
-   * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`, it's text as
-   * actual Id and same applies to `title`.
+   * Public method for setting item which is currently sorted by. It will take id of object in `headers` as `colId`,
+   * it's text as actual Id and same applies to `title`.
    * @memberof SortItemsController
    * @function setSortItem
    */
   public setSortItem() {
     this.options.currentField = {
-      colId: this.headers.indexOf(this.sortObject.sortObject),
+      colId: _.findIndex(this.headers, this.sortObject.sortObject),
       id: this.sortObject.sortObject.text.toLowerCase(),
       title: this.sortObject.sortObject.text
     };

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,7 +1,9 @@
 ///<reference path="../tsd.d.ts"/>
 import services from './services';
+import components from './components';
 
 module common {
   export const app = angular.module('miqStaticAssets.common', []);
   services(app);
+  components(app);
 }


### PR DESCRIPTION
This component is helper component for `pf-sort` it uses [patternfly's implementation](http://angular-patternfly.rhcloud.com/#/api/patternfly.sort.directive:pfSort) and just filter out items from header columns for gtls.