### PR TITLE
When any warning happens in tslint, throw error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,13 @@ module.exports = {
   devtool: !production && 'source-map',
   module: {
     rules: [
-      {enforce: 'pre', test: /\.ts?$/, loader: 'tslint-loader', exclude: /(node_modules|libs)/},
+      {
+        enforce: 'pre',
+        test: /\.ts?$/,
+        loader: 'tslint-loader',
+        exclude: /(node_modules|libs)/,
+        options: {emitErrors: true}
+      },
       {test: /\.ts$/, loaders: ['ts-loader'], exclude: /(node_modules|libs)/},
       {test: /\.html$/, loader: 'raw-loader', exclude: /(node_modules|libs|dist|tsd)/},
       // stylesheets


### PR DESCRIPTION
As @skateman talked with me, it would be good to throw error whenever there is warning in tslint, so we force people to obey rules much thoroughly. However emit file anyways so we can fix these things later on (while on `npm start`/`yarn start`), build on the other hand will fail so travis will complain about these errors as @himdel proposed.