### PR TITLE
Add modalDat when dynamic is set to true in modal

### DIFF
--- a/src/dialog-editor/services/modal/modal.html
+++ b/src/dialog-editor/services/modal/modal.html
@@ -91,7 +91,7 @@
         </dialog-editor-modal-field-template>
       </div>
       <div ng-if="vm.modalData.dynamic">
-        <dialog-editor-modal-field-template template="dynamic.html">
+        <dialog-editor-modal-field-template template="dynamic.html" modal-data="vm.modalData">
         </dialog-editor-modal-field-template>
       </div>
     </form>


### PR DESCRIPTION
### FIxes https://github.com/ManageIQ/manageiq-ui-classic/issues/2174
This should solve issue with setting dynamic to true. Proiblem was, that the data was not passed to modal dialog-editor-modal-field-template.

@eclarizio @romanblanco @h-kataria 