### PR TITLE
coverage.sh - cd to scripts before assuming ../node_modules

### DIFF
--- a/scripts/.coverage.sh
+++ b/scripts/.coverage.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+cd "`dirname "$0"`"
 cat ../coverage/lcov.info | ../node_modules/coveralls/bin/coveralls.js


### PR DESCRIPTION
Introduced in #29, `coverage.sh` is not run with CWD=scripts/, causing it to fail - fixed by changing to the right directory first..

@karelhala can you..? :)