### PR TITLE
Add one-way binding for external tree node selection in treeView

### DIFF
--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -3,12 +3,22 @@ import * as ng from 'angular';
 export default class TreeViewController {
   public node;
   public data = require('../data/tree.json');
+  public selectNode;
 
   /*@ngInject*/
   constructor(private $scope : ng.IScope, private $timeout : ng.ITimeoutService) {};
 
   public resetState(node) {
     sessionStorage.clear();
+  }
+
+  public selectRandom(node) {
+    let keys = JSON.stringify(this.data)
+      .match(/\"key\":\"[^\"]+\"/g)
+      .map((item) => item.replace(/\"key\":\"([^\"]+)\"/, '$1'));
+    let key = keys[Math.floor(Math.random() * keys.length)];
+
+    this.selectNode = { key: key };
   }
 
   public lazyLoad(node) {

--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -1,5 +1,7 @@
-<miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)"></miq-tree-view>
+<miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>
 <button ng-click="vm.resetState();">Reset state</button>
+<button ng-click="vm.selectRandom();">Select random</button>
+<p>Note: programmatically selecting a node is not firing the onSelect event on purpose.</p>
 <div ng-if="vm.node">
   <h3>Selected node:</h3>
   <pre>{{ vm.node | json }}</pre>

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -25,6 +25,7 @@ export class TreeViewController {
         }
 
         if (this.getTreeState(node) === !node.state.expanded) {
+          this.tree.revealNode(node, {silent: true});
           this.tree.toggleNodeExpanded(node);
         }
       });

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -3,9 +3,10 @@ import * as ng from 'angular';
 export class TreeViewController {
   private tree;
 
-  public reselect;
-  public data;
   public name : string;
+  public data;
+  public selected;
+  public reselect;
   public onSelect: (args: {node: any}) => void;
   public lazyLoad: (args: {node: any}) => Promise<any>;
 
@@ -18,11 +19,26 @@ export class TreeViewController {
       this.tree = ng.element(element).treeview(true);
 
       this.tree.getNodes().forEach((node) => {
+        // Initial node selection right after rendering
+        if (this.selected && this.matchNode(node, this.selected)) {
+          this.selectNode(node);
+        }
+
         if (this.getTreeState(node) === !node.state.expanded) {
           this.tree.toggleNodeExpanded(node);
         }
       });
     });
+  }
+
+  public $onChanges(changes) {
+    // Prevent initial node selection before the tree is fully rendered
+    if (!changes.selected.isFirstChange() &&
+        changes.selected.previousValue !== undefined &&
+        changes.selected.currentValue !== undefined) {
+      let node = this.findNode(changes.selected.currentValue);
+      this.$timeout(() => this.selectNode(node));
+    }
   }
 
   private renderTree(element) {
@@ -42,6 +58,22 @@ export class TreeViewController {
         onRendered:      () => this.$timeout(resolve)
       });
     });
+  }
+
+  private findNode(params) {
+    return this.tree.getNodes().find(node => this.matchNode(node, params));
+  }
+
+  private matchNode(node, params) {
+    return Object.keys(params)
+      .map(param => node[param] === params[param])
+      .every(bool => bool);
+  }
+
+  private selectNode(node) {
+    this.tree.revealNode(node, {silent: true});
+    this.tree.selectNode(node, {silent: true});
+    this.tree.expandNode(node);
   }
 
   private setTreeState(state) {
@@ -73,6 +105,7 @@ export default class TreeView implements ng.IComponentOptions {
   public bindings: any = {
     name: '@',
     data: '<',
+    selected: '<',
     reselect: '<',
     onSelect: '&',
     lazyLoad: '&'


### PR DESCRIPTION
If you want to programmatically select a node from outside the component, simply set its `selected` attribute to an object that has some matching attributes with a node.

`<miq-tree-view ... selected="{key: 'something'}">`

@karelhala or @himdel 