### PR TITLE
Fixed GTL icons and images when both are present

### DIFF
--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -44,7 +44,7 @@
                value="{{row.id}}"
                ng-checked="row.checked"
                class="list-grid-checkbox">
-        <i ng-if="row.cells[columnKey].icon && tableCtrl.hasIcon(row, columnKey)"
+        <i ng-if="tableCtrl.hasIcon(row, columnKey)"
            class="{{row.cells[columnKey].icon}}"
            title="{{row.cells[columnKey].title}}">
           <i ng-if="row.cells[columnKey].icon2" ng-class="row.cells[columnKey].icon2"></i>

--- a/src/gtl/components/data-table/dataTableComponent.ts
+++ b/src/gtl/components/data-table/dataTableComponent.ts
@@ -56,8 +56,8 @@ export class DataTableController extends DataViewClass implements IDataTableBind
    * @param columnKey header column key.
    * @returns {boolean} true | false, if column has icon or not.
    */
-  public hasIcon(row, columKey): boolean {
-    return row && row.cells && row.cells[columKey].hasOwnProperty('icon');
+  public hasIcon(row, columnKey): boolean {
+    return row && row.cells && row.cells[columnKey].hasOwnProperty('icon') && row.cells[columnKey].icon;
   }
 
   /**
@@ -68,8 +68,8 @@ export class DataTableController extends DataViewClass implements IDataTableBind
    * @param columnKey header column key.
    * @returns {boolean} true | false, if column has image or not.
    */
-  public hasImage(row, columKey): boolean {
-    return row && row.cells && row.cells[columKey].hasOwnProperty('image');
+  public hasImage(row, columnKey): boolean {
+    return row && row.cells && row.cells[columnKey].hasOwnProperty('image') && row.cells[columnKey].image;
   }
 
   /**


### PR DESCRIPTION
The `hasOwnProperty` wasn't testing if the property is `null` so the `hasImage` and `hasIcon` functions always returned `true`.