### PR TITLE
Optionally display images as node icons in treeView

### DIFF
--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -46,6 +46,7 @@ export class TreeViewController {
     return new Promise((resolve) => {
       ng.element(element).treeview({
         data:            this.data,
+        showImage:       true,
         expandIcon:      'fa fa-fw fa-angle-right',
         collapseIcon:    'fa fa-fw fa-angle-down',
         loadingIcon:     'fa fa-fw fa-spinner fa-pulse',


### PR DESCRIPTION
Missed [this parameter](https://github.com/patternfly/patternfly-bootstrap-treeview/#showimage) from the initial configuration of `bootstrap-treeview`.