### PR TITLE
NoEmitOnError flag for typescript compiler.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "removeComments": false,
+    "noEmitOnError": true,
     "sourceMap": true,
     "typeRoots" : ["./node_modules/@types"],
     "lib": ["es2015", "DOM", "ScriptHost"]


### PR DESCRIPTION
 In an effort to not allow bad stuff into the build this flag will not compile the bad stuff. I'm seeing on other typescript projects that things get committed even though they raise compile errors (this should not be allowed IMO). Keeps it clean from the start.

wdyt?