### PR TITLE
Dialog Editor: Updated Styles

### DIFF
--- a/demo/controllers/dialogEditorController.ts
+++ b/demo/controllers/dialogEditorController.ts
@@ -6,10 +6,10 @@ export default class DialogEditorController {
     this.init({
       'content': [{
         'dialog_tabs': [{
-          'label': 'New tab',
+          'label': 'New Tab',
           'position': 0,
           'dialog_groups': [{
-            'label': 'New box',
+            'label': 'New Section',
             'position': 0,
             'dialog_fields': []
           }],

--- a/demo/views/dialog/editor.html
+++ b/demo/views/dialog/editor.html
@@ -1,17 +1,32 @@
 <div class="row">
-  <div class="col-md-6">
+  <div class="col-md-12">
     <h2>General</h2>
-    <label>Dialog's name</label>
-    <input title="Dialog editor name" pf-label="Name">
-    <dialog-editor-tabs></dialog-editor-tabs>
-    <dialog-editor-boxes></dialog-editor-boxes>
   </div>
-  <div class="col-md-6">
-    <label>Dialog's description</label>
-    <textarea ng-model="vm.dialog.content[0].description" title="Dialog editor description"></textarea>
-    <h2>Toolbox</h2>
-    <div class="draggable">
-      <dialog-editor-field-static></dialog-editor-field-static>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <form class="form-horizontal">
+      <div pf-form-group pf-label="Dialog's name">
+        <input title="Dialog editor name">
+      </div>
+      <div pf-form-group pf-label="Dialog's description">
+        <textarea ng-model="vm.dialog.content[0].description"
+                  title="Dialog editor description">
+        </textarea>
+      </div>
+    </form>
+  </div>
+</div>
+<div class="dialog-designer-container">
+  <div class="toolbox-container">
+    <div class="static-field-container" id="toolbox">
+      <div class="draggable">
+        <dialog-editor-field-static></dialog-editor-field-static>
+      </div>
+    </div>
+    <div class="editable-fields-container">
+      <dialog-editor-tabs></dialog-editor-tabs>
+      <dialog-editor-boxes></dialog-editor-boxes>
     </div>
   </div>
 </div>

--- a/src/dialog-editor/components/box/box.html
+++ b/src/dialog-editor/components/box/box.html
@@ -1,28 +1,29 @@
 <div class='dialog'>
-  <div style="background-color: #f1f1f1; padding: 20px;"
+  <div class="dialog-editor-container"
        ng-model='vm.dialogTabs[vm.service.activeTab].dialog_groups'
        ui-sortable='vm.sortableOptionsBox'
        ng-repeat='tab in vm.dialogTabs'
        ng-if='tab.position === vm.service.activeTab'>
     <!-- tab content -->
     <div ng-repeat='box in tab.dialog_groups track by $index'>
-      <div class="panel panel-default"
+      <div class="panel panel-default" ng-class="{'draggable-box': vm[highlightBox_+$index] === true}"
            data-drop='true'
            jqyoui-droppable='{multiple: true, onDrop: "vm.droppableOptions"}'
            ng-model='box.dialog_fields'>
-        <div class="panel-heading">
-          <i class="pficon-edit"
+           <div class="panel-heading"
+                ng-mouseenter="vm[highlightBox_+$index] = true" ng-mouseleave="vm[highlightBox_+$index] = false">
+                <strong style="padding-left: 8px;">{{ box.label }}</strong>
+                <button type="button" class="close hide show-on-hover"
+                  ng-click="vm.removeBox(box.position)">
+            <span aria-hidden="true">
+              <i class="fa header-fa fa-times"></i>
+            </span>
+          </button>
+          <i class="pf header-pf pficon-edit close hide show-on-hover"
              ng-click='vm.editDialogModal(
                vm.service.activeTab,
                box.position
-             )'></i>
-          <strong>{{ box.label }}</strong>
-          <button type="button" class="close"
-                  ng-click="vm.removeBox(box.position)">
-            <span aria-hidden="true">
-              <i class="fa fa-times"></i>
-            </span>
-          </button>
+            )'></i>
         </div>
         <div class="panel-body">
           <div ui-sortable='vm.sortableOptionsFields'
@@ -32,7 +33,7 @@
               <i class="fa fa-object-group"></i>
               {{ 'Drag your components here' | translate }}
             </div>
-            <div ng-repeat='field in box.dialog_fields'>
+            <div ng-repeat='field in box.dialog_fields' class="draggable-field">
               <form class="form-horizontal">
                 <dialog-editor-field box-position="box.position" field-data='field'></dialog-editor-field>
               </form>
@@ -44,15 +45,16 @@
     <div class="blank-slate-pf nosort"
          ng-if='tab.dialog_groups.length === 0'
          ng-click='vm.addBox()'>
-      <div class="blank-slate-pf-icon">
+      <div class="blank-slate-pf-icon" style="cursor: pointer;">
         <i class="fa fa-plus-circle"></i>
       </div>
-      <h1 translate>Start with adding a box</h1>
+      <h1 translate style="cursor: pointer;">Start with adding a section</h1>
     </div>
-    <div class="panel panel-default nosort">
+    <div class="add-section-box nosort">
       <a ng-click='vm.addBox()' translate>
-        <i class="pficon-add-circle-o"></i>&nbsp;Create Box
+        <i class="pficon-add-circle-o"></i>&nbsp;&nbsp;{{ 'Add Section' | translate }}
       </a>
     </div>
+    <div>&nbsp;</div>
   </div>
 </div>

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -65,7 +65,7 @@ class BoxController {
       .push(
         {
           description: __('Description'),
-          label: __('Label'),
+          label: __('New Section'),
           display: 'edit',
           position: 0,
           dialog_fields: [],

--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -76,15 +76,25 @@
     </select>
 
   </div>
-  <div class="col-sm-5">
-    <button type="button" class="close"
+  <div class="col-sm-5 editor-field-actions">
+    <button type="button" class="close hide"
+            ng-click="vm.removeField(
+              vm.service.activeTab,
+              vm.boxPosition,
+              vm.fieldData.position
+            )">
+            <span aria-hidden="true">
+              <i class="fa fa-times"></i>
+            </span>
+    </button>
+    <button type="button" class="close hide"
             ng-click="vm.editDialogModal(
               vm.service.activeTab,
               vm.boxPosition,
               vm.fieldData.position
             )">
       <span aria-hidden="true">
-        <i class="pficon-edit"></i>
+        <i class="pf pficon-edit"></i>
       </span>
     </button>
   </div>

--- a/src/dialog-editor/components/field/fieldComponent.ts
+++ b/src/dialog-editor/components/field/fieldComponent.ts
@@ -1,3 +1,5 @@
+import * as _ from 'lodash';
+
 /**
  * Controller for the Dialog Editor field component
  * @memberof miqStaticAssets
@@ -33,6 +35,25 @@ class FieldController {
    */
   public editDialogModal(tab: number, box: number, field: number) {
     this.DialogEditorModal.showModal(tab, box, field);
+  }
+
+  /**
+   * Remove Field
+   * @memberof FieldController
+   * @function remmoveField
+   * @param {number} tabId is an index of tab, where the box is placed
+   * @param {number} boxId is an index of box, where the field is placed
+   * @param {number} fieldId is an index of field
+   */
+  public removeField(tabId: number, boxId: number, fieldId: number) {
+    _.remove(
+      this.DialogEditor.getDialogTabs()[
+        tabId
+        ].dialog_groups[
+        boxId
+        ].dialog_fields,
+        (field: any) => field.position === fieldId
+    );
   }
 }
 

--- a/src/dialog-editor/components/tab-list/tab-list.html
+++ b/src/dialog-editor/components/tab-list/tab-list.html
@@ -4,13 +4,13 @@
     data-tabs='tabs'>
   <li ng-class='{active: tab.active}' ng-repeat='tab in vm.tabList'>
     <a class="select-tab" ng-click='vm.selectTab(tab.position)' data-toggle='tab'>
-      <i class="pficon-edit" ng-click='vm.editDialogModal(tab.position)'></i>
       {{ tab.label }}
-      <i class='delete-tab glyphicon glyphicon-remove' ng-click='vm.removeTab(tab.position)'></i>
+      <i class="pficon-edit tab-icon hide" ng-click='vm.editDialogModal(tab.position)'></i>
+      <i class='glyphicon glyphicon-remove tab-icon hide' ng-click='vm.removeTab(tab.position)'></i>
     </a>
   </li>
   <li class='nosort'>
-    <a ng-click='vm.addTab()'>
+    <a class="create-tab" ng-click='vm.addTab()'>
       <i class='pficon-add-circle-o'></i>
       &nbsp; {{ 'Create Tab' | translate }}
     </a>

--- a/src/dialog-editor/components/toolbox/toolbox.html
+++ b/src/dialog-editor/components/toolbox/toolbox.html
@@ -1,23 +1,11 @@
-<div class="container-fluid container-cards-pf">
-  <div class="row row-cards-pf">
-    <div class="col-xs-6 col-sm-4 col-md-4"
-         ng-repeat='dialogField in vm.fields'
-         data-drag="true"
-         jqyoui-draggable="{animate:true, placeholder: 'keep', deepCopy: true}"
-         data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
-         ng-model="dialogField.placeholders">
-      <div class="card-pf card-pf-aggregate-status">
-        <h2 class="card-pf-title">
-          {{dialogField.label}}
-        </h2>
-        <div class="card-pf-body">
-          <p class="card-pf-aggregate-status-notifications">
-            <span class="card-pf-aggregate-status-notification">
-              <i ng-class="dialogField.icon"></i>
-            </span>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div><!-- /row -->
-</div><!-- /container -->
+<ul class="static-field-list">
+  <li class="static-field-item"
+      ng-repeat='dialogField in vm.fields'
+      data-drag="true"
+      jqyoui-draggable="{animate:true, placeholder: 'keep', deepCopy: true}"
+      data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
+      ng-model="dialogField.placeholders">
+      <i class="static-field-icon {{dialogField.icon}}"></i>
+      <div>{{dialogField.label}}</div>
+  </li>
+</ul>

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -68,7 +68,7 @@ export class ToolboxController {
       new DialogField(
         'DialogFieldDropDownList',
         'fa fa-caret-square-o-down',
-        __('Dropdown List'),
+        __('Dropdown'),
         {
           data_type: 'string',
           values: [],
@@ -82,7 +82,7 @@ export class ToolboxController {
         __('Radio Button'),
         {
           data_type: 'string',
-          values: [],
+          values: [[1, 'One'], [2, 'Two'], [3, 'Three']],
           options: {sort_by: 'description', sort_order: 'ascending'},
         }
       ),
@@ -90,13 +90,13 @@ export class ToolboxController {
       new DialogField(
         'DialogFieldDateControl',
         'fa fa-calendar',
-        __('Date Control')
+        __('Datepicker')
       ),
     dialogFieldDateTimeControl:
       new DialogField(
         'DialogFieldDateTimeControl',
         'fa fa-clock-o',
-        __('Date Time Control')
+        __('Timepicker')
       ),
     dialogFieldTagControl:
       new DialogField(

--- a/src/dialog-editor/services/modal/modal.html
+++ b/src/dialog-editor/services/modal/modal.html
@@ -2,7 +2,7 @@
   <button type="button" class="close" ng-click="$dismiss()" aria-hidden="true">
     <span class="pficon pficon-close"></span>
   </button>
-  <h4 class="modal-title" id="myModalLabel" translate>Edit Dialog field</h4>
+  <h4 class="modal-title" id="myModalLabel" translate>{{vm.modalTitle}}</h4>
 </div>
 
 <div class="modal-body">
@@ -111,9 +111,6 @@
 </div>
 
 <div class="modal-footer">
-  <button class="btn btn-danger"
-          type="button"
-          ng-click="vm.deleteField()" translate>Delete</button>
   <button type="button" class="btn btn-default" ng-click="$dismiss()" translate>Cancel</button>
   <button type="button"
           class="btn btn-primary"

--- a/src/dialog-editor/services/modal/modalService.ts
+++ b/src/dialog-editor/services/modal/modalService.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import * as ng from 'angular';
+import {__} from '../../../common/translateFunction';
 
 /**
  * Controller for the Dialog Editor modal service
@@ -12,6 +13,7 @@ class ModalController {
   public element: string;
   public categories: any;
   public dialog: any;
+  public modalTitle: string;
 
   /*@ngInject*/
   constructor(private dialogDetails: any,
@@ -35,9 +37,11 @@ class ModalController {
      && ng.isUndefined(this.dialog.boxId)
      && ng.isDefined(this.dialog.tabId)) {
       this.element = 'tab';
+      this.modalTitle = __('Edit Tab Details');
     } else if (ng.isUndefined(this.dialog.fieldId)
             && ng.isDefined(this.dialog.boxId)
             && ng.isDefined(this.dialog.tabId)) {
+      this.modalTitle = __('Edit Section Details');
       this.element = 'box';
     } else if (ng.isDefined(this.dialog.fieldId)
             && ng.isDefined(this.dialog.boxId)
@@ -80,6 +84,40 @@ class ModalController {
               this.categories = categories;
             }
           );
+        }
+        // set modal title
+        if (!this.modalData.dynamic) {
+          var titleLabel;
+
+          switch (this.modalData.type) {
+            case 'DialogFieldTextBox':
+              titleLabel = __('Text Box');
+              break;
+            case 'DialogFieldTextAreaBox':
+              titleLabel = __('Text Area');
+              break;
+            case 'DialogFieldCheckBox':
+              titleLabel = __('Check Box');
+              break;
+            case 'DialogFieldDropDownList':
+              titleLabel = __('Dropdown');
+              break;
+            case 'DialogFieldRadioButton':
+              titleLabel = __('Radio Button');
+              break;
+            case 'DialogFieldDateControl':
+              titleLabel = __('Datepicker');
+              break;
+            case 'DialogFieldDateTimeControl':
+              titleLabel = __('Timepicker');
+              break;
+            case 'DialogFieldTagControl':
+              titleLabel = __('Tag Control');
+              break;
+          }
+          this.modalTitle =  __('Edit ') + titleLabel +  __(' Field');
+        } else {
+          this.modalTitle = this.modalTitle = __('Edit Field');
         }
         break;
       default:

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,0 +1,95 @@
+// Styleguide:
+// - Prefix names with color-
+// - Name the variable as the color it represents, not its intended function
+// - If the color includes an alpha channel suffix with -xx
+// - If the color is an approximate match suffix with -approx
+//  - Do not suffix '-solid' for exact matches
+// - If the color already exists with -approx modifier, append a count -x starting at 2
+// - Use only hyphens and lowercase characters
+//
+// Examples
+// $color-blue: #0000ff
+// $color-governor-bay-approx: #3B4CC4
+// $color-governor-bay-approx-2: #3B4AC5
+// $color-white-70: rgba(255, 255, 255, 0.7)
+// $color-cerulean-45-approx: rgba(0, 173, 239, 0.45)
+//
+// Use a tool such as : http://name-of-color.com/ to find the name of your color
+
+// Grays
+$color-white: #fff;
+$color-off-white: #ddd;
+$color-black-haze-approx: #f4f7f8;
+$color-white-smoke: #f5f5f5;
+$color-gallery-approx: #eee;
+$color-cararra-approx: #ebebeb;
+$color-light-gray-approx: #d1d1d1;
+$color-gray-nurse-approx: #e9e8e8;
+$color-gray: #808080;
+$color-gray-1: #b1b1b1;
+$color-gray-2: #8b8d8f;
+$color-bombay-approx: #b1b3b6;
+$color-concrete-solid: #f2f2f2;
+$color-mountain-mist-approx: #939598;
+$color-abbey-approx: #4c4f56;
+$color-medium-gray-3: #666;
+$color-white-94: rgba(255, 255, 255, 0.94);
+
+$color-cape-cod-approx: #414042;
+$color-mine-shaft-approx: #333;
+$color-black: #000;
+$color-black-1: rgba(3, 3, 3, 1);
+$color-black-20: rgba(0, 0, 0, 0.2);
+$color-black-30: rgba(0, 0, 0, 0.3);
+$color-dark-gray-75: rgba($color-cape-cod-approx, 0.75);
+
+// Reds
+$color-red: #f00;
+$color-radical-red-approx: #f13b54;
+$color-froly-approx: #f1757b;
+$color-coral-approx: #f88954;
+$color-misty-rose-approx: #fbe7e7;
+$color-lava-approx: #cc151d;
+$color-boston-university-red: #c00;
+$color-serenade-approx: #fdf4ea;
+$color-cadmium-orange-approx: #eb822b;
+$color-tahiti-gold-approx: #ec7a08;
+
+// Greens
+$color-green: #0f0;
+$color-green-1: #008000;
+$color-green-crayola-approx: #23a27e;
+$color-dark-green-1: #3c763d;
+$color-mountain-meadow-approx: #1dc58e;
+$color-frostee-approx: #e8f9e6;
+$color-apple-approx: #4da146;
+
+// Blues
+$color-blue: #00f;
+$color-ebony-clay-approx: #2b2e3e;
+$color-martinique-approx: #33394d;
+$color-gun-power-approx: #3d445c;
+$color-storm-gray-approx: #6e7385;
+$color-blue-de-france-approx: #3397db;
+$color-picton-blue-approx: #44bde6;
+$color-light-blue: #0099d3;
+$color-lochmara-approx: #0088ce;
+$color-medium-blue-3: #0d6f9a;
+$color-pale-cerulean-approx: #95c3e3;
+$color-polar-approx: #e2f5f6;
+$color-deep-ocean-approx: #1c3753;
+$color-tarawera-approx: #063451;
+$color-blue-50: #def3ff;
+$color-blue-300: #39a5dc;
+$color-pattens-blue-approx: #e3f4fd;
+$color-spindle-approx: #b3d3e7;
+$color-onahau-approx: #d4edfa;
+
+// Purples
+$color-prelude-approx: #cebee1;
+$color-lavender-purple-approx: #9f7fc3;
+$color-royal-purple-approx: #6d3ba4;
+$color-kingfisher-daisy-approx: #3b0083;
+$color-paua-approx: #2d0064;
+$color-tolopea-approx: #1e0042;
+$color-black-russian-approx: #0f0021;

--- a/src/styles/dialog-editor-boxes.scss
+++ b/src/styles/dialog-editor-boxes.scss
@@ -1,0 +1,135 @@
+.dialog-editor-container {
+  background-color: #fff;
+  padding: 20px;
+  margin-bottom: 10px;
+}
+
+.draggable-box {
+  background-color: $color-white-94;
+  border-radius: 1px;
+  cursor: pointer;
+  margin-right: 16px;
+  margin-top: 10px;
+  height: 100%;
+  width: 100%;
+  position: relative;
+
+  &.selected {
+    border: 3px solid $color-blue-300;
+  }
+
+  &:hover {
+    border: 1px solid $color-gray-1;
+    box-shadow: 0 2px 6px $color-black-20;
+
+    .header-fa {
+      float: right;
+      font-size: 22px;
+    }
+
+    &.selected {
+      border: 3px solid $color-blue-300;
+    }
+
+    .header-pf {
+      float: right;
+      font-size: 16px;
+      padding-top: 3px;
+      padding-right: 8px;
+    }
+
+    .show-on-hover {
+      display: initial !important;
+    }
+
+    &::before {
+      background-image: linear-gradient(to bottom, $color-lochmara-approx 60%, $color-white 0%);
+      background-position: left;
+      background-repeat: repeat-y;
+      background-size: 2px 5px;
+      border: 4px solid $color-lochmara-approx;
+      bottom: 4px;
+      content: "";
+      left: 4px;
+      position: absolute;
+      top: 3px;
+      width: 10px;
+    }
+  }
+
+  &:first-child {
+    margin-top: 0px;
+  }
+}
+
+.draggable-field {
+  background-color: $color-white-94;
+  border-radius: 1px;
+  cursor: pointer;
+  margin-right: 16px;
+  margin-top: 10px;
+  width: 100%;
+  padding-top: 9px;
+  padding-left: 20px;
+  padding-right: 8px;
+  padding-bottom: 2px;
+  position: relative;
+  z-index: 600;
+
+  &.selected {
+    border: 3px solid $color-blue-300;
+  }
+
+  &:hover {
+    border: 1px solid $color-gray-1;
+    box-shadow: 0 2px 6px $color-black-20;
+
+    &.selected {
+      border: 3px solid $color-blue-300;
+    }
+
+    button {
+      display: inherit !important;
+      position: relative;
+      top: 4px;
+    }
+
+    &::before {
+      background-image: linear-gradient(to bottom, $color-lochmara-approx 60%, $color-white 0%);
+      background-position: left;
+      background-repeat: repeat-y;
+      background-size: 2px 5px;
+      border: 4px solid $color-lochmara-approx;
+      bottom: 4px;
+      content: "";
+      left: 4px;
+      position: absolute;
+      top: 3px;
+      width: 10px;
+    }
+  }
+
+  &:first-child {
+    margin-top: 0px;
+  }
+
+  img {
+    height: 100%;
+    margin-right: 8px;
+    object-fit: contain;
+  }
+}
+
+.add-section-box {
+  cursor: pointer;
+  height: 45px;
+  width: 100%;
+  padding-left: 10px;
+  padding-top: 10px;
+  border: 2px dashed $color-gray-1;
+  margin-bottom: 26px;
+
+  a {
+    cursor: pointer;
+  }
+}

--- a/src/styles/dialog-editor-toolbox.scss
+++ b/src/styles/dialog-editor-toolbox.scss
@@ -1,0 +1,69 @@
+.static-field-container {
+  background-color: $color-white-94;
+  border: 1.5px solid $color-light-gray-approx;
+  box-shadow: 0 2px 6px $color-black-30;
+  position: absolute;
+
+  .static-field-icon {
+    font-size: 28px;
+    padding-top: 6px;
+    vertical-align: middle;
+  }
+
+  .static-field-list {
+    list-style: none;
+    width: 107px;
+    overflow-y: auto;
+    margin-bottom: 0px;
+    padding-left: 0;
+  }
+
+  .static-field-item {
+    background-color: $color-white-94;
+    border-bottom: 1px solid $color-gray-1;
+    border-radius: 1px;
+    cursor: pointer;
+    height: 70px;
+    width: 100%;
+    position: relative;
+    text-align: center;
+    vertical-align: middle;
+    z-index: 600;
+
+    &:hover {
+      border: 1px solid $color-gray-1;
+      box-shadow: 0 2px 6px $color-black-20;
+
+      &::before {
+        background-image: linear-gradient(to bottom, $color-lochmara-approx 60%, $color-white 0%);
+        background-position: left;
+        background-repeat: repeat-y;
+        background-size: 2px 5px;
+        border: 4px solid $color-lochmara-approx;
+        bottom: 4px;
+        content: "";
+        left: 4px;
+        position: absolute;
+        top: 3px;
+        width: 10px;
+      }
+    }
+
+    .fa {
+      font-size: 26px;
+      margin-top: 6px;
+      vertical-align: middle;
+    }
+
+    span {
+      position: relative;
+      top: 4px;
+    }
+
+    img {
+      height: 100%;
+      margin-right: 8px;
+      object-fit: contain;
+    }
+  }
+}

--- a/src/styles/dialog-editor.scss
+++ b/src/styles/dialog-editor.scss
@@ -1,0 +1,61 @@
+.dialog-designer-container {
+  background-color: #f1f1f1;
+  height: 100%;
+  width: 100%;
+
+  .toolbox-container {
+    height: 100%;
+    position: relative;
+    width: 100%;
+
+    .editable-fields-container {
+      padding-top: 10px;
+      padding-left: 120px;
+      width: 80%;
+    }
+
+    a {
+      color: #000;
+    }
+  }
+}
+
+.create-tab {
+  cursor: pointer !important;
+}
+
+.select-tab {
+  cursor: pointer !important;
+
+  &:hover {
+    i {
+      display: initial !important;
+    }
+  }
+}
+
+.tab-icon {
+  opacity: .6;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.pficon-edit.tab-icon {
+  padding-left: 6px;
+}
+
+.editor-field-actions {
+  .fa {
+    float: right;
+    font-size: 22px;
+  }
+
+  .pf {
+    float: right;
+    font-size: 16px;
+    padding-top: 3px;
+    padding-right: 8px;
+  }
+}

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -1,3 +1,8 @@
+@import 'colors';
+@import 'dialog-editor';
+@import 'dialog-editor-toolbox';
+@import 'dialog-editor-boxes';
+
 .miq-sand-paper, .miq-sand-paper > div { /* emulates "cards-pf" background color */
   background: #f5f5f5;
   overflow: hidden;
@@ -383,7 +388,7 @@ miq-fonticon-picker {
 .miq-dialog {
   .has-error {
     color: red;
-    
+
     .form-control {
       border-color: red;
     }


### PR DESCRIPTION
Updated the Dialog Editor:

- Updated layout:  
    - Dialog Name and Description as horizontal form 
    - Toolbox on left, Tabs/Sections/Fields on right. 
![image](https://user-images.githubusercontent.com/12733153/29943597-160e3db4-8e68-11e7-92a0-d9477f5a624f.png)
- Added grab handles to toolbox items, boxes/sections, and fields/elements (appear on hover):
Toolbox Item:
![image](https://user-images.githubusercontent.com/12733153/29943162-6a2fa420-8e66-11e7-8cc3-c7271afccd35.png)
Section:
![image](https://user-images.githubusercontent.com/12733153/29943189-8d558276-8e66-11e7-82a0-5905cb6923a5.png)
Field:
![image](https://user-images.githubusercontent.com/12733153/29943205-9fbe7c06-8e66-11e7-8b9d-361da74e4f82.png)
- Added edit/pencil and remove/trashcan icons to Tabs, Sections, and Fields (appear on hover):
![image](https://user-images.githubusercontent.com/12733153/29943252-d82a0cf4-8e66-11e7-8260-2823cd89ca8f.png)
![image](https://user-images.githubusercontent.com/12733153/29943267-e8463270-8e66-11e7-97a3-40b7522a68bf.png)
![image](https://user-images.githubusercontent.com/12733153/29943278-f74444b0-8e66-11e7-82f0-546283252c3a.png)
- Details Modal:
    - Added component specific modal Titles Ex: "Edit Textarea Field" and "Edit Tab Details"
    - Removed Delete button
- Replaced "box" terminology with "section"

Pivotal: https://www.pivotaltracker.com/n/projects/1613907/stories/150461077
@romanblanco 
@serenamarie125 
