### PR TITLE
Add ability to edit the dialog field associations in the UI

### DIFF
--- a/src/dialog-editor/components/modal-field-template/check-box.html
+++ b/src/dialog-editor/components/modal-field-template/check-box.html
@@ -21,10 +21,3 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}">
-</div>

--- a/src/dialog-editor/components/modal-field-template/date-time-control.html
+++ b/src/dialog-editor/components/modal-field-template/date-time-control.html
@@ -6,13 +6,6 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}">
-</div>
 <div pf-form-group pf-label="{{'Show Past Dates'|translate}}">
   <input bs-switch
          ng-model="vm.modalData.options.show_past_dates"

--- a/src/dialog-editor/components/modal-field-template/dialog-field-association-info.html
+++ b/src/dialog-editor/components/modal-field-template/dialog-field-association-info.html
@@ -1,0 +1,6 @@
+<div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
+  <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
+          ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
+          multiple pf-select>
+  </select>
+</div>

--- a/src/dialog-editor/components/modal-field-template/dynamic.html
+++ b/src/dialog-editor/components/modal-field-template/dynamic.html
@@ -18,17 +18,3 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}"/>
 </div>
-<div pf-form-group pf-label="{{'Auto refresh'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}"/>
-</div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}"/>
-</div>

--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -20,13 +20,6 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}">
-</div>
 <div pf-form-group pf-label="{{'Default value'|translate}}">
   <select class="form-control" pf-select
           ng-model="vm.modalData.default_value"

--- a/src/dialog-editor/components/modal-field-template/tag-control.html
+++ b/src/dialog-editor/components/modal-field-template/tag-control.html
@@ -20,13 +20,6 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}">
-</div>
 <div pf-form-group pf-label="{{'Category'|translate}}">
   <select class="form-control" pf-select
           ng-model="vm.modalData.options.category_id"

--- a/src/dialog-editor/components/modal-field-template/text-area-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-area-box.html
@@ -26,13 +26,6 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}">
-</div>
 <div pf-form-group pf-label="{{'Validation'|translate}}">
   <input id="validator_rule" name="validator_rule"
          ng-model="vm.modalData.validator_rule"/>

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -32,13 +32,6 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>
-<div pf-form-group pf-label="{{'Auto refresh on change'|translate}}">
-  <input bs-switch
-         ng-model="vm.modalData.trigger_auto_refresh"
-         type="checkbox"
-         switch-on-text="{{'Yes'|translate}}"
-         switch-off-text="{{'No'|translate}}"/>
-</div>
 <div pf-form-group pf-label="{{'Validation'|translate}}">
   <input id="validator_rule" name="validator_rule"
           ng-model="vm.modalData.validator_rule"/>

--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -1,0 +1,112 @@
+import DialogEditor from './dialogEditorService';
+import * as angular from 'angular';
+
+describe('DialogEditor test', () => {
+  let dialogEditor;
+
+  beforeEach(() => {
+    angular.mock.module('miqStaticAssets.dialogEditor');
+    angular.mock.module('miqStaticAssets.common');
+    angular.mock.inject(() => {
+      dialogEditor = new DialogEditor();
+    });
+  });
+
+  describe('#setData', () => {
+    it('sets data to the data property', () => {
+      dialogEditor.setData('test');
+      expect(dialogEditor.data).toEqual('test');
+    });
+  });
+
+  describe('#getDialogId', () => {
+    let dialogData = {content: [{id: 123}]};
+
+    beforeEach(() => {
+      dialogEditor.setData(dialogData);
+    });
+
+    it('returns the id of the dialog', () => {
+      expect(dialogEditor.getDialogId()).toEqual(123);
+    });
+  });
+
+  describe('#getDialogLabel', () => {
+    let dialogData = {content: [{label: 'label'}]};
+
+    beforeEach(() => {
+      dialogEditor.setData(dialogData);
+    });
+
+    it('returns the label of the dialog', () => {
+      expect(dialogEditor.getDialogLabel()).toEqual('label');
+    });
+  });
+
+  describe('#getDialogDescription', () => {
+    let dialogData = {content: [{description: 'description'}]};
+
+    beforeEach(() => {
+      dialogEditor.setData(dialogData);
+    });
+
+    it('returns the description of the dialog', () => {
+      expect(dialogEditor.getDialogDescription()).toEqual('description');
+    });
+  });
+
+  describe('#getDialogTabs', () => {
+    let dialogData = {content: [{dialog_tabs: 'dialog_tabs'}]};
+
+    beforeEach(() => {
+      dialogEditor.setData(dialogData);
+    });
+
+    it('returns the dialog_tabs of the dialog', () => {
+      expect(dialogEditor.getDialogTabs()).toEqual('dialog_tabs');
+    });
+  });
+
+  describe('#getDynamicFields', () => {
+    let field1 = {
+      id: 1,
+      dynamic: true
+    };
+
+    let field2 = {
+      id: 2,
+      dynamic: true
+    };
+
+    let field3 = {
+      id: 3,
+      dynamic: false
+    };
+
+    let data = {
+      content: [{
+        dialog_tabs: [{
+          dialog_groups: [{
+            dialog_fields: [field1, field2, field3]
+          }]
+        }]
+      }]
+    };
+
+    beforeEach(() => {
+      dialogEditor.setData(data);
+    });
+
+    describe('when the list of dynamic field contains the given field id', () => {
+      it('returns the dynamic fields without the given field', () => {
+        expect(dialogEditor.getDynamicFields(2)).toEqual([field1]);
+      });
+    });
+
+    describe('when the list of dynamic field does not contain the given field id', () => {
+      it('returns the full list of dynamic fields', () => {
+        expect(dialogEditor.getDynamicFields(4)).toEqual([field1, field2]);
+      });
+    });
+  });
+});

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 export default class DialogEditorService {
   public data: any = {};
   public activeTab: number = 0;
@@ -46,6 +48,21 @@ export default class DialogEditorService {
    */
   public getDialogTabs() {
     return this.data.content[0].dialog_tabs;
+  }
+
+  public getDynamicFields(idToExclude) {
+    let dynamicFields = [];
+    _.forEach(this.data.content[0].dialog_tabs, (tab: any) => {
+      _.forEach(tab.dialog_groups, (group: any) => {
+        _.forEach(group.dialog_fields, (field: any) => {
+          if (field.dynamic === true && field.id !== idToExclude) {
+            dynamicFields.push(field);
+          }
+        });
+      });
+    });
+
+    return dynamicFields;
   }
 
   /**

--- a/src/dialog-editor/services/modal/modal.html
+++ b/src/dialog-editor/services/modal/modal.html
@@ -90,6 +90,11 @@
                                             modal-data="vm.modalData">
         </dialog-editor-modal-field-template>
       </div>
+      <div>
+        <dialog-editor-modal-field-template template="dialog-field-association-info.html"
+                                            modal-data="vm.modalData">
+        </dialog-editor-modal-field-template>
+      </div>
       <div ng-if="vm.modalData.dynamic">
         <dialog-editor-modal-field-template template="dynamic.html" modal-data="vm.modalData">
         </dialog-editor-modal-field-template>

--- a/src/dialog-editor/services/modal/modalService.ts
+++ b/src/dialog-editor/services/modal/modalService.ts
@@ -10,6 +10,7 @@ import {__} from '../../../common/translateFunction';
 class ModalController {
   public modalTab: string = 'element_information';
   public modalData: any;
+  public dynamicFieldList: any;
   public element: string;
   public categories: any;
   public dialog: any;
@@ -65,6 +66,16 @@ class ModalController {
       _.cloneDeep(elements[this.element]);
 
     if (this.element === 'field') {
+      this.modalData.dynamicFieldList = this.DialogEditor.getDynamicFields(this.modalData.id);
+
+      const dialogFieldResponderIds = _.map(this.modalData.dynamicFieldList, (field) => {
+        if (_.includes(this.modalData.dialog_field_responders, field['name'])) {
+          return field['id'];
+        }
+      });
+
+      this.modalData.dialog_field_responders = dialogFieldResponderIds;
+
       // load categories from API, if the field is Tag Control
       if (this.modalData.type === 'DialogFieldTagControl') {
         this.resolveCategories().then(


### PR DESCRIPTION
Note that users will no longer be able to turn on "auto refresh" or "auto refresh other fields when modified" after this PR, as the dialog field associations are going to end up handling that logic. The classic UI dialog editor will still retain these options for now.

This will require [this PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/2112) from the classic UI to ignore the list of dynamic dialog fields that is going to be passed through the API, as well as [this PR](https://github.com/ManageIQ/manageiq/pull/15937) from the main repo to actually build the associations from the IDs being passed in.

https://www.pivotaltracker.com/story/show/148013513

/cc @gmcculloug, @romanblanco 
@miq-bot add_label enhancement