### PR TITLE
Added tree selector component

### DIFF
--- a/application-settings.js
+++ b/application-settings.js
@@ -14,7 +14,8 @@ module.exports = {
     siteSwitcher: '/site-switcher',
     fonticonPicker: '/fonticon-picker',
     dialogs: '/dialog-user',
-    treeView: '/tree-view'
+    treeView: '/tree-view',
+    treeSelector: '/tree-selector'
   },
   nodePackages: 'node_modules/',
   get stylesheetPath() {

--- a/demo/controllers/index.ts
+++ b/demo/controllers/index.ts
@@ -6,6 +6,7 @@ import FonticonPickerController from './fonticonPickerController';
 import DialogUserController from './dialogUserController';
 import DialogEditorController from './dialogEditorController';
 import TreeViewController from './treeViewController';
+import TreeSelectorController from './treeSelectorController';
 import * as ng from 'angular';
 
 export default (module: ng.IModule) => {
@@ -17,4 +18,5 @@ export default (module: ng.IModule) => {
   module.controller('demoDialogUser', DialogUserController);
   module.controller('demoDialogEditor', DialogEditorController);
   module.controller('demoTreeView', TreeViewController);
+  module.controller('demoTreeSelector', TreeSelectorController);
 };

--- a/demo/controllers/treeSelectorController.ts
+++ b/demo/controllers/treeSelectorController.ts
@@ -1,0 +1,30 @@
+import * as ng from 'angular';
+
+const URL = '/data/lazyTree.json';
+
+export default class TreeSelectorController {
+  public data = require('../data/tree.json');
+  public showTree;
+  public selectedValue = 'No node selected';
+  public selectables = {
+      key: '(^gc-)|(^lc-)',
+  };
+
+  /*@ngInject*/
+  constructor(private $http) {}
+
+  public handleSelected = (node) => {
+    this.selectedValue = node.text;
+  }
+
+  public openTreeView = (open: boolean) => {
+    this.showTree = open;
+  }
+
+  public getData = (node?) => {
+    return this.$http({
+      method: 'GET',
+      url: node ? `${URL}?id=${encodeURIComponent(node.key)}` : URL,
+    }).then(response => response.data);
+  }
+}

--- a/demo/services/availableComponentsService.ts
+++ b/demo/services/availableComponentsService.ts
@@ -92,7 +92,11 @@ export default class AvailableComponentsService {
         new AvailableComponent('tree-view',
           'TreeView',
           '/tree-view',
-          require('./../views/tree-view/basic.html'), 'demoTreeView as vm')
+          require('./../views/tree-view/basic.html'), 'demoTreeView as vm'),
+        new AvailableComponent('tree-selector',
+          'TreeSelector',
+          '/tree-selector',
+          require('./../views/tree-view/tree-selector.html'), 'demoTreeSelector as vm')
       ])
     ];
   }

--- a/demo/views/tree-view/tree-selector.html
+++ b/demo/views/tree-view/tree-selector.html
@@ -1,0 +1,12 @@
+<h2>Selected node: <label>{{vm.selectedValue}}</label></h2>
+<button ng-click="vm.openTreeView(!vm.showTree)">Toggle tree</button>
+<tree-selector
+  ng-show="vm.showTree"
+  name="tree-selector"
+  data="vm.data"
+  selectables="vm.selectables"
+  display="vm.openTreeView(open)"
+  on-select="vm.handleSelected(node)"
+  lazy-load="vm.getData"
+  >
+</tree-selector>

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ module miqStaticAssets {
     'miqStaticAssets.gtl',
     'miqStaticAssets.siteSwitcher',
     'miqStaticAssets.fonticonPicker',
-    'miqStaticAssets.treeView'
+    'miqStaticAssets.treeView',
+    'miqStaticAssets.treeSelector'
   ]);
 }

--- a/src/tree-selector/index.ts
+++ b/src/tree-selector/index.ts
@@ -1,0 +1,7 @@
+import TreeSelector from './treeSelectorComponent';
+import * as angular from 'angular';
+
+module treeSelector {
+  export const app = angular.module('miqStaticAssets.treeSelector', []);
+  app.component('treeSelector', new TreeSelector);
+}

--- a/src/tree-selector/treeSelector.html
+++ b/src/tree-selector/treeSelector.html
@@ -1,0 +1,8 @@
+<miq-tree-view
+  ng-if="$ctrl.data"
+  name="vm.name"
+  reselect="false"
+  data="$ctrl.data"
+  lazy-load="$ctrl.handleLazyLoad({node: node})"
+  on-select="$ctrl.handleSelect({node: node})">
+</miq-tree-view>

--- a/src/tree-selector/treeSelectorComponent.ts
+++ b/src/tree-selector/treeSelectorComponent.ts
@@ -1,0 +1,60 @@
+import * as ng from 'angular';
+
+export class TreeSelectorController {
+  public data: any;
+  public selectables: any;
+  public display: any;
+  public onSelect: any;
+  public lazyLoad: any;
+  public name: string;
+
+  /*@ngInject*/
+  constructor(private $http, private $timeout : ng.ITimeoutService) {
+  }
+
+  public $onInit() {
+    this.data = this.parseSelectable(this.data);
+  }
+
+  public matchSelectable(node) {
+    return Object.keys(this.selectables).map((key) =>
+      !!node[key].match(this.selectables[key])
+    ).every(bool => bool);
+  }
+
+  public handleLazyLoad = (node) => {
+    const dataPromise = this.lazyLoad(node);
+    return dataPromise().then((data) => {
+      return this.parseSelectable(data);
+    });
+  }
+
+  public parseSelectable = (data: any) => {
+    return data.map((node, key) => {
+      const parsedData = {...node};
+      if(parsedData.nodes) {
+        parsedData.nodes = this.parseSelectable(parsedData.nodes);
+      }
+      parsedData.selectable = this.matchSelectable(parsedData);
+      return parsedData;
+    });
+  }
+
+  public handleSelect = (data) => {
+    this.onSelect({node: data.node});
+    this.display({open: false});
+  }
+}
+
+export default class TreeSelector implements ng.IComponentOptions {
+  public controller = TreeSelectorController;
+  public template = require('./treeSelector.html');
+  public bindings: any = {
+    data: '<',
+    name: '@',
+    selectables: '<',
+    display: '&',
+    onSelect: '&',
+    lazyLoad: '&'
+  };
+}


### PR DESCRIPTION
This is a wrapper component to treeView component.
It provides lazy load function to load partial data from passed Url, and parsing function, which marks some tree nodes as selectable, based on provided regExp.

There is also function which returns selected node.

## Usage
```
<button ng-click="vm.openTreeView(!vm.showTree)">Toggle tree</button>
 <tree-selector
   ng-show="vm.showTree"
   data="vm.data"
   selectables="(^gc-)|(^lc-)"
   display="vm.openTreeView"
   on-select="vm.handleSelected(node)"
   lazy-load="vm.getData"
   >
 </tree-selector>
```
* data: initial data for tree, shares the same format as [treeview](https://github.com/patternfly/patternfly-bootstrap-treeview)
* selectables: regular expression. this specifies which nodes in the tree can be selected
* display: function which handles showing/hiding tree
* on-select: function which handles node selection event. Node parameter is the selected node in tree
* lazy-load: function that handles lazy tree loading. It must return Promise 