### PR TITLE
Fixed missing icons in the fonticon picker component

### DIFF
--- a/src/fonticon-picker/services/fonticonService.ts
+++ b/src/fonticon-picker/services/fonticonService.ts
@@ -24,8 +24,8 @@ export default class FonticonService {
   }
 
   private static clearRule(rule: string, family: string): string {
-    let cleared = FonticonService.removeChars(rule.replace('::before', ''), '.');
-    return family + FonticonService.removeChars(cleared, family);
+    let re = new RegExp(`.*(${family}\-[a-z0-9\-\_]+).*`);
+    return rule.replace(re, '$1');
   }
 
   private static makeRuleObject(family, value): any {
@@ -33,9 +33,5 @@ export default class FonticonService {
       'class': `${family} ${value}`,
       'selector': `.${family}.${value}`
     };
-  }
-
-  private static removeChars(source, chars) {
-    return source.split(chars).join('');
   }
 }


### PR DESCRIPTION
Regular expression for the rescue @karelhala 

**Before:**
![screenshot from 2017-08-16 12-27-09](https://user-images.githubusercontent.com/649130/29359296-5dc73606-827e-11e7-8446-9b8ae9e980c7.png)

**After:**
![screenshot from 2017-08-16 12-27-42](https://user-images.githubusercontent.com/649130/29359297-5dc7713e-827e-11e7-9af0-e627e933fabb.png)