### PR TITLE
Do not use minified version of ui-components in coverage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "karma start",
     "prepublish": "webpack || true",
     "build": "webpack --config webpack.vendor.config.js && webpack -p",
+    "build-dev": "webpack --config webpack.vendor.config.js && webpack",
     "install-vendor": "webpack --config webpack.vendor.config.js",
     "build-docs": "jsdoc -c jsdoc-conf.json"
   },

--- a/scripts/.build.sh
+++ b/scripts/.build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 yarn install
-yarn run build
+yarn run build-dev
 yarn test

--- a/src/common/components/sortItemsComponent.spec.ts
+++ b/src/common/components/sortItemsComponent.spec.ts
@@ -23,7 +23,7 @@ describe('Sort items test', () =>  {
       };
       angular.mock.module('miqStaticAssets.common');
       angular.mock.inject(($componentController) => {
-        sortItemsCtrl = $componentController('miqSortItems', {$element: angular.element()}, bindings);
+        sortItemsCtrl = $componentController('miqSortItems', {$element: angular.element('')}, bindings);
       });
     });
 

--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -80,7 +80,7 @@ export class SortItemsController {
    * @function fillFields
    */
   private fillFields() {
-    _.each(this.headers, (oneCol, key) => {
+    _.each(this.headers, (oneCol: any, key) => {
       if (!oneCol.hasOwnProperty('is_narrow') && oneCol.hasOwnProperty('text')) {
         this.options.fields.push({
           colId: key,

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -102,7 +102,7 @@ class BoxController {
    * @param {number} ui jQuery object
    */
   public droppableOptions(e: any, ui: any) {
-    let droppedItem = ng.element(e.target).scope();
+    let droppedItem: any = ng.element(e.target).scope();
     // update indexes of other boxes after changing their order
     this.DialogEditor.updatePositions(
       droppedItem.box.dialog_fields

--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -36,7 +36,7 @@ class TabListController {
       helper: 'clone',
       revert: 50,
       stop: (e: any, ui: any) => {
-        let sortedTab = ng.element(ui.item).scope().$parent;
+        let sortedTab: any = ng.element(ui.item).scope().$parent;
         let tabList = sortedTab.vm.tabList;
         this.DialogEditor.updatePositions(tabList);
         let activeTab: any = _.find(tabList, {active: true});

--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -39,7 +39,7 @@ describe('Dialog field test', () => {
     beforeEach(() => {
       bindings = {
         field: dialogField,
-        onUpdate: function () { },
+        onUpdate: () => true,
         inputDisabled: false
       };
       angular.mock.module('miqStaticAssets.dialogUser');
@@ -81,7 +81,7 @@ describe('Dialog field test', () => {
     it('should report back information when a field gets updated', () => {
       bindings = {
         field: dialogField,
-        onUpdate: jasmine.createSpy('onUpdate', (dialogFieldName: any, value: any) => { }),
+        onUpdate: jasmine.createSpy('onUpdate', (dialogFieldName: any, value: any) => true),
         inputDisabled: false
       };
       angular.mock.module('miqStaticAssets.dialogUser');

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -10,8 +10,8 @@ describe('Dialog test', () =>  {
     beforeEach(() => {
       bindings = {
       dialog: dialog,
-      refreshField: function(){},
-      onUpdate: function(){},
+      refreshField: () => true,
+      onUpdate: () => true,
       inputDisabled: false
       };
       angular.mock.module('miqStaticAssets.dialogUser');
@@ -50,8 +50,8 @@ describe('Dialog test', () =>  {
     beforeEach(() => {
       bindings = {
       dialog: dialogData,
-      refreshField: function() {},
-      onUpdate: function(){},
+      refreshField: () => true,
+      onUpdate: () => true,
       inputDisabled: false
       };
       angular.mock.module('miqStaticAssets.dialogUser');

--- a/src/gtl/components/data-table/dataTableComponent.spec.ts
+++ b/src/gtl/components/data-table/dataTableComponent.spec.ts
@@ -28,10 +28,10 @@ describe('DataTable test', () =>  {
   };
   let settings = {perpage: 5, current: 1, items: 2, total: 1, sortBy: {sortObject: {col_idx: 0}, isAscending: true}};
 
-  const onItemSelected = jasmine.createSpy('onItemSelected', (item: any, isSelected: boolean) => {}),
-        onRowClick = jasmine.createSpy('onRowClick', (item: any) => {}),
-        onSort = jasmine.createSpy('onSort', (headerId: any, isAscending: boolean) => {}),
-        loadMoreItems = jasmine.createSpy('loadMoreItems', (start: number, perPage: number) => {});
+  const onItemSelected = jasmine.createSpy('onItemSelected', (item: any, isSelected: boolean) => true),
+        onRowClick = jasmine.createSpy('onRowClick', (item: any) => true),
+        onSort = jasmine.createSpy('onSort', (headerId: any, isAscending: boolean) => true),
+        loadMoreItems = jasmine.createSpy('loadMoreItems', (start: number, perPage: number) => true);
 
   describe('controller', () => {
     let dataTableCtrl;

--- a/src/gtl/components/pagination/paginationComponent.spec.ts
+++ b/src/gtl/components/pagination/paginationComponent.spec.ts
@@ -1,24 +1,23 @@
 describe('Pagination test', () =>  {
   let bindings,
-      perPage =
-        {
-          'labelItems': 'Items',
-          'enabled': true,
-          'text': '20 Items',
-          'value': 20,
+      perPage = {
+        'labelItems': 'Items',
+        'enabled': true,
+        'text': '20 Items',
+        'value': 20,
+        'hidden': false,
+        'items': [{'text': '5 Items', 'value': 5, 'hidden': false, 'enabled': true}, {
+          'text': '10 Items',
+          'value': 10,
           'hidden': false,
-          'items': [{'text': '5 Items', 'value': 5, 'hidden': false, 'enabled': true}, {
-            'text': '10 Items',
-            'value': 10,
-            'hidden': false,
-            'enabled': true
-          }, {'text': '20 Items', 'value': 20, 'hidden': false, 'enabled': true}, {
-            'text': '50 Items',
-            'value': 50,
-            'hidden': false,
-            'enabled': true
-          }]
-        },
+          'enabled': true
+        }, {'text': '20 Items', 'value': 20, 'hidden': false, 'enabled': true}, {
+          'text': '50 Items',
+          'value': 50,
+          'hidden': false,
+          'enabled': true
+        }]
+      },
       settings = {
         'perpage': 20,
         'current': 1,

--- a/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.spec.ts
@@ -94,7 +94,9 @@ describe('Toolbar test', () =>  {
     });
 
     it('creates toolbar', () => {
-      const dropdownToggle: any = angular.element(compiledElement[0].querySelectorAll('button:not(.uib-dropdown-toggle)'));
+      const dropdownToggle: any = angular.element(
+        compiledElement[0].querySelectorAll('button:not(.uib-dropdown-toggle)')
+      );
       expect(dropdownToggle.length).toBe(2);
       expect(compiledElement.find('miq-toolbar-list').length).toBe(3);
     });


### PR DESCRIPTION
Coverage is right now generated from minified version of ui-components, which is not totally great. So this PR introduces new script in `package.json` which is `build-dev`, it's the same as `build` however it does not uses `-p` for `webpack` so we have normal output.

Also fixes couple of problems with build, where it threw error with some variables without type and some empty function blocks are rewritten from `function() {}` to `() => true`, which is shorter and does not produce any errors.