### PR TITLE
Changed background color in the Dialog Editor

### DIFF
--- a/src/styles/dialog-editor.scss
+++ b/src/styles/dialog-editor.scss
@@ -1,5 +1,5 @@
 .dialog-designer-container {
-  background-color: #f1f1f1;
+  background-color: #ffffff;
   height: 100%;
   width: 100%;
 


### PR DESCRIPTION
The gray background looked strange in the editor, trying white colour

Before:
![screenshot-2017-9-7 manageiq automation](https://user-images.githubusercontent.com/1187051/30168286-3b5defca-93e9-11e7-945d-c3043652c25f.png)

After:
![screenshot-2017-9-7 manageiq automation 1](https://user-images.githubusercontent.com/1187051/30168294-41beb8a4-93e9-11e7-9ab8-45d1d00f2810.png)

@dtaylor113 what you think?