### PR TITLE
Add available component builder so we can use it much easilly

### DIFF
--- a/demo/controllers/availableComponentsController.ts
+++ b/demo/controllers/availableComponentsController.ts
@@ -3,6 +3,7 @@ import {IAvailableGroup} from '../services/availableComponentsService';
 
 export default class AvailableComponentsController {
   public availableComponents: IAvailableGroup[];
+
   /* @ngInject */
   public constructor() {
     this.availableComponents = (new AvailableComponentsService()).availableComponents;

--- a/demo/controllers/dataTableController.ts
+++ b/demo/controllers/dataTableController.ts
@@ -1,5 +1,27 @@
 import * as _ from 'lodash';
+import {ComponentDemo} from '../services/availableComponentBuilder';
 
+@ComponentDemo({
+  name: 'small',
+  title: 'Small tile',
+  template: require('./../views/tile-view/small.html'),
+  group: 'tile-menu',
+  controller: 'demoDataTable as vm'
+})
+@ComponentDemo({
+  name: 'big',
+  title: 'Big tile',
+  template: require('./../views/tile-view/big.html'),
+  group: 'tile-menu',
+  controller: 'demoDataTable as vm'
+})
+@ComponentDemo({
+  name: 'basic',
+  title: 'Basic data table',
+  template: require('./../views/data-table/basic.html'),
+  group: 'data-table',
+  controller: 'demoDataTable as vm'
+})
 export default class DataTableController {
   public rows;
   public cols;

--- a/demo/controllers/dialogEditorController.ts
+++ b/demo/controllers/dialogEditorController.ts
@@ -1,4 +1,12 @@
 import DialogEditorService from '../../src/dialog-editor/services/dialogEditorService';
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'editor',
+  title: 'Dialog editor',
+  template: require('./../views/dialog/editor.html'),
+  group: 'dialog',
+  controller: 'demoDialogEditor as vm'
+})
 export default class DialogEditorController {
   public dialog: any;
   /* @ngInject */

--- a/demo/controllers/dialogUserController.ts
+++ b/demo/controllers/dialogUserController.ts
@@ -1,4 +1,11 @@
-
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'user',
+  title: 'Dialog user',
+  template: require('./../views/dialog/user.html'),
+  group: 'dialog',
+  controller: 'demoDialogUser as vm'
+})
 export default class DialogUserController {
   public dialog: any;
   public showDialogData: boolean;

--- a/demo/controllers/fonticonPickerController.ts
+++ b/demo/controllers/fonticonPickerController.ts
@@ -1,2 +1,10 @@
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'basic',
+  title: 'Fonticon picker',
+  template: require('./../views/fonticon-picker/basic.html'),
+  group: 'fonticon-picker',
+  controller: 'demoFonticonPicker as vm'
+})
 export default class FonticonPickerController {
 }

--- a/demo/controllers/siteSwitcherController.ts
+++ b/demo/controllers/siteSwitcherController.ts
@@ -1,3 +1,11 @@
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'basic',
+  title: 'Site switcher',
+  template: require('./../views/site-switcher/basic.html'),
+  group: 'site-switcher',
+  controller: 'demoSiteSwitcher as vm'
+})
 export default class SiteSwitcherController {
   public sites: any;
   constructor() {

--- a/demo/controllers/toolbarMenuController.ts
+++ b/demo/controllers/toolbarMenuController.ts
@@ -1,3 +1,19 @@
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'basic',
+  title: 'Basic Toolbar Menu',
+  template: require('./../views/toolbar-menu/basic.html'),
+  group: 'toolbar-menu',
+  controller: 'demoToolbarMenu as vm'
+})
+@ComponentDemo({
+  name: 'custom_html',
+  title: 'Custom Html Toolbar Menu',
+  template: require('./../views/toolbar-menu/custom-html.html'),
+  location: '/custom',
+  group: 'toolbar-menu',
+  controller: 'demoToolbarMenu as vm'
+})
 export default class ToolbarMenuController {
   public toolbarMenu: any;
   public customToolbarItems: any;

--- a/demo/controllers/treeSelectorController.ts
+++ b/demo/controllers/treeSelectorController.ts
@@ -1,5 +1,13 @@
 import * as ng from 'angular';
+import {ComponentDemo} from '../services/availableComponentBuilder';
 
+@ComponentDemo({
+  name: 'tree-selector',
+  title: 'TreeSelector',
+  template: require('./../views/tree-view/tree-selector.html'),
+  group: 'tree-view',
+  controller: 'demoTreeSelector as vm'
+})
 export default class TreeSelectorController {
   public display = false;
   public node;

--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -1,5 +1,12 @@
 import * as ng from 'angular';
-
+import {ComponentDemo} from '../services/availableComponentBuilder';
+@ComponentDemo({
+  name: 'tree-view',
+  title: 'TreView',
+  template: require('./../views/tree-view/basic.html'),
+  group: 'tree-view',
+  controller: 'demoTreeView as vm'
+})
 export default class TreeViewController {
   public node;
   public data = require('../data/tree.json');

--- a/demo/services/availableComponentBuilder.ts
+++ b/demo/services/availableComponentBuilder.ts
@@ -1,0 +1,32 @@
+import {AvailableComponent, default as AvailableComponentsService} from './availableComponentsService';
+
+function checkProperties(settings, fields, target?) {
+  for (let field of fields) {
+    if (!settings.hasOwnProperty(field)) {
+      let suffix = target ? `Called on class ${target['name']}.` : '';
+      throw new Error(`Available component has to have ${field} set up! ${suffix}`);
+    }
+  }
+}
+
+export function ComponentDemo(settings: any) {
+  function componentFactory() {
+    return new AvailableComponent(
+      settings.name,
+      settings.title || settings.name,
+      settings.location || `/${settings.name}`,
+      settings.template,
+      settings.controller
+    );
+  }
+
+  return function(target: Function) {
+    checkProperties(settings, ['controller', 'name', 'template', 'group'], target);
+    let availCmps = new AvailableComponentsService();
+    const currentGroup = availCmps.availableComponents.filter(group => group.name === settings.group);
+    if (!currentGroup) {
+      throw new Error(`Selected group '${settings.group}' does not exists!`);
+    }
+    currentGroup.forEach(oneGroup => oneGroup.components.push(componentFactory()));
+  };
+}

--- a/demo/services/availableComponentsService.ts
+++ b/demo/services/availableComponentsService.ts
@@ -27,77 +27,28 @@ export class AvailableComponent implements IAvailComponent {
     public template: string,
     public controller: string) { }
 }
+
 export default class AvailableComponentsService {
+  public static instance: AvailableComponentsService;
   public availableComponents: IAvailableGroup[];
 
   public constructor() {
+    if (AvailableComponentsService.instance) {
+      return AvailableComponentsService.instance;
+    }
     this.initComponents();
+    AvailableComponentsService.instance = this;
   }
 
-  private initComponents() {
+  public initComponents() {
     this.availableComponents = [
-      new AvailableGroup('toolbar-menu', 'Toolbar Menu Components', '/toolbar-menu', [
-        new AvailableComponent('basic', '' +
-          'Basic Toolbar Menu',
-          '/basic',
-          require('./../views/toolbar-menu/basic.html'),
-          'demoToolbarMenu as vm'),
-        new AvailableComponent('custom_html', '' +
-          'Custom Html Toolbar Menu',
-          '/custom',
-          require('./../views/toolbar-menu/custom-html.html'),
-          'demoToolbarMenu as vm')
-      ]),
-      new AvailableGroup('tile-menu', 'Tile Components', '/tile-view', [
-        new AvailableComponent('small',
-          'Small tile',
-          '/small',
-          require('./../views/tile-view/small.html'),
-          'demoDataTable as vm'),
-        new AvailableComponent('big',
-          'Big tile',
-          '/big',
-          require('./../views/tile-view/big.html'),
-          'demoDataTable as vm'),
-      ]),
-      new AvailableGroup('data-table', 'Data table Components', '/data-table', [
-        new AvailableComponent('basic',
-          'Basic data table',
-          '/basic',
-          require('./../views/data-table/basic.html'), 'demoDataTable as vm')
-      ]),
-      new AvailableGroup('site-switcher', 'Site Switcher Components', '/site-switcher', [
-        new AvailableComponent('basic',
-          'Site switcher',
-          '/basic',
-          require('./../views/site-switcher/basic.html'), 'demoSiteSwitcher as vm')
-      ]),
-      new AvailableGroup('fonticon-picker', 'Fonticon Picker Components', '/fonticon-picker', [
-        new AvailableComponent('basic',
-          'Fonticon picker',
-          '/basic',
-          require('./../views/fonticon-picker/basic.html'), 'demoFonticonPicker as vm')
-      ]),
-      new AvailableGroup('dialog', 'Dialog Components', '/dialog', [
-        new AvailableComponent('editor',
-          'Dialog editor',
-          '/editor',
-          require('./../views/dialog/editor.html'), 'demoDialogEditor as vm'),
-        new AvailableComponent('user',
-          'Dialog user',
-          '/user',
-          require('./../views/dialog/user.html'), 'demoDialogUser as vm')
-      ]),
-      new AvailableGroup('tree-view', 'Tree Components', '/tree', [
-        new AvailableComponent('tree-view',
-          'TreeView',
-          '/tree-view',
-          require('./../views/tree-view/basic.html'), 'demoTreeView as vm'),
-        new AvailableComponent('tree-selector',
-          'TreeSelector',
-          '/tree-selector',
-          require('./../views/tree-view/tree-selector.html'), 'demoTreeSelector as vm')
-      ])
+      new AvailableGroup('toolbar-menu', 'Toolbar Menu Components', '/toolbar-menu', []),
+      new AvailableGroup('tile-menu', 'Tile Components', '/tile-view', []),
+      new AvailableGroup('data-table', 'Data table Components', '/data-table', []),
+      new AvailableGroup('site-switcher', 'Site Switcher Components', '/site-switcher', []),
+      new AvailableGroup('fonticon-picker', 'Fonticon Picker Components', '/fonticon-picker', []),
+      new AvailableGroup('dialog', 'Dialog Components', '/dialog', []),
+      new AvailableGroup('tree-view', 'Tree Components', '/tree', [])
     ];
   }
 }

--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -80,7 +80,7 @@ export class SortItemsController {
    * @function fillFields
    */
   private fillFields() {
-    _.each(this.headers, (oneCol, key) => {
+    _.each(this.headers, (oneCol: any, key) => {
       if (!oneCol.hasOwnProperty('is_narrow') && oneCol.hasOwnProperty('text')) {
         this.options.fields.push({
           colId: key,

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -102,7 +102,7 @@ class BoxController {
    * @param {number} ui jQuery object
    */
   public droppableOptions(e: any, ui: any) {
-    let droppedItem = ng.element(e.target).scope();
+    let droppedItem: any = ng.element(e.target).scope();
     // update indexes of other boxes after changing their order
     this.DialogEditor.updatePositions(
       droppedItem.box.dialog_fields

--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -36,7 +36,7 @@ class TabListController {
       helper: 'clone',
       revert: 50,
       stop: (e: any, ui: any) => {
-        let sortedTab = ng.element(ui.item).scope().$parent;
+        let sortedTab: any = ng.element(ui.item).scope().$parent;
         let tabList = sortedTab.vm.tabList;
         this.DialogEditor.updatePositions(tabList);
         let activeTab: any = _.find(tabList, {active: true});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
+    "experimentalDecorators": true,
     "removeComments": false,
     "noEmitOnError": true,
     "sourceMap": true,


### PR DESCRIPTION
To register new group you will have to add new item with name, location, title and empty array of components. When registering available component use custom decorator above some class to register it:
```Typescript
@ComponentDemo({
  name: 'tree-view-new',
  title: 'TreView',
  template: require('./../views/tree-view/basic.html'),
  controller: 'demoTreeView as vm'
})
export default class TreeViewController {
  //Demo treeView controller implementation
}
```

If you need more components registered under same controller use `AvailableCmp` multiple times as seen at [demo/controllers/dataTableController.ts](https://github.com/ManageIQ/ui-components/pull/127/files#diff-5884d947210a1d2824f3a7a10e833088)
```Typescript
@ComponentDemo({
  name: 'small',
  title: 'Small tile',
  template: require('./../views/tile-view/small.html'),
  group: 'tile-menu',
  controller: 'demoDataTable as vm'
})
@ComponentDemo({
  name: 'big',
  title: 'Big tile',
  template: require('./../views/tile-view/big.html'),
  group: 'tile-menu',
  controller: 'demoDataTable as vm'
})
@ComponentDemo({
  name: 'basic',
  title: 'Basic data table',
  template: require('./../views/data-table/basic.html'),
  group: 'data-table',
  controller: 'demoDataTable as vm'
})
export default class DataTableController {
  //Implementation of DataTablecontroller
}
```