### PR TITLE
Enable map for main css file in bower distribution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "description": "UI components for ManageIQ project",
   "main": [
     "dist/css/ui-components.css",
+    "dist/css/ui-components.css.map",
     "dist/js/ui-components.js",
     "dist/js/ui-components.js.map"
   ],


### PR DESCRIPTION
Since `ActionController` complains that `/assets/manageiq-ui-components/dist/css/ui-components.css.map` is missing we should ship map file for styles.