### PR TITLE
Remove CSS rule to hide help icon in dialog fields

### DIFF
--- a/demo/data/dialog-data.json
+++ b/demo/data/dialog-data.json
@@ -100,6 +100,7 @@
                       "created_at": "2017-06-16T19:29:28Z",
                       "updated_at": "2017-06-16T19:29:28Z",
                       "label": "Environment",
+                      "description": "This shows the help message for the field",
                       "dialog_group_id": 10000000002378,
                       "position": 1,
                       "dynamic": false,

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -307,9 +307,6 @@ miq-fonticon-picker {
       border-color: red;
     }
   }
-  .help-icon {
-    display: none;
-  }
 }
 /* end dialog control styling */
 
@@ -331,8 +328,8 @@ miq-fonticon-picker {
 
 
 .span-right-border{
-  border-right: 1px solid #d1d1d1; 
-  padding-right: 10px; 
+  border-right: 1px solid #d1d1d1;
+  padding-right: 10px;
   margin-right: 10px !important;
 }
 


### PR DESCRIPTION
![screencast from 2017-09-21 10-33-13](https://user-images.githubusercontent.com/1187051/30686408-79a9ea84-9eb8-11e7-944a-d9e1afc68b58.gif)

**Pivotal tasks**:

https://www.pivotaltracker.com/story/show/150614285
https://www.pivotaltracker.com/story/show/150614221

@chalettu can you take a look on this?