### PR TITLE
Add checking for empty items in button select

### DIFF
--- a/dist/js/ui-components.js
+++ b/dist/js/ui-components.js
@@ -446,8 +446,9 @@
 	     * @returns {boolean} true|false if it's item with button or button select type.
 	     */
 	    ToolbarController.isButtonOrSelect = function (item) {
-	        return item.type && (ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item) ||
-	            ToolbarController.isButtonTwoState(item));
+	        return item.type && ((ToolbarController.isButtonSelect(item) && item.items && item.items.length !== 0)
+	            || ToolbarController.isButton(item)
+	            || ToolbarController.isButtonTwoState(item));
 	    };
 	    ToolbarController.isButtonTwoState = function (item) {
 	        return item.type === toolbarType_1.ToolbarType.BUTTON_TWO_STATE;

--- a/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
@@ -36,11 +36,30 @@ describe('Toolbar test', () =>  {
       expect(toolbarCtrl.hasContent(items)).toBe(false);
     });
 
+    it('should have no content even with correct type', () => {
+      let items: Array<IToolbarItem> = [{
+        type: 'someBadType'
+      }, {
+        type: ToolbarType.BUTTON_SELECT
+      }];
+      expect(toolbarCtrl.hasContent(items)).toBe(false);
+      items = [{
+        type: 'someBadType'
+      }, {
+        type: ToolbarType.BUTTON_SELECT,
+        items: []
+      }];
+      expect(toolbarCtrl.hasContent(items)).toBe(false);
+    });
+
     it('should have content', () => {
       const items: Array<IToolbarItem> = [{
         type: 'someBadType'
       }, {
-        type: ToolbarType.BUTTON_SELECT
+        type: ToolbarType.BUTTON_SELECT,
+        items: [{
+          type: ToolbarType.BUTTON
+        }]
       }];
       expect(toolbarCtrl.hasContent(items)).toBe(true);
     });

--- a/src/toolbar/components/toolbar-menu/toolbarComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.ts
@@ -142,8 +142,11 @@ export class ToolbarController {
    * @returns {boolean} true|false if it's item with button or button select type.
    */
   private static isButtonOrSelect(item: IToolbarItem): boolean {
-    return item.type && (ToolbarController.isButtonSelect(item) || ToolbarController.isButton(item) ||
-      ToolbarController.isButtonTwoState(item));
+    return item.type && (
+        (ToolbarController.isButtonSelect(item) && item.items && item.items.length !== 0)
+        || ToolbarController.isButton(item)
+        || ToolbarController.isButtonTwoState(item)
+      );
   }
 
   private static isButtonTwoState(item: IToolbarItem): boolean {


### PR DESCRIPTION
Fixes blank `miq-toolbar-group` if there are no items in button select. New test case to check this.

https://github.com/ManageIQ/ui-components/issues/23