### PR TITLE
Dialog Editor Validations

### DIFF
--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -1,0 +1,65 @@
+import {__} from '../../common/translateFunction';
+import * as _ from 'lodash';
+
+export default class DialogValidationService {
+  public invalid: any = [];
+
+  /** @ngInject */
+  constructor(private DialogEditor: any) {
+  }
+
+  /**
+   * Run validations across each dialog elements.
+   * @memberof DialogValidationService
+   * @function dialogIsValid
+   */
+  public dialogIsValid() {
+    var validators = {
+      dialog: [
+        dialog => ({ status: ! _.isEmpty(dialog.label),
+                     errorMessage: __('Dialog needs to have a label') }),
+        dialog => ({ status: dialog.dialog_tabs.length > 0,
+                     errorMessage: __('Dialog needs to have at least one tab') })
+      ],
+      tabs: [
+        tab => ({ status: ! _.isEmpty(tab.label),
+                  errorMessage: __('Dialog tab needs to have a name') }),
+        tab => ({ status: tab.dialog_groups.length > 0,
+                  errorMessage: __('Dialog tab needs to have at least one box') })
+      ],
+      groups: [
+        group => ({ status: ! _.isEmpty(group.label),
+                    errorMessage: __('Dialog box needs to have a name') }),
+        group => ({ status: group.dialog_fields.length > 0,
+                    errorMessage: __('Dialog box needs to have at least one element') })
+      ],
+      fields: [
+        field => ({ status: ! _.isEmpty(field.name),
+                    errorMessage: __('Dialog element needs to have a name') }),
+        field => ({ status: ! _.isEmpty(field.label),
+                    errorMessage: __('Dialog element needs to have a label') })
+      ]
+    };
+
+    let invalid = [];
+    let validate = function (f, item) {
+      let validation = f(item);
+      if (!validation.status) {
+        invalid.push({ message: validation.errorMessage, item: item });
+      }
+      return validation.status;
+    };
+
+    return _.every(DialogEditor.data.content, dialog =>
+      _.every(validators.dialog, f => validate(f, dialog)) &&
+      _.every(dialog.dialog_tabs, tab =>
+        _.every(validators.tabs, f => validate(f, tab)) &&
+        _.every(tab.dialog_groups, group =>
+          _.every(validators.groups, f => validate(f, group)) &&
+          _.every(group.dialog_fields, field =>
+            _.every(validators.fields, f => validate(f, field)))
+        )
+      )
+    );
+  }
+

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -2,7 +2,7 @@ import {__} from '../../common/translateFunction';
 import * as _ from 'lodash';
 
 export default class DialogValidationService {
-  public invalid: any = [];
+  public invalid: any = {};
 
   /** @ngInject */
   constructor(private DialogEditor: any) {
@@ -14,7 +14,7 @@ export default class DialogValidationService {
    * @function dialogIsValid
    */
   public dialogIsValid() {
-    var validators = {
+    let validators = {
       dialog: [
         dialog => ({ status: ! _.isEmpty(dialog.label),
                      errorMessage: __('Dialog needs to have a label') }),
@@ -41,25 +41,26 @@ export default class DialogValidationService {
       ]
     };
 
-    let invalid = [];
-    let validate = function (f, item) {
+    const self = this;
+    let validate = (f, item) => {
       let validation = f(item);
-      if (!validation.status) {
-        invalid.push({ message: validation.errorMessage, item: item });
+      if (! validation.status) {
+        self.invalid = { element: item, message: validation.errorMessage };
       }
       return validation.status;
     };
 
-    return _.every(DialogEditor.data.content, dialog =>
+    return _.every(this.DialogEditor.data.content, dialog =>
       _.every(validators.dialog, f => validate(f, dialog)) &&
-      _.every(dialog.dialog_tabs, tab =>
+      _.every((<any>dialog).dialog_tabs, tab =>
         _.every(validators.tabs, f => validate(f, tab)) &&
-        _.every(tab.dialog_groups, group =>
+        _.every((<any>tab).dialog_groups, group =>
           _.every(validators.groups, f => validate(f, group)) &&
-          _.every(group.dialog_fields, field =>
-            _.every(validators.fields, f => validate(f, field)))
+          _.every((<any>group).dialog_fields, field =>
+            _.every(validators.fields, f => validate(f, field))
+          )
         )
       )
     );
   }
-
+}

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -5,7 +5,6 @@ export default class DialogValidationService {
   public invalid: any = {};
   private validators: any = {};
 
-  /** @ngInject */
   constructor() {
     this.validators = {
       dialog: [
@@ -31,9 +30,8 @@ export default class DialogValidationService {
                     errorMessage: __('Dialog element needs to have a name') }),
         field => ({ status: ! _.isEmpty(field.label),
                     errorMessage: __('Dialog element needs to have a label') })
-      ]
+      ],
     };
-
   }
 
   /**

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -5,7 +5,7 @@ export default class DialogValidationService {
   public invalid: any = {};
 
   /** @ngInject */
-  constructor(private DialogEditor: any) {
+  constructor() {
   }
 
   /**
@@ -13,7 +13,7 @@ export default class DialogValidationService {
    * @memberof DialogValidationService
    * @function dialogIsValid
    */
-  public dialogIsValid() {
+  public dialogIsValid(dialogData: any) {
     let validators = {
       dialog: [
         dialog => ({ status: ! _.isEmpty(dialog.label),
@@ -50,7 +50,7 @@ export default class DialogValidationService {
       return validation.status;
     };
 
-    return _.every(this.DialogEditor.data.content, dialog =>
+    return _.every(dialogData, dialog =>
       _.every(validators.dialog, f => validate(f, dialog)) &&
       _.every((<any>dialog).dialog_tabs, tab =>
         _.every(validators.tabs, f => validate(f, tab)) &&

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -3,18 +3,11 @@ import * as _ from 'lodash';
 
 export default class DialogValidationService {
   public invalid: any = {};
+  private validators: any = {};
 
   /** @ngInject */
   constructor() {
-  }
-
-  /**
-   * Run validations across each dialog elements.
-   * @memberof DialogValidationService
-   * @function dialogIsValid
-   */
-  public dialogIsValid(dialogData: any) {
-    let validators = {
+    this.validators = {
       dialog: [
         dialog => ({ status: ! _.isEmpty(dialog.label),
                      errorMessage: __('Dialog needs to have a label') }),
@@ -41,6 +34,14 @@ export default class DialogValidationService {
       ]
     };
 
+  }
+
+  /**
+   * Run validations across each dialog elements.
+   * @memberof DialogValidationService
+   * @function dialogIsValid
+   */
+  public dialogIsValid(dialogData: any) {
     const self = this;
     let validate = (f, item) => {
       let validation = f(item);
@@ -51,13 +52,13 @@ export default class DialogValidationService {
     };
 
     return _.every(dialogData, dialog =>
-      _.every(validators.dialog, f => validate(f, dialog)) &&
+      _.every(this.validators.dialog, f => validate(f, dialog)) &&
       _.every((<any>dialog).dialog_tabs, tab =>
-        _.every(validators.tabs, f => validate(f, tab)) &&
+        _.every(this.validators.tabs, f => validate(f, tab)) &&
         _.every((<any>tab).dialog_groups, group =>
-          _.every(validators.groups, f => validate(f, group)) &&
+          _.every(this.validators.groups, f => validate(f, group)) &&
           _.every((<any>group).dialog_fields, field =>
-            _.every(validators.fields, f => validate(f, field))
+            _.every(this.validators.fields, f => validate(f, field))
           )
         )
       )

--- a/src/dialog-editor/services/index.ts
+++ b/src/dialog-editor/services/index.ts
@@ -1,7 +1,9 @@
 import DialogEditorService from './dialogEditorService';
+import DialogValidationService from './dialogValidationService';
 import ModalService from './modal/modalService';
 
 export default (module: ng.IModule) => {
   module.service('DialogEditor', DialogEditorService);
   module.service('DialogEditorModal', ModalService);
+  module.service('DialogValidation', DialogValidationService);
 };


### PR DESCRIPTION
taking the method from PR https://github.com/ManageIQ/manageiq-ui-classic/pull/2055 as a new service for Dialog validations:

> 
> After these changes, it won't be possible to submit invalid dialog.
> The methods are testing that
> 
> - dialog has a name
> - dialog has at least one tab
> - every dialog tab have a name
> - every dialog tab has at least one box
> - every dialog box has a name
> - every dialog box has at least one element
> - every element has a name
> 
> if one test fails, the `Save` buttons becomes disabled.
> 
> Links
> ----------------
> * https://www.pivotaltracker.com/story/show/144481043
> 
> Steps for Testing/QA
> -------------------------------
> 
> Automation -> Automate -> Customization -> Edit this / Add a new dialog in the Dialog Editor -> [see the screencast]
> 
> ![screencast from 2017-08-30 16-21-22](https://user-images.githubusercontent.com/1187051/29877333-97ef6886-8d9f-11e7-9adf-c05b5a5c5790.gif)

/cc @skateman @himdel @karelhala 