### PR TITLE
Toolbar color

### DIFF
--- a/demo/data/toolbar.json
+++ b/demo/data/toolbar.json
@@ -4,6 +4,7 @@
       "id": "middleware_server_policy_choice",
       "type": "buttonSelect",
       "img": "middleware_server_policy_choice.png",
+      "color": "blue",
       "imgdis": "middleware_server_policy_choice.png",
       "icon": "fa fa-shield fa-lg",
       "name": "middleware_server_policy_choice",
@@ -20,6 +21,7 @@
           "id": "middleware_server_policy_choice__middleware_server_tag",
           "type": "button",
           "img": "middleware_server_tag.png",
+          "color": "#900000",
           "imgdis": "middleware_server_tag.png",
           "icon": "pficon pficon-edit fa-lg",
           "name": "middleware_server_policy_choice__middleware_server_tag",
@@ -39,6 +41,7 @@
       "id": "download_choice__download_csv",
       "type": "button",
       "img": "download_csv.png",
+      "color": "#009000",
       "imgdis": "download_csv.png",
       "icon": "fa fa-file-text-o fa-lg",
       "name": "download_choice__download_csv",
@@ -108,6 +111,22 @@
           "url_parms": "main_div"
         }
       ]
+    },
+    {
+      "id": "middleware_server_power_choice",
+      "type": "button",
+      "color": "#0000F0",
+      "img": "middleware_server_power_choice.png",
+      "imgdis": "middleware_server_power_choice.png",
+      "icon": "fa fa-power-off fa-lg",
+      "name": "middleware_server_power_choice",
+      "hidden": false,
+      "pressed": null,
+      "onwhen": "1+",
+      "data": null,
+      "enabled": true,
+      "title": "Power",
+      "text": "Power"
     }
   ],
   [

--- a/src/toolbar/components/toolbar-menu/toolbar-button.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-button.html
@@ -13,8 +13,13 @@
         ng-class="{active: toolbarButton.selected, disabled: !toolbarButton.enabled}"
         ng-hide="toolbarButton.hidden"
         ng-click="onItemClick({item: toolbarButton, $event: $event})">
-  <i ng-if="toolbarButton.icon && toolbarButton.text" class="{{toolbarButton.icon}}" style="margin-right: 5px;"></i>
-  <i ng-if="toolbarButton.icon && !toolbarButton.text" class="{{toolbarButton.icon}}"></i>
+  <i ng-if="toolbarButton.icon && toolbarButton.text"
+     class="{{toolbarButton.icon}}"
+     ng-style="{color: toolbarButton.color}"
+     style="margin-right: 5px;"></i>
+  <i ng-if="toolbarButton.icon && !toolbarButton.text"
+     class="{{toolbarButton.icon}}"
+     ng-style="{color: toolbarButton.color}"></i>
   <img ng-if="toolbarButton.img_url && !toolbarButton.icon" ng-src="{{toolbarButton.img_url}}"
        data-enabled="{{toolbarButton.img_url}}"
        data-disabled="{{toolbarButton.img_url}}">

--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -1,7 +1,10 @@
 <div class="btn-group" ng-class="vm.dropDownClass" uib-dropdown ng-if="vm.isEmpty">
   <button type="button" uib-dropdown-toggle class="btn uib-dropdown-toggle btn-default"
           ng-class="{disabled: !vm.toolbarList.enabled}" title="{{vm.toolbarList.title}}">
-    <i class="{{vm.toolbarList.icon}}" style="margin-right: 5px;" ng-if="vm.toolbarList.icon"></i>
+    <i class="{{vm.toolbarList.icon}}"
+       style="margin-right: 5px;"
+       ng-if="vm.toolbarList.icon"
+       ng-style="{color: vm.toolbarList.color}"></i>
     {{vm.toolbarList.text}}
     <span class="caret"></span>
   </button>
@@ -25,8 +28,8 @@
          data-prompt="{{item.prompt}}"
          data-popup="{{item.popup}}"
          data-url="{{item.url}}">
-        <i ng-if="item.icon && item.text" class="{{item.icon}}" style="margin-right: 5px;"></i>
-        <i ng-if="item.icon && !item.text" class="{{item.icon}}"></i>
+        <i ng-if="item.icon && item.text" class="{{item.icon}}" ng-style="{color: item.color}" style="margin-right: 5px;"></i>
+        <i ng-if="item.icon && !item.text" class="{{item.icon}}" ng-style="{color: item.color}"></i>
         <img ng-if="item.img_url && !item.icon" ng-src="{{item.img_url}}"
              data-enabled="{{item.img_url}}"
              data-disabled="{{item.img_url}}">

--- a/src/toolbar/components/toolbar-menu/toolbar-view.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-view.html
@@ -10,6 +10,6 @@
           data-popup="{{item.popup}}"
           ng-click="vm.onItemClick({item: item, $event: $event})"
           name="{{item.name}}">
-    <i class="{{item.icon}}" style=""></i>
+    <i class="{{item.icon}}" style="" ng-style="{color: item.color}"></i>
   </button>
 </div>

--- a/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
@@ -95,7 +95,7 @@ describe('Toolbar test', () =>  {
 
     it('creates toolbar', () => {
       const dropdownToggle: any = angular.element(compiledElement[0].querySelectorAll('button:not(.uib-dropdown-toggle)'));
-      expect(dropdownToggle.length).toBe(1);
+      expect(dropdownToggle.length).toBe(2);
       expect(compiledElement.find('miq-toolbar-list').length).toBe(3);
     });
   });


### PR DESCRIPTION
closes #84 

As requested toolbar items should be colored based on JSON property `color` for each item.

Buttons, dropdown lists and dropdown items are colored by this property. Separators are **not** colored.

Color property can be hexa number with hash in it and text corresponding to such color.

### Before
![selection_173](https://user-images.githubusercontent.com/3439771/28164875-af001f28-67d1-11e7-9255-2f6b45f5cc34.png)

### After
![selection_175](https://user-images.githubusercontent.com/3439771/28164872-accdbcb0-67d1-11e7-879b-f8b0c6d6c092.png)

###### Note: added another button with `Power` text to test data.