### PR TITLE
Allow to select a lazily loadable node in treeView

### DIFF
--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -6,13 +6,15 @@ export default class TreeViewController {
   public selectNode;
 
   /*@ngInject*/
-  constructor(private $scope : ng.IScope, private $timeout : ng.ITimeoutService) {};
+  constructor(private $scope : ng.IScope, private $timeout : ng.ITimeoutService, private $window : ng.IWindowService) {
+  };
 
-  public resetState(node) {
+  public resetState() {
     sessionStorage.clear();
+    this.$window.location.reload();
   }
 
-  public selectRandom(node) {
+  public selectRandom() {
     let keys = JSON.stringify(this.data)
       .match(/\"key\":\"[^\"]+\"/g)
       .map((item) => item.replace(/\"key\":\"([^\"]+)\"/, '$1'));

--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -23,6 +23,10 @@ export default class TreeViewController {
     this.selectNode = { key: key };
   }
 
+  public selectLazy() {
+    this.selectNode = [{key: 'lp-1'}, {key: 'lc-2'}, {key: 'lgc-1'}];
+  }
+
   public lazyLoad(node) {
     let data = require('../data/lazyTree.json');
     // Wait to simulate HTTP delay

--- a/demo/data/lazyTree.json
+++ b/demo/data/lazyTree.json
@@ -7,6 +7,13 @@
   {
     "key": "lc-2",
     "icon": "ff ff-diamond",
-    "text": "Lazy Child 2"
+    "text": "Lazy Child 2",
+    "nodes": [
+      {
+        "key": "lgc-1",
+        "icon": "ff ff-diamond",
+        "text": "Lazy grandchild 1"
+      }
+    ]
   }
 ]

--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -1,7 +1,9 @@
-<miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>
-<button ng-click="vm.resetState();">Reset state</button>
+<button ng-click="vm.resetState();">Reset</button>
 <button ng-click="vm.selectRandom();">Select random</button>
 <p>Note: programmatically selecting a node is not firing the onSelect event on purpose.</p>
+
+<miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>
+
 <div ng-if="vm.node">
   <h3>Selected node:</h3>
   <pre>{{ vm.node | json }}</pre>

--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -1,5 +1,6 @@
 <button ng-click="vm.resetState();">Reset</button>
 <button ng-click="vm.selectRandom();">Select random</button>
+<button ng-click="vm.selectLazy();">Select lazy</button>
 <p>Note: programmatically selecting a node is not firing the onSelect event on purpose.</p>
 
 <miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -2,6 +2,7 @@ import * as ng from 'angular';
 
 export class TreeViewController {
   private tree;
+  private element;
 
   public name : string;
   public data;
@@ -14,9 +15,10 @@ export class TreeViewController {
   constructor(private $element : ng.IRootElementService, private $timeout : ng.ITimeoutService) {}
 
   public $onInit() {
-    let element = this.$element[0].querySelector('div.treeview');
-    this.renderTree(element).then(() => {
-      this.tree = ng.element(element).treeview(true);
+    this.element = ng.element(this.$element[0].querySelector('div.treeview'));
+
+    this.renderTree().then(() => {
+      this.tree = this.element.treeview(true);
 
       this.tree.getNodes().forEach((node) => {
         // Initial node selection right after rendering
@@ -42,9 +44,9 @@ export class TreeViewController {
     }
   }
 
-  private renderTree(element) {
+  private renderTree() {
     return new Promise((resolve) => {
-      ng.element(element).treeview({
+      this.element.treeview({
         data:            this.data,
         showImage:       true,
         expandIcon:      'fa fa-fw fa-angle-right',

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -65,13 +65,10 @@ export class TreeViewController {
   }
 
   private findNode(params) {
-    return this.tree.getNodes().find(node => this.matchNode(node, params));
-  }
-
-  private matchNode(node, params) {
-    return Object.keys(params)
+    return this.tree.getNodes().find(node => Object.keys(params)
       .map(param => node[param] === params[param])
-      .every(bool => bool);
+      .every(bool => bool)
+    );
   }
 
   /*

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -3,6 +3,7 @@ import * as ng from 'angular';
 export class TreeViewController {
   private tree;
   private element;
+  private rendered : boolean = false;
 
   public name : string;
   public data;
@@ -31,14 +32,14 @@ export class TreeViewController {
           this.tree.toggleNodeExpanded(node);
         }
       });
+
+      this.rendered = true;
     });
   }
 
   public $onChanges(changes) {
     // Prevent initial node selection before the tree is fully rendered
-    if (!changes.selected.isFirstChange() &&
-        changes.selected.previousValue !== undefined &&
-        changes.selected.currentValue !== undefined) {
+    if (!changes.selected.isFirstChange() && this.rendered && changes.selected.currentValue !== undefined) {
       let node = this.findNode(changes.selected.currentValue);
       this.$timeout(() => this.selectNode(node));
     }


### PR DESCRIPTION
Sometimes we want to select a node that's not yet loaded. This is now possible by passing an array of node matchers in the `selected` attribute of the component. The first element of the array should match a node that's already available in the tree. The others should match its children, each in one level until the last element that matches the finaly node to be selected.

For example:
```json
[
  {
    "title": "Parent",
    "nodes": [
      {
        "title": "Child",
        "nodes": [
          {
            "title": "Grandchild"
          }
        ]
      }
    ]
  }
]
```
If the tree above is lazily loaded on each level and you want to select the `Grandchild` node, you would need:
```html
<miq-tree-view ... selected="[{'title': 'Parent'}, {'title': 'Child'}, {'title': 'Grandchild'}]"/>
```