### PR TITLE
Toolbar list - make dropDownClass optional, rename to dropdownClass

### DIFF
--- a/demo/controllers/dataTableController.ts
+++ b/demo/controllers/dataTableController.ts
@@ -38,7 +38,7 @@ export default class DataTableController {
       this.settings.selectAllTitle = 'select all';
       this.settings.sortedByTitle = 'sorted by';
       this.settings.perPageTitle = 'per page';
-      this.settings.dropDownClass = ['someClass'];
+      this.settings.dropdownClass = ['someClass'];
     });
   }
 

--- a/src/common/components/sortItemsComponent.spec.ts
+++ b/src/common/components/sortItemsComponent.spec.ts
@@ -19,7 +19,7 @@ describe('Sort items test', () =>  {
         onSort: onSort,
         headers: headers,
         sortObject: sortObject,
-        dropDownClass: ['someClass']
+        dropdownClass: ['someClass']
       };
       angular.mock.module('miqStaticAssets.common');
       angular.mock.inject(($componentController) => {

--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -10,7 +10,7 @@ export class SortItemsController {
   public headers: any;
   public options: any;
   public sortObject: any;
-  public dropDownClass: any[];
+  public dropdownClass: any[];
   public onSort: (args: {sortObject: any, isAscending: boolean}) => void;
 
   /* @ngInject */
@@ -31,7 +31,7 @@ export class SortItemsController {
         this.setSortItem();
       }
     }
-    if (changesObj.dropDownClass) {
+    if (changesObj.dropdownClass) {
       this.applyClass();
     }
   }
@@ -93,13 +93,13 @@ export class SortItemsController {
 
   /**
    * Method for applying additional class for dropdown.
-   * dropDownClass can be either string of classes, or array.
+   * dropdownClass can be either string of classes, or array.
    */
   private applyClass() {
-    if (this.dropDownClass) {
-      Array.isArray(this.dropDownClass) ?
-        this.$element.find('.uib-dropdown').addClass(...this.dropDownClass) :
-        this.$element.find('.uib-dropdown').addClass(this.dropDownClass);
+    if (this.dropdownClass) {
+      Array.isArray(this.dropdownClass) ?
+        this.$element.find('.uib-dropdown').addClass(...this.dropdownClass) :
+        this.$element.find('.uib-dropdown').addClass(this.dropdownClass);
     }
   }
 }
@@ -138,6 +138,6 @@ export default class SortItems implements ng.IComponentOptions {
     onSort: '&',
     headers: '<',
     sortObject: '<',
-    dropDownClass: '<'
+    dropdownClass: '<'
   };
 }

--- a/src/gtl/components/pagination/pagination.html
+++ b/src/gtl/components/pagination/pagination.html
@@ -17,7 +17,7 @@
       <miq-sort-items ng-if="paginationCtrl.settings.sortBy"
                     sort-object="paginationCtrl.settings.sortBy"
                     headers="paginationCtrl.settings.columns"
-                    drop-down-class="paginationCtrl.settings.dropDownClass"
+                    dropdown-class="paginationCtrl.settings.dropdownClass"
                     on-sort="paginationCtrl.onChangeSort({sortId: sortObject.colId, isAscending: isAscending})">
       </miq-sort-items>
       <!-- Sort items by end -->
@@ -27,7 +27,7 @@
   <div class="form-group">
     <!-- Per page start -->
      <miq-toolbar-list on-item-click="paginationCtrl.onChangePerPage({item: item})"
-                    drop-down-class="paginationCtrl.settings.dropDownClass"
+                    dropdown-class="paginationCtrl.settings.dropdownClass"
                     toolbar-list="paginationCtrl.perPage"></miq-toolbar-list>
     <!-- Per page end -->
     <!-- Number of records start -->

--- a/src/gtl/components/pagination/paginationComponent.spec.ts
+++ b/src/gtl/components/pagination/paginationComponent.spec.ts
@@ -31,7 +31,7 @@ describe('Pagination test', () =>  {
         },
         'selectAllTitle': 'Select All',
         'sortedByTitle': 'Sorted By',
-        'dropDownClass': ['someClass'],
+        'dropdownClass': ['someClass'],
         'columns': [{'is_narrow': true}, {'is_narrow': true}, {
           'text': 'Messaging Name',
           'sort': 'str',

--- a/src/gtl/interfaces/dataTable.ts
+++ b/src/gtl/interfaces/dataTable.ts
@@ -27,7 +27,7 @@ export interface ITableSettings {
   sortBy: ITableSortBy;
   paging: ITablePaging;
   columns?: any;
-  dropDownClass?: any[];
+  dropdownClass?: any[];
   startIndex?: number;
   endIndex?: number;
   hideSelect?: boolean;

--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -1,4 +1,4 @@
-<div class="btn-group" ng-class="vm.dropDownClass" uib-dropdown ng-if="vm.isEmpty">
+<div class="btn-group" ng-class="vm.dropdownClass" uib-dropdown ng-if="vm.isEmpty">
   <button type="button" uib-dropdown-toggle class="btn uib-dropdown-toggle btn-default"
           ng-class="{disabled: !vm.toolbarList.enabled}" title="{{vm.toolbarList.title}}">
     <i class="{{vm.toolbarList.icon}}"

--- a/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
@@ -81,6 +81,6 @@ export default class ToolbarList {
   public bindings: any = {
     toolbarList: '<',
     onItemClick: '&',
-    dropDownClass: '<'
+    dropDownClass: '<?'
   };
 }

--- a/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
@@ -6,7 +6,7 @@ import {IToolbarItem} from '../../interfaces/toolbar';
  */
 export interface IToolbarListBindings {
   toolbarList: any;
-  dropDownClass: any[];
+  dropdownClass: any[];
   onItemClick: (args: {item: any}) => void;
 }
 
@@ -19,7 +19,7 @@ export interface IToolbarListBindings {
 export class ToolbarListController implements IToolbarListBindings {
   public toolbarList: IToolbarItem;
   public isEmpty: boolean = false;
-  public dropDownClass: any[];
+  public dropdownClass: any[];
 
   /**
    * Method for handling clicking on toolbar list's item.
@@ -81,6 +81,6 @@ export default class ToolbarList {
   public bindings: any = {
     toolbarList: '<',
     onItemClick: '&',
-    dropDownClass: '<?'
+    dropdownClass: '<?'
   };
 }


### PR DESCRIPTION
`dropDownClass` (and `drop-down-class`) look like a typo, renaming to `dropdownClass` and `dropdown-class`.

Also making `dropdownClass` optional, since we always check before using, and don't always pass it in.

Cc @karelhala 