### PR TITLE
GTL - fetchData - use post instead of get

### DIFF
--- a/src/gtl/services/dataTableService.spec.ts
+++ b/src/gtl/services/dataTableService.spec.ts
@@ -28,18 +28,19 @@ describe('DataTableSettingsService test', () =>  {
     expect(
       angular.equals(
         DataTableSettingsService.generateConfig(modelName, tree, currId),
-        { params: {
-            model: modelName,
-            active_tree: tree,
-            model_id: currId
-        }}
+        {
+          model: modelName,
+          active_tree: tree,
+          model_id: currId
+        }
       )
     ).toBeTruthy();
   });
 
   it('should fetch data from server', (done) => {
-    httpBackend.expectGET(`/data/dataTable.json?active_tree=${tree}&model=${modelName}&model_id=${currId}`)
+    httpBackend.expectPOST(`/data/dataTable.json`, { active_tree: tree, model: modelName, model_id: currId })
       .respond(dataTableData);
+
     dataTableSettings.retrieveRowsAndColumnsFromUrl(modelName, tree, currId).then((responseData: IRowsColsResponse) => {
       expect(responseData.cols.length > 0).toBeTruthy();
       expect(responseData.rows.length > 0).toBeTruthy();

--- a/src/gtl/services/dataTableService.ts
+++ b/src/gtl/services/dataTableService.ts
@@ -52,19 +52,19 @@ export default class DataTableService implements IDataTableService {
   }
 
   /**
-   * Method which will do actual http get request using $http service.
+   * Method which will do actual http request using $http service.
    * @param config which contains config params.
    * @returns {IHttpPromise<any>} promise for later data filtering.
    */
   private fetchData(config: any): ng.IPromise<any> {
-    return this.$http.get(
+    return this.$http.post(
       this.MiQEndpointsService.rootPoint + this.MiQEndpointsService.endpoints.listDataTable,
       config
     );
   }
 
   /**
-   * Static function which will generate http get config from given variables.
+   * Static function which will generate http config from given variables.
    * @param modelName string with name of model.
    * @param activeTree string with active tree.
    * @param currId ID of current item.
@@ -79,13 +79,13 @@ export default class DataTableService implements IDataTableService {
                                isExplorer?: string,
                                settings?: any,
                                records?: any) {
-    let config = {params: {}};
-    _.assign(config.params, DataTableService.generateModelConfig(modelName));
-    _.assign(config.params, DataTableService.generateActiveTreeConfig(activeTree));
-    _.assign(config.params, DataTableService.generateModuleIdConfig(currId));
-    _.assign(config.params, DataTableService.generateExplorerConfig(isExplorer));
-    _.assign(config.params, DataTableService.generateParamsFromSettings(settings));
-    _.assign(config.params, DataTableService.generateRecords(records));
+    let config = {};
+    _.assign(config, DataTableService.generateModelConfig(modelName));
+    _.assign(config, DataTableService.generateActiveTreeConfig(activeTree));
+    _.assign(config, DataTableService.generateModuleIdConfig(currId));
+    _.assign(config, DataTableService.generateExplorerConfig(isExplorer));
+    _.assign(config, DataTableService.generateParamsFromSettings(settings));
+    _.assign(config, DataTableService.generateRecords(records));
     return config;
   }
 


### PR DESCRIPTION
..because sometimes, the list of record ids is simply too long to fit in a GET request.

(For example, go to the list of VMs, switch to 1000 per page, select them all, and do Configuration > Set Ownership.)


Do not merge before ManageIQ/manageiq-ui-classic#1833.