### PR TITLE
Toolbar styling and markup cleanup

### DIFF
--- a/demo/styles/demo-app.scss
+++ b/demo/styles/demo-app.scss
@@ -26,43 +26,6 @@ table .narrow {
   margin-top: 60px;
 }
 
-.miq-toolbar-group {
-  padding-right: 15px;
-}
-.toolbar-pf-actions {
-  .form-group {
-    display: table-cell;
-    float: left;
-    border-right: 1px solid #d1d1d1;
-
-    .demo-checkbox {
-      position: absolute;margin-left: 10px;margin-top: 1px;
-    }
-  }
-  .form-horizontal .form-group:after {
-    clear: both;
-  }
-}
-
-.miq-custom-html {
-  .checkbox-inline {
-    position: relative;
-    display: inline-block;
-    padding-left: 20px;
-    margin-bottom: 0;
-    vertical-align: middle;
-    font-weight: normal;
-    cursor: pointer;
-  }
-   .form-group {
-    display: table-cell;
-    float: left;
-    &:not(.has-clear) {
-      margin-right: 20px;
-    }
-  }
-}
-
 .dl-horizontal.tile dt {
   float: left;
   width: 100px;

--- a/demo/views/toolbar-menu/basic.html
+++ b/demo/views/toolbar-menu/basic.html
@@ -1,5 +1,9 @@
-<div class="toolbar-pf-actions">
-  <miq-toolbar-menu toolbar-items="vm.toolbarMenu"
-                    toolbar-views="vm.toolbarMenuViews"
-                    on-view-click="vm.onViewClick(item)"></miq-toolbar-menu>
+<div class="container-fluid">
+  <div class="row toolbar-pf">
+    <div class="toolbar-pf-actions">
+      <miq-toolbar-menu toolbar-items="vm.toolbarMenu"
+                        toolbar-views="vm.toolbarMenuViews"
+                        on-view-click="vm.onViewClick(item)"></miq-toolbar-menu>
+    </div>
+  </div>
 </div>

--- a/demo/views/toolbar-menu/custom-html.html
+++ b/demo/views/toolbar-menu/custom-html.html
@@ -1,4 +1,6 @@
-<div class="toolbar-pf-actions">
-  <miq-toolbar-menu toolbar-items="vm.customToolbarItems"
-                    on-view-click="vm.onViewClick(item)"></miq-toolbar-menu>
+<div class="container-fluid">
+  <div class="row toolbar-pf">
+     <miq-toolbar-menu toolbar-items="vm.customToolbarItems"
+                       on-view-click="vm.onViewClick(item)"></miq-toolbar-menu>
+  </div>
 </div>

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -8,33 +8,37 @@
   overflow: hidden;
 }
 
-
 /* Begin Patternfly Toolbar overrides */
 
-.toolbar-pf .form-group .btn,
-.toolbar-pf .form-group .btn-group { /* overrides _toolbar.scss to account for intermediate Angular markup */
-  margin-left: 5px;
-}
 
-.form-group.miq-toolbar-group { /* styling for "Custom Html Toolbar Menu" example (used on classic-ui topology screen) */
-  display: inline-block;
-  .miq-custom-html {
-    form {
-      display: inline-block;
-    }
-    .form-group {
-      margin-bottom: 0 !important;
-      border-right: 0;
-      &:last-child {
-        padding-right: 0px
+/* overrides _toolbar.scss to account for intermediate Angular markup and adjusted the margins to properly style wrapped form-groups */
+
+.miq-toolbar-actions {
+  margin-top: -10px;
+  .form-group:first-of-type {
+    padding-left: 0;
+  }
+  .form-group {
+    margin-top: 10px;
+    padding-left: 20px;
+    padding-right: 15px; /* adjusted to account for button margin */
+    white-space: nowrap;
+    .btn { /* margin for buttons (not part of Patternfly) */
+      margin-right: 5px;
+      i {
+        margin-right: 5px;
       }
     }
   }
 }
 
+.miq-custom-html {
+  .form-group.text, .form-group.has-clear {
+    padding-right: 20px; 
+  }
+}
+
 /* End Patternfly Toolbar overrides */
-
-
 
 /* Begin Patternfly Tab overrides used in the Dialog Editor */
 

--- a/src/toolbar/components/toolbar-menu/toolbar-button.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-button.html
@@ -17,8 +17,7 @@
         ng-click="onItemClick({item: toolbarButton, $event: $event})">
   <i ng-if="toolbarButton.icon && toolbarButton.text"
      class="{{toolbarButton.icon}}"
-     ng-style="{color: toolbarButton.color}"
-     style="margin-right: 5px;"></i>
+     ng-style="{color: toolbarButton.color}"></i>
   <i ng-if="toolbarButton.icon && !toolbarButton.text"
      class="{{toolbarButton.icon}}"
      ng-style="{color: toolbarButton.color}"></i>

--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -2,7 +2,6 @@
   <button type="button" uib-dropdown-toggle class="btn uib-dropdown-toggle btn-default"
           ng-class="{disabled: !vm.toolbarList.enabled}" title="{{vm.toolbarList.title}}">
     <i class="{{vm.toolbarList.icon}}"
-       style="margin-right: 5px;"
        ng-if="vm.toolbarList.icon"
        ng-style="{color: vm.toolbarList.color}"></i>
     {{vm.toolbarList.text}}

--- a/src/toolbar/components/toolbar-menu/toolbar-menu.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-menu.html
@@ -1,7 +1,8 @@
 <div class="toolbar-pf-actions miq-toolbar-actions">
-  <div class="form-group miq-toolbar-group"
+  <div class="miq-toolbar-group"
        ng-repeat="toolbarItem in vm.toolbarItems"
-       ng-if="vm.hasContent(toolbarItem)">
+       ng-if="vm.hasContent(toolbarItem)"
+       ng-class="{'form-group': !vm.toolbarHasCustom(toolbarItem)}">
     <ng-repeat ng-repeat="item in toolbarItem ">
       <miq-toolbar-button ng-if="item.type === vm.getButtonType()"
                           toolbar-button="item"

--- a/src/toolbar/components/toolbar-menu/toolbarComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.ts
@@ -1,6 +1,6 @@
 import {IToolbarItem} from '../../interfaces/toolbar';
 import {ToolbarType} from '../../interfaces/toolbarType';
-
+import * as _ from 'lodash';
 /**
  * @memberof miqStaticAssets
  * @ngdoc controller
@@ -18,6 +18,17 @@ export class ToolbarController {
   constructor(private $window: ng.IWindowService,
               private $location: ng.ILocationService,
               private $sce: ng.ISCEService) {
+  }
+
+  /**
+   * Method for finding custom toolbar item's per each toolbar group.
+   * @memberof ToolbarController
+   * @function toolbarHasCustom
+   * @param toolbarItem toolbar group item.
+   * @returns {any[]} array of custom items in toolbar.
+   */
+  public toolbarHasCustom(toolbarItem): any {
+    return _.find(toolbarItem, {name: 'custom'});
   }
 
   /**


### PR DESCRIPTION
This PR cleans up the toolbar markup and styling and adjusts the button positioning to match Patternfly.

Follow-up PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/2226

Old

<img width="896" alt="screen shot 2017-09-25 at 11 24 23 am" src="https://user-images.githubusercontent.com/1287144/30816544-3c4ac9a4-a1e4-11e7-854c-4185576733ce.png">
<img width="772" alt="screen shot 2017-09-25 at 11 24 11 am" src="https://user-images.githubusercontent.com/1287144/30816543-3c4a3cf0-a1e4-11e7-845d-b605afc573d4.png">

New

<img width="884" alt="screen shot 2017-09-25 at 11 23 37 am" src="https://user-images.githubusercontent.com/1287144/30816546-3c4e4ac0-a1e4-11e7-8968-35a9add4db32.png">
<img width="891" alt="screen shot 2017-09-25 at 11 23 46 am" src="https://user-images.githubusercontent.com/1287144/30816545-3c4e031c-a1e4-11e7-87a8-5caa37aad848.png">

