### PR TITLE
npm - use prepublish instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manageiq-ui-components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "UI components for ManageIQ project",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "webpack --watch",
     "test": "karma start",
     "prepublish": "typings install && webpack && webpack --config webpack.vendor.config.js",
-    "build-docs": "jsdoc -c jsdoc-conf.json"
+    "build-docs": "jsdoc -c jsdoc-conf.json",
+    "bower": "bower install"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack --watch",
     "test": "karma start",
-    "postinstall": "bower install && typings install && webpack && webpack --config webpack.vendor.config.js",
+    "prepublish": "typings install && webpack && webpack --config webpack.vendor.config.js",
     "build-docs": "jsdoc -c jsdoc-conf.json"
   },
   "repository": {


### PR DESCRIPTION
postinstall is not only called after `npm install`, but also after having installed the package

prepublish is called only before publish *and* on doing a standalone `npm install`

So moving those actions to prepublish so that people using the package won't need typescript & typings, etc. Also removed bower install, because we can't assume that people using the npm package will even have bower..

I've already released a npm version of the package to be able to test, I'll do the bower thing after this is merged...

Cc @karelhala - any other thoughts where to put it?
