### PR TITLE
Clean build process so there are no more errors with missing __ function

### DIFF
--- a/src/common/translateFunction.ts
+++ b/src/common/translateFunction.ts
@@ -1,0 +1,7 @@
+export function __(translateString) {
+  if (window.hasOwnProperty('__')) {
+    return window['__'](translateString);
+  } else {
+    return translateString;
+  }
+}

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -1,5 +1,6 @@
 import * as ng from 'angular';
 import * as _ from 'lodash';
+import {__} from '../../../common/translateFunction';
 
 /**
  * Controller for the Dialog Editor box component
@@ -85,7 +86,7 @@ class BoxController {
   public removeBox(id: number) {
     _.remove(
       this.dialogTabs[this.DialogEditor.activeTab].dialog_groups,
-      (box) => box.position === id
+      (box: any) => box.position === id
     );
     // update indexes of other boxes after removing
     this.DialogEditor.updatePositions(

--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -1,5 +1,6 @@
 import * as ng from 'angular';
 import * as _ from 'lodash';
+import {__} from '../../../common/translateFunction';
 
 /**
  * Controller for the Dialog Editor tab list component
@@ -38,7 +39,8 @@ class TabListController {
         let sortedTab = ng.element(ui.item).scope().$parent;
         let tabList = sortedTab.vm.tabList;
         this.DialogEditor.updatePositions(tabList);
-        this.DialogEditor.activeTab = _.find(tabList, {active: true}).position;
+        let activeTab: any = _.find(tabList, {active: true});
+        this.DialogEditor.activeTab = activeTab.position;
       },
     };
   }
@@ -91,7 +93,7 @@ class TabListController {
       }
     }
     // remove tab with matching id
-    _.remove(this.tabList, (tab) => tab.position === id);
+    _.remove(this.tabList, (tab: any) => tab.position === id);
     // update indexes of other tabs after removing
     if (this.tabList.length !== 0) {
       this.DialogEditor.updatePositions(this.tabList);
@@ -99,7 +101,7 @@ class TabListController {
       return;
     }
     // set activity in the service
-    let activeTabData = _.find(
+    let activeTabData: any = _.find(
       this.tabList,
       {active: true}
     );

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -10,7 +10,7 @@ class DialogField {
               options: any = {}) {
     this.icon = icon;
     this.label = label;
-    this.placeholders = (<any>Object).assign({
+    this.placeholders = Object.assign({
       name: '',
       description: '',
       type: type,

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -1,3 +1,4 @@
+import {__} from '../../../common/translateFunction';
 class DialogField {
   public icon: string;
   public label: string;
@@ -9,7 +10,7 @@ class DialogField {
               options: any = {}) {
     this.icon = icon;
     this.label = label;
-    this.placeholders = Object.assign({
+    this.placeholders = (<any>Object).assign({
       name: '',
       description: '',
       type: type,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "removeComments": false,
     "sourceMap": true,
-    "typeRoots" : ["./node_modules/@types"]
+    "typeRoots" : ["./node_modules/@types"],
+    "lib": ["es2015", "DOM", "ScriptHost"]
   },
   "files": [
     "src/index.ts"


### PR DESCRIPTION
This PR fixes errors which were shown in console if any phase of build was ran (`npm run build` or `npm start`). Helper function was introduced, which checks if `__` exists on window object and if it does not exists it will return string which was passed to it, if it exists it will return result of `__(translateString)`.

No UI changes.