### PR TITLE
Align the page indication number input field to center

### DIFF
--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -360,7 +360,7 @@ miq-fonticon-picker {
       margin: 0;
     }
     input[type="number"] {
-      text-align: right;
+      text-align: center;
       width: 35px;
       -moz-appearance: textfield;
     }


### PR DESCRIPTION
After consulting with @sbulage we agreed that the fix for this BZ should be to align the content of the input field to center. However, I'm not sure if this is good from the UX perspective, can you please take a look @epwinchell?

**Before:**
![screenshot from 2017-09-26 10-59-18](https://user-images.githubusercontent.com/649130/30851800-f8bb16c8-a2a9-11e7-82f7-89d0bdc8843f.png)

**After:**
![screenshot from 2017-09-26 10-59-06](https://user-images.githubusercontent.com/649130/30851810-fdc595da-a2a9-11e7-9d7b-fcf8e9fe106a.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1486644