### PR TITLE
[WIP] Make sure parent nodes are expanded when loading treeView state

### DIFF
--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -18,6 +18,7 @@ export class TreeViewController {
       this.tree = ng.element(element).treeview(true);
 
       this.tree.getNodes().forEach((node) => {
+        this.tree.revealNode(node, {silent: true});
         if (this.getTreeState(node) === !node.state.expanded) {
           this.tree.toggleNodeExpanded(node);
         }


### PR DESCRIPTION
There's no way to reproduce the issue using clicking, but #129 introduces a programmatic way of selecting and expanding tree nodes. If a non-visible node with children gets selected and expanded, the tree state object will hold its state and after a refresh it can go ugly (see below).

This PR enforces to expand all the parent nodes of an expanded node.

**Before:**
![screenshot from 2017-08-24 17-19-43](https://user-images.githubusercontent.com/649130/29673795-8cf21702-88f0-11e7-94cc-371436bab233.png)

**After:**
![screenshot from 2017-08-24 17-20-02](https://user-images.githubusercontent.com/649130/29673806-93e9a084-88f0-11e7-9bcf-92ade3106880.png)
