### PR TITLE
Allow reloading the TreeView if its data has been changed

### DIFF
--- a/demo/controllers/treeViewController.ts
+++ b/demo/controllers/treeViewController.ts
@@ -33,6 +33,10 @@ export default class TreeViewController {
     return new Promise(resolve => this.$timeout(() => resolve(data), 1500));
   }
 
+  public reloadData() {
+    this.data = require('../data/lazyTree.json');
+  }
+
   public nodeSelect(node) {
     // Drop some attributes to keep the output short
     delete node.$el;

--- a/demo/views/tree-view/basic.html
+++ b/demo/views/tree-view/basic.html
@@ -1,6 +1,7 @@
 <button ng-click="vm.resetState();">Reset</button>
 <button ng-click="vm.selectRandom();">Select random</button>
 <button ng-click="vm.selectLazy();">Select lazy</button>
+<button ng-click="vm.reloadData();">Reload data</button>
 <p>Note: programmatically selecting a node is not firing the onSelect event on purpose.</p>
 
 <miq-tree-view name="demo-tree" data="vm.data" lazy-load="vm.lazyLoad(node)" on-select="vm.nodeSelect(node)" selected="vm.selectNode"></miq-tree-view>

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -3,7 +3,7 @@ import * as ng from 'angular';
 export class TreeViewController {
   private tree;
   private element;
-  private rendered : boolean = false;
+  private rendered : boolean;
 
   public name : string;
   public data;
@@ -16,8 +16,9 @@ export class TreeViewController {
   constructor(private $element : ng.IRootElementService, private $timeout : ng.ITimeoutService) {}
 
   public $onChanges(changes) {
-    // Render the tree after the data has been sent for the first time
-    if (changes.data && !this.rendered && changes.data.currentValue !== undefined) {
+    // Render the tree after the data has attribute been altered
+    // WARNING: Do not use this for lazy-loading!
+    if (changes.data && changes.data.currentValue !== undefined) {
       this.renderTree();
     }
 
@@ -32,9 +33,11 @@ export class TreeViewController {
    *
    * This function searches for the `<div class='treeview'>` element in the
    * template and renders the treeview into it with the `data` attribute of
-   * the component.
+   * the component. The function clears any elements from the container div
+   * and so the function can be used for re-rendering the tree if necessary.
    */
   private renderTree() {
+    this.rendered = false;
     this.element = ng.element(this.$element[0].querySelector('div.treeview'));
     this.element.empty();
 

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -36,6 +36,7 @@ export class TreeViewController {
    */
   private renderTree() {
     this.element = ng.element(this.$element[0].querySelector('div.treeview'));
+    this.element.empty();
 
     new Promise((resolve) => {
       this.element.treeview({

--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -18,7 +18,6 @@ export class TreeViewController {
   public $onChanges(changes) {
     // Render the tree after the data has been sent for the first time
     if (changes.data && !this.rendered && changes.data.currentValue !== undefined) {
-      this.element = ng.element(this.$element[0].querySelector('div.treeview'));
       this.renderTree();
     }
 
@@ -28,7 +27,16 @@ export class TreeViewController {
     }
   }
 
+  /*
+   * @function renderTree
+   *
+   * This function searches for the `<div class='treeview'>` element in the
+   * template and renders the treeview into it with the `data` attribute of
+   * the component.
+   */
   private renderTree() {
+    this.element = ng.element(this.$element[0].querySelector('div.treeview'));
+
     new Promise((resolve) => {
       this.element.treeview({
         data:            this.data,


### PR DESCRIPTION
I thought we can avoid having this feature, but it seems like we're re-rendering the trees sometimes.