### PR TITLE
Corrected object name for tabs sorting

### DIFF
--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -36,7 +36,7 @@ class TabListController {
       revert: 50,
       stop: (e: any, ui: any) => {
         let sortedTab = ui.item.scope();
-        let tabList = sortedTab.$parent.dialogEditorTabs.tabList;
+        let tabList = sortedTab.$parent.vm.tabList;
         this.DialogEditor.updatePositions(tabList);
         this.DialogEditor.activeTab = _.find(tabList, {active: true}).position;
       },


### PR DESCRIPTION
Because of this mistake, it was impossible to close newly created tab in the dialog editor