### PR TITLE
tileView - fix columns to actually be available inside the card

### DIFF
--- a/src/gtl/components/tile-view/tileViewComponent.ts
+++ b/src/gtl/components/tile-view/tileViewComponent.ts
@@ -82,6 +82,10 @@ export class TileViewController extends DataViewClass implements IDataTableBindi
       this.options.showSelectBox = !this.settings.hideSelect;
     }
 
+    if (changesObj.columns) {
+      this.options.columns = this.columns;
+    }
+
     this.setPagingNumbers();
   }
 

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -131,6 +131,7 @@ table.miq-table-with-footer { /* not currently used */
       dl.dl-horizontal.tile {
         dt {
           margin-left: 10px;
+          width: 100px;
         }
         dd {
           margin-left: 120px;


### PR DESCRIPTION
the card could not access `tileCtrl.columns` because it has access only to the `pf-card-view` `config` object.

Adding `columns` to the config object so that it is available.

Also fixed the spacing a bit - there was no visual space between `dt` and `dl` (**Foo**:bar)

Cc @karelhala 


Infra provider - fine & now:

![provider-infra](https://user-images.githubusercontent.com/289743/30114450-5f57eabc-9307-11e7-82b1-e32f3829d62c.png)

![fix-provider-infra](https://user-images.githubusercontent.com/289743/30114463-63e01834-9307-11e7-9e6c-b1e06433d2c2.png)



https://bugzilla.redhat.com/show_bug.cgi?id=1486702