### PR TITLE
Remove mapped files from gitignire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ vendor.css
 coverage
 
 !dist/js/ui-components.js.map
+!dist/css/ui-components.css.map

--- a/bower.json
+++ b/bower.json
@@ -4,9 +4,7 @@
   "description": "UI components for ManageIQ project",
   "main": [
     "dist/css/ui-components.css",
-    "dist/css/ui-components.css.map",
-    "dist/js/ui-components.js",
-    "dist/js/ui-components.js.map"
+    "dist/js/ui-components.js"
   ],
   "authors": [
     ""
@@ -18,8 +16,10 @@
     "*",
     "!dist/",
     "!dist/*",
+    "!dist/js/*",
+    "!dist/css/*",
     "!LICENSE",
-    "!README.adoc"
+    "!README.md"
   ],
   "dependencies": {},
   "devDependencies": {}

--- a/dist/css/ui-components.css.map
+++ b/dist/css/ui-components.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":"","file":"css/ui-components.css","sourceRoot":""}


### PR DESCRIPTION
As @jzigmund mentioned in https://github.com/ManageIQ/ui-components/pull/66#issuecomment-299181036 `dist/css/ui-components.css.map` was still not present in distributed bower due to policy at Bower, that only one file with can be treated as main with given filetype [main-list](https://github.com/bower/spec/blob/master/json.md#user-content-main). So we do not ignore `.map` files in dist folder for github and also do not ignore whole folders `js` and `css` in `dist`.