### PR TITLE
Wrapper component around patternfly-bootstrap-treeview for explorers

### DIFF
--- a/application-settings.js
+++ b/application-settings.js
@@ -13,7 +13,8 @@ module.exports = {
     gtl: '/gtl',
     siteSwitcher: '/site-switcher',
     fonticonPicker: '/fonticon-picker',
-    dialogs: '/dialog-user'
+    dialogs: '/dialog-user',
+    treeView: '/tree-view'
   },
   nodePackages: 'node_modules/',
   get stylesheetPath() {

--- a/demo/controllers/index.ts
+++ b/demo/controllers/index.ts
@@ -5,6 +5,7 @@ import SiteSwitcherController from './siteSwitcherController';
 import FonticonPickerController from './fonticonPickerController';
 import DialogUserController from './dialogUserController';
 import DialogEditorController from './dialogEditorController';
+import TreeViewController from './treeViewController';
 import * as ng from 'angular';
 
 export default (module: ng.IModule) => {
@@ -15,4 +16,5 @@ export default (module: ng.IModule) => {
   module.controller('demoFonticonPicker', FonticonPickerController);
   module.controller('demoDialogUser', DialogUserController);
   module.controller('demoDialogEditor', DialogEditorController);
+  module.controller('demoTreeView', TreeViewController);
 };

--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -1,0 +1,29 @@
+import * as ng from 'angular';
+
+export default class TreeViewController {
+  public node;
+  public data = require('../data/tree.json');
+
+  /*@ngInject*/
+  constructor(private $scope : ng.IScope, private $timeout : ng.ITimeoutService) {};
+
+  public resetState(node) {
+    sessionStorage.clear();
+  }
+
+  public lazyLoad(node) {
+    let data = require('../data/lazyTree.json');
+    // Wait to simulate HTTP delay
+    return new Promise(resolve => this.$timeout(() => resolve(data), 1500));
+  }
+
+  public nodeSelect(node) {
+    // Drop some attributes to keep the output short
+    delete node.$el;
+    delete node.nodes;
+    delete node.searchResult;
+
+    this.node = node;
+    this.$scope.$apply();
+  }
+}

--- a/demo/data/lazyTree.json
+++ b/demo/data/lazyTree.json
@@ -1,0 +1,12 @@
+[
+  {
+    "key": "lc-1",
+    "icon": "ff ff-diamond",
+    "text": "Lazy Child 1"
+  },
+  {
+    "key": "lc-2",
+    "icon": "ff ff-diamond",
+    "text": "Lazy Child 2"
+  }
+]

--- a/demo/data/tree.json
+++ b/demo/data/tree.json
@@ -1,0 +1,37 @@
+[
+  {
+    "key": "p-1",
+    "icon": "ff ff-diamond",
+    "text": "Parent",
+    "nodes": [
+      {
+        "key": "c-1",
+        "icon": "ff ff-diamond",
+        "text": "Child 1",
+        "nodes": [
+          {
+            "key": "gc-1",
+            "icon": "ff ff-diamond",
+            "text": "Grandchild 1"
+          },
+          {
+            "key": "gc-2",
+            "icon": "ff ff-diamond",
+            "text": "Grandchild 2"
+          }
+        ]
+      },
+      {
+        "key": "c-2",
+        "icon": "ff ff-diamond",
+        "text": "Child 2"
+      }
+    ]
+  },
+  {
+    "key": "lp-1",
+    "icon": "ff ff-diamond",
+    "text": "Lazy Parent",
+    "lazyLoad": true
+  }
+]

--- a/demo/services/availableComponentsService.ts
+++ b/demo/services/availableComponentsService.ts
@@ -87,6 +87,12 @@ export default class AvailableComponentsService {
           'Dialog user',
           '/user',
           require('./../views/dialog/user.html'), 'demoDialogUser as vm')
+      ]),
+      new AvailableGroup('tree-view', 'Tree Components', '/tree', [
+        new AvailableComponent('tree-view',
+          'TreeView',
+          '/tree-view',
+          require('./../views/tree-view/basic.html'), 'demoTreeView as vm')
       ])
     ];
   }

--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -1,0 +1,6 @@
+<miq-tree-view name="demo-tree" data="{{ vm.data }}" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)"></miq-tree-view>
+<button ng-click="vm.resetState();">Reset state</button>
+<div ng-if="vm.node">
+  <h3>Selected node:</h3>
+  <pre>{{ vm.node | json }}</pre>
+</div>

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ng-annotate-webpack-plugin": "0.1.3",
     "node-sass": "^3.13.0",
     "patternfly": "^3.15.0",
+    "patternfly-bootstrap-treeview": "^2.1.5",
     "raw-loader": "0.5.1",
     "rx": "^4.1.0",
     "rx-angular": "^1.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ module miqStaticAssets {
     'miqStaticAssets.dialogUser',
     'miqStaticAssets.gtl',
     'miqStaticAssets.siteSwitcher',
-    'miqStaticAssets.fonticonPicker'
+    'miqStaticAssets.fonticonPicker',
+    'miqStaticAssets.treeView'
   ]);
 }

--- a/src/tree-view/index.ts
+++ b/src/tree-view/index.ts
@@ -1,0 +1,6 @@
+import TreeView from './treeViewComponent';
+import * as angular from 'angular';
+module treeView {
+  export const app = angular.module('miqStaticAssets.treeView', []);
+  app.component('miqTreeView', new TreeView);
+}

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -1,0 +1,79 @@
+import * as ng from 'angular';
+
+export class TreeViewController {
+  public tree;
+  public reselect;
+  public data;
+  public name : string;
+  public onSelect: (args: {node: any}) => void;
+  public lazyLoad: (args: {node: any}) => Promise<any>;
+
+  /*@ngInject*/
+  constructor(private $element : ng.IRootElementService) {}
+
+  public $onInit() {
+    let element = this.$element[0].querySelector('div.treeview');
+    this.renderTree(element).then(() => {
+      this.tree = ng.element(element).treeview(true);
+
+      this.tree.getNodes().forEach((node) => {
+        if (this.getTreeState(node) === !node.state.expanded) {
+          this.tree.toggleNodeExpanded(node);
+        }
+      });
+    });
+  }
+
+  private renderTree(element) {
+    return new Promise((resolve) => {
+      ng.element(element).treeview({
+        data:            this.data,
+        expandIcon:      'fa fa-fw fa-angle-right',
+        collapseIcon:    'fa fa-fw fa-angle-down',
+        loadingIcon:     'fa fa-fw fa-spinner fa-pulse',
+        levels:          1,
+        allowReselect:   this.reselect,
+        showBorders:     false,
+        onNodeExpanded:  this.setTreeState(true),
+        onNodeCollapsed: this.setTreeState(false),
+        onNodeSelected:  (_event, node) => this.onSelect({node: node}),
+        lazyLoad:        (node, render) => this.lazyLoad({node: node}).then(render),
+        onRendered:      () => resolve()
+      });
+    });
+  }
+
+  private setTreeState(state) {
+    return (_event, node) => {
+      let persist = JSON.parse(sessionStorage.getItem(`treeView-${this.name}`));
+      // Initialize the session storage object
+      if (!persist) {
+        persist = {};
+      }
+      // Save the third argument as the new node state
+      persist[node.key] = state;
+      sessionStorage.setItem(`treeView-${this.name}`, JSON.stringify(persist));
+    };
+  }
+
+  private getTreeState(node) {
+    let persist = JSON.parse(sessionStorage.getItem(`treeView-${this.name}`));
+    // Initialize the session storage object
+    if (!persist) {
+      persist = {};
+    }
+    return persist[node.key];
+  }
+}
+
+export default class TreeView implements ng.IComponentOptions {
+  public controller = TreeViewController;
+  public template = '<div class="treeview treeview-pf-select"></div>';
+  public bindings: any = {
+    name: '@',
+    data: '@',
+    reselect: '@',
+    onSelect: '&',
+    lazyLoad: '&'
+  };
+}

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -10,3 +10,4 @@ import 'angular-ui-sortable';
 import 'angular-dragdrop';
 import 'angular-bootstrap-switch';
 import 'ui-select';
+import 'patternfly-bootstrap-treeview';

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,7 +485,7 @@ bootstrap-switch@3.3.2:
   dependencies:
     jquery ">=1.9.0"
 
-bootstrap-switch@^3.3.2, bootstrap-switch@~3.3.2:
+bootstrap-switch@^3.3.4, bootstrap-switch@~3.3.2:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz#70e0aeb2a877c0dc766991de108e2170fc29a2ff"
 
@@ -2742,6 +2742,10 @@ jquery-match-height@^0.7.0, jquery-match-height@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/jquery-match-height/-/jquery-match-height-0.7.2.tgz#f8d9f3ba5314daab109cf07408674be204be5f0e"
 
+jquery-ui-bundle@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui-bundle/-/jquery-ui-bundle-1.12.1.tgz#d6be2e4c377494e2378b1cae2920a91d1182d8c4"
+
 "jquery@>= 2.1.x", jquery@>=1.10, jquery@>=1.7, jquery@>=1.7.0, jquery@>=1.7.1, jquery@>=1.8, jquery@>=1.9.0, "jquery@^1.8.3 || ^2.0 || ^3.0":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
@@ -3745,6 +3749,13 @@ path-type@^1.0.0:
 patternfly-bootstrap-combobox@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/patternfly-bootstrap-combobox/-/patternfly-bootstrap-combobox-1.1.7.tgz#6a5e3ccd1170c21b3c4b4aa168a7413e1ddbb6e1"
+
+patternfly-bootstrap-treeview@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/patternfly-bootstrap-treeview/-/patternfly-bootstrap-treeview-2.1.5.tgz#4c29f2582fb8a2f28f0a928f2f0d324d21d6990d"
+  dependencies:
+    bootstrap "3.3.x"
+    jquery ">= 2.1.x"
 
 patternfly-bootstrap-treeview@~2.1.0:
   version "2.1.1"


### PR DESCRIPTION
This is nothing but a wrapper around [patternfly-bootstrap-treeview](https://github.com/patternfly/patternfly-bootstrap-treeview/) to provide it as a component. In the future it should be rewritten without jQuery. It will be used on [left-side explorer screens](https://github.com/ManageIQ/manageiq-ui-classic/issues/1871) in the classic UI. For the more complex trees with checkboxes a new component will be created in the future.

![screenshot from 2017-08-19 13-22-20](https://user-images.githubusercontent.com/649130/29486242-76c71968-84e1-11e7-8746-f8b9951c1b6a.png)

**Usage:** 
```html
<miq-tree-view name="tree-name" reselect="bool" data="[]" lazy-load="func" on-select="func"></miq-tree-view>
```
The `data` should contain the tree nodes in the format specified by [patternfly-bootstrap-treeview](https://github.com/patternfly/patternfly-bootstrap-treeview/#data-structure), the two callbacks functions should be in the following form:
```js
function lazyLoad(node) {
  return new Promise(function (resolve) {
    // do something  with the node
    resolve(data); // same format as above
  });
}

function nodeSelect(node) {
  // do something with the node
}
```
If you want to allow firing an onSelect event on an already selected node, you should set the `reselect` parameter to `true`.

@karelhala and @himdel please review, @Hyperkid123 you can use this in the dialog editor.