### PR TITLE
Prevent unselection of an already selected node in TreeView

### DIFF
--- a/src/tree-selector/treeSelector.html
+++ b/src/tree-selector/treeSelector.html
@@ -1,7 +1,7 @@
 <miq-tree-view
   ng-if="$ctrl.data"
   name="vm.name"
-  reselect="false"
+  reselect="true"
   data="$ctrl.data"
   lazy-load="$ctrl.handleLazyLoad({node: node})"
   on-select="$ctrl.handleSelect({node: node})">

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -54,6 +54,7 @@ export class TreeViewController {
         loadingIcon:     'fa fa-fw fa-spinner fa-pulse',
         levels:          1,
         allowReselect:   this.reselect,
+        preventUnselect: true,
         showBorders:     false,
         onNodeExpanded:  this.setTreeState(true),
         onNodeCollapsed: this.setTreeState(false),


### PR DESCRIPTION
This is the standard behavior in MiQ trees, if a node is selected it can't be unselected by clicking on it. This caused issues in the `TreeSelector` but it has been fixed by enabling `reselect`.

cc @Hyperkid123 