### PR TITLE
Cleaned up TreeSelector component to be more similar to TreeView

### DIFF
--- a/demo/controllers/treeSelectorController.ts
+++ b/demo/controllers/treeSelectorController.ts
@@ -1,30 +1,25 @@
 import * as ng from 'angular';
 
-const URL = '/data/lazyTree.json';
-
 export default class TreeSelectorController {
+  public display = false;
+  public node;
   public data = require('../data/tree.json');
-  public showTree;
-  public selectedValue = 'No node selected';
-  public selectables = {
-      key: '(^gc-)|(^lc-)',
-  };
 
   /*@ngInject*/
-  constructor(private $http) {}
+  constructor(private $timeout : ng.ITimeoutService) {}
 
-  public handleSelected = (node) => {
-    this.selectedValue = node.text;
+  public toggleTree() {
+    this.display = !this.display;
+  };
+
+  public nodeSelect(node) {
+    this.node = node;
+    this.display = false;
   }
 
-  public openTreeView = (open: boolean) => {
-    this.showTree = open;
-  }
-
-  public getData = (node?) => {
-    return this.$http({
-      method: 'GET',
-      url: node ? `${URL}?id=${encodeURIComponent(node.key)}` : URL,
-    }).then(response => response.data);
+  public lazyLoad(node) {
+    let data = require('../data/lazyTree.json');
+    // Wait to simulate HTTP delay
+    return new Promise(resolve => this.$timeout(() => resolve(data), 1500));
   }
 }

--- a/demo/views/tree-view/tree-selector.html
+++ b/demo/views/tree-view/tree-selector.html
@@ -1,12 +1,18 @@
-<h2>Selected node: <label>{{vm.selectedValue}}</label></h2>
-<button ng-click="vm.openTreeView(!vm.showTree)">Toggle tree</button>
-<miq-tree-selector
-  ng-show="vm.showTree"
-  name="tree-selector"
-  data="vm.data"
-  selectables="vm.selectables"
-  display="vm.openTreeView(open)"
-  on-select="vm.handleSelected(node)"
-  lazy-load="vm.getData"
-  >
-</miq-tree-selector>
+<div class="col-sm-4">
+  <div class="input-group">
+    <input type="text" class="form-control" ng-value="vm.node.key" disabled>
+    <span class="input-group-btn">
+      <button class="btn btn-default" ng-click="vm.toggleTree();"><i class="ff ff-load-balancer"></i></button>
+    </span>
+  </div>
+</div>
+<div class="col-sm-4" ng-show="vm.display">
+  <miq-tree-selector
+    name="tree-selector"
+    data="vm.data"
+    selectable="{ key: '(^gc-)|(^lc-)' }"
+    on-select="vm.nodeSelect(node)"
+    lazy-load="vm.lazyLoad(node)"
+    >
+  </miq-tree-selector>
+</div>

--- a/src/tree-selector/treeSelector.html
+++ b/src/tree-selector/treeSelector.html
@@ -1,8 +1,9 @@
 <miq-tree-view
-  ng-if="$ctrl.data"
-  name="vm.name"
+  name="{{ $ctrl.name }}"
+  data="$ctrl.parsedData"
+  selected="$ctrl.selected"
   reselect="true"
-  data="$ctrl.data"
+  on-select="$ctrl.onSelect({node: node})"
   lazy-load="$ctrl.handleLazyLoad({node: node})"
-  on-select="$ctrl.handleSelect({node: node})">
+  >
 </miq-tree-view>

--- a/src/tree-selector/treeSelectorComponent.ts
+++ b/src/tree-selector/treeSelectorComponent.ts
@@ -1,36 +1,34 @@
 import * as ng from 'angular';
 
 export class TreeSelectorController {
-  public data: any;
-  public selectables: any;
-  public display: any;
-  public onSelect: any;
-  public lazyLoad: any;
   public name: string;
+  public data: any;
+  public selected: any;
+  public selectable: any;
+  public onSelect: Function;
+  public lazyLoad: Function;
 
-  /*@ngInject*/
-  constructor(private $http, private $timeout : ng.ITimeoutService) {
+  public parsedData: any;
+  private rendered = false;
+
+  public $onChanges(changes) {
+    // Render the tree after the data has been sent for the first time
+    if (changes.data && !this.rendered && changes.data.currentValue !== undefined) {
+      this.parsedData = this.parseSelectable(this.data);
+      this.rendered = true;
+    }
   }
 
-  public $onInit() {
-    this.data = this.parseSelectable(this.data);
+  public handleLazyLoad(node) {
+    return this.lazyLoad(node).then(data => this.parseSelectable(data));
   }
 
-  public matchSelectable(node) {
-    return Object.keys(this.selectables).map((key) =>
-      !!node[key].match(this.selectables[key])
-    ).every(bool => bool);
+  private matchSelectable(node) {
+    return Object.keys(this.selectable).every(key => !!node[key].match(this.selectable[key]));
   }
 
-  public handleLazyLoad = (node) => {
-    const dataPromise = this.lazyLoad(node);
-    return dataPromise().then((data) => {
-      return this.parseSelectable(data);
-    });
-  }
-
-  public parseSelectable = (data: any) => {
-    return data.map((node, key) => {
+  private parseSelectable(data) {
+    return data.map(node => {
       const parsedData = {...node};
       if(parsedData.nodes) {
         parsedData.nodes = this.parseSelectable(parsedData.nodes);
@@ -39,21 +37,16 @@ export class TreeSelectorController {
       return parsedData;
     });
   }
-
-  public handleSelect = (data) => {
-    this.onSelect({node: data.node});
-    this.display({open: false});
-  }
 }
 
 export default class TreeSelector implements ng.IComponentOptions {
   public controller = TreeSelectorController;
   public template = require('./treeSelector.html');
   public bindings: any = {
-    data: '<',
     name: '@',
-    selectables: '<',
-    display: '&',
+    data: '<',
+    selected: '<',
+    selectable: '<',
     onSelect: '&',
     lazyLoad: '&'
   };


### PR DESCRIPTION
I wanted to use the `TreeSelector` for catalog entry point selection in MiQ, but I realized that it's unusable. Here are some fixes:
* Handling the visibility of the tree moved out from the component
* Added support for data loaded after the component initialization
* Refactored the `matchSelectable` and `parseSelectable` functions
* Passing the `onSelect` method directly to the TreeView component
* Renamed `selectables` attribute to `selectable`
* Added the possibility to initially select a node using the `selected` attribute
* Reorganized public and private variables
* Created a more straightforward demo

@Hyperkid123 please take a look at this and try to understand the concept.
@himdel please review.