### PR TITLE
Improved state (re)storing for the TreeView component

### DIFF
--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -3,7 +3,14 @@
 <button ng-click="vm.selectLazy();">Select lazy</button>
 <p>Note: programmatically selecting a node is not firing the onSelect event on purpose.</p>
 
-<miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>
+<miq-tree-view
+  name="demo-tree"
+  data="vm.data"
+  lazy-load="vm.lazyLoad(node)"
+  on-select="vm.nodeSelect(node)"
+  selected="vm.selectNode"
+  persist="key"
+></miq-tree-view>
 
 <div ng-if="vm.node">
   <h3>Selected node:</h3>

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -41,7 +41,7 @@ export class TreeViewController {
         preventUnselect: true,
         showBorders:     false,
         onNodeExpanded:  this.setTreeState(true),
-        onNodeCollapsed: this.setTreeState(false),
+        onNodeCollapsed: this.setTreeState(undefined),
         onNodeSelected:  (_event, node) => this.$timeout(() => this.onSelect({node: node})),
         lazyLoad:        (node, render) => this.$timeout(() => this.lazyLoad({node: node}).then(render)),
         onRendered:      () => this.$timeout(resolve)

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -115,8 +115,9 @@ export class TreeViewController {
       if (!node) {
         return reject();
       }
-      // No need to expand if the node has no children
+      // No need to wait if the node is not lazy
       if (!node.lazyLoad) {
+        this.tree.expandNode(node);
         return resolve();
       }
 


### PR DESCRIPTION
I extracted the miq-specific `key` attribute from the state storing part of TreeView. From now on if you want to store the tree state, you'd need to set the `persist` string parameter to a key that's uniquely set for each node in the `data`. In the miq-related context this should be `key`, but it basically can be anything. It was not necessary to store collapsed nodes in the session storage as they are always rendered as collapsed. So now it's possible to save the path to an expanded node instead of the `true` value that helps us in restoring the state of a lazily loadable node.