### PR TITLE
Serve data jsons over POST method

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,16 @@ const webpack = require('webpack'),
     new BrowserSyncPlugin({
       host: 'localhost',
       port: 4000,
-      server: {baseDir: [__dirname + settings.distFolder]}
+      server: {baseDir: [__dirname + settings.distFolder]},
+      middleware: [
+        {
+          route: "/data",
+          handle: function (req, res, next) {
+            req.method = 'GET';
+            return next();
+          }
+        }
+      ]
     }, {
       use: spa({
         selector: '[ng-app]'


### PR DESCRIPTION
After merging https://github.com/ManageIQ/ui-components/pull/110 data for demo application were not present because the request was using POST method for static data. This PR adds middleware option to browsersync where any request to `/data` will be changed to use GET method.