### PR TITLE
[WIP] Introducing the quadicon component

### DIFF
--- a/application-settings.js
+++ b/application-settings.js
@@ -14,8 +14,9 @@ module.exports = {
     siteSwitcher: '/site-switcher',
     fonticonPicker: '/fonticon-picker',
     dialogs: '/dialog-user',
+    quadicon: '/quadicon',
     treeView: '/tree-view',
-    treeSelector: '/tree-selector'
+    treeSelector: '/tree-selector',
   },
   nodePackages: 'node_modules/',
   get stylesheetPath() {

--- a/demo/controllers/index.ts
+++ b/demo/controllers/index.ts
@@ -5,6 +5,7 @@ import SiteSwitcherController from './siteSwitcherController';
 import FonticonPickerController from './fonticonPickerController';
 import DialogUserController from './dialogUserController';
 import DialogEditorController from './dialogEditorController';
+import QuadiconController from './quadiconController';
 import TreeViewController from './treeViewController';
 import TreeSelectorController from './treeSelectorController';
 import * as ng from 'angular';
@@ -17,6 +18,7 @@ export default (module: ng.IModule) => {
   module.controller('demoFonticonPicker', FonticonPickerController);
   module.controller('demoDialogUser', DialogUserController);
   module.controller('demoDialogEditor', DialogEditorController);
+  module.controller('demoQuadicon', QuadiconController);
   module.controller('demoTreeView', TreeViewController);
   module.controller('demoTreeSelector', TreeSelectorController);
 };

--- a/demo/controllers/quadiconController.ts
+++ b/demo/controllers/quadiconController.ts
@@ -1,0 +1,139 @@
+export default class QuadiconController {
+  public quads = [
+    {
+      topLeft: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'Ah ... ! What\'s happening?',
+      },
+      topRight: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'Er, excuse me, who am I? Hello?',
+      },
+      bottomLeft: {
+        text: '42',
+        tooltip: 'Why am I here? What\'s my purpose in life?',
+      },
+      bottomRight: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'What do I mean by who am I?',
+      },
+    },
+    {
+      topLeft: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'Calm down, get a grip now ... oh!',
+      },
+      topRight: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'This is an interesting sensation, what is it?',
+      },
+      bottomLeft: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'It’s a sort of ... yawning, tingling sensation',
+      },
+      bottomRight: {
+        text: '42',
+        tooltip: 'in my ... my ... well I suppose I’d better start finding names for things',
+      },
+    },
+    {
+      topLeft: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'if I want to make any headway in what for the sake of what I shall call',
+      },
+      topRight: {
+        text: '42',
+        tooltip: 'an argument I shall call the world, so let’s call it my stomach.',
+      },
+      bottomLeft: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'Good. Ooooh, it’s getting quite strong.',
+      },
+      bottomRight: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'And hey, what’s about this whistling roaring \
+        sound going past what I’m suddenly going to call my head?',
+      },
+    },
+    {
+      topLeft: {
+        text: '42',
+        tooltip: 'Perhaps I can call that ... wind!',
+      },
+      topRight: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'Is that a good name?',
+      },
+      bottomLeft: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'It’ll do ... perhaps I can find a better name for it later when I’ve found out what it’s for.',
+      },
+      bottomRight: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'It must be something very important because there certainly seems to be a hell of a lot of it.',
+      },
+    },
+    {
+      fonticon: 'fa fa-cogs',
+      tooltip: 'Hey! What’s this thing?',
+    },
+    {
+      fileicon: '/assets/100/vendor-hawkular.png',
+      tooltip: 'This ... let’s call it a tail - yeah, tail.',
+    },
+    {
+      text: '42',
+      tooltip: 'Hey! I can can really thrash it about pretty good can’t I?',
+    },
+    {
+      topLeft: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'Wow! Wow! That feels great!',
+      },
+      topRight: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'Doesn’t seem to achieve very much',
+      },
+      bottomLeft: {
+        text: '42',
+        tooltip: 'but I’ll probably find out what it’s for later on.',
+      },
+      bottomRight: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'Now - have I built up any coherent picture of things yet?',
+      },
+      middle: {
+        fonticon: 'fa fa-shield',
+        tooltip: 'No.',
+      }
+    },
+    {
+      topLeft: {
+        fonticon: 'fa fa-cog',
+        tooltip: 'Never mind, hey, this is really exciting,',
+      },
+      topRight: {
+        fonticon: 'fa fa-play',
+        background: 'blue',
+        tooltip: 'so much to find out about, so much to look forward to,',
+      },
+      bottomLeft: {
+        text: '42',
+        tooltip: 'I’m quite dizzy with anticipation ...',
+      },
+      bottomRight: {
+        fonticon: 'fa fa-shield',
+        tooltip: 'Or is it the wind?',
+      },
+      middle: {
+        fileicon: '/assets/100/vendor-hawkular.png',
+        tooltip: 'There really is a lot of that now isn’t it?',
+      }
+    },
+  ];
+}

--- a/demo/services/availableComponentsService.ts
+++ b/demo/services/availableComponentsService.ts
@@ -88,6 +88,12 @@ export default class AvailableComponentsService {
           '/user',
           require('./../views/dialog/user.html'), 'demoDialogUser as vm')
       ]),
+      new AvailableGroup('quadicon', 'Quadicon Components', '/quadicon', [
+        new AvailableComponent('basic',
+          'Quadicon',
+          '/quadicon',
+          require('./../views/quadicon/basic.html'), 'demoQuadicon as vm')
+      ]),
       new AvailableGroup('tree-view', 'Tree Components', '/tree', [
         new AvailableComponent('tree-view',
           'TreeView',

--- a/demo/views/quadicon/basic.html
+++ b/demo/views/quadicon/basic.html
@@ -1,0 +1,3 @@
+<div class="col-xs-1" ng-repeat="quad in vm.quads">
+  <miq-quadicon data="quad"></miq-quadicon>
+</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ module miqStaticAssets {
     'miqStaticAssets.gtl',
     'miqStaticAssets.siteSwitcher',
     'miqStaticAssets.fonticonPicker',
+    'miqStaticAssets.quadicon',
     'miqStaticAssets.treeView',
     'miqStaticAssets.treeSelector'
   ]);

--- a/src/quadicon/components/index.ts
+++ b/src/quadicon/components/index.ts
@@ -1,0 +1,7 @@
+import Quadicon from './quadicon';
+import Quaditem from './quaditem';
+
+export default (module: ng.IModule) => {
+  Quadicon(module);
+  Quaditem(module);
+};

--- a/src/quadicon/components/quadicon/index.ts
+++ b/src/quadicon/components/quadicon/index.ts
@@ -1,0 +1,6 @@
+import * as ng from 'angular';
+import Quadicon from './quadiconComponent';
+
+export default (module: ng.IModule) => {
+  module.component('miqQuadicon', new Quadicon);
+};

--- a/src/quadicon/components/quadicon/quadicon.html
+++ b/src/quadicon/components/quadicon/quadicon.html
@@ -1,0 +1,12 @@
+<div class="quad-wrapper" ng-if="$ctrl.isQuad()">
+  <miq-quaditem
+    data="$ctrl.data[item]"
+    tooltip="{{ $ctrl.data[item].tooltip }}"
+    ng-repeat="item in $ctrl.quadSet"
+    ng-class="item | kebabCase"
+    ng-style="$ctrl.getBackground(item)"
+  />
+</div>
+<div class="single-wrapper" ng-if="!$ctrl.isQuad()">
+  <miq-quaditem data="$ctrl.data" tooltip="{{ $ctrl.data.tooltip }}" />
+</div>

--- a/src/quadicon/components/quadicon/quadiconComponent.ts
+++ b/src/quadicon/components/quadicon/quadiconComponent.ts
@@ -1,0 +1,22 @@
+import * as ng from 'angular';
+
+export class QuadiconController {
+  public data : any;
+  public quadSet = ['topLeft', 'topRight', 'bottomLeft', 'bottomRight', 'middle'];
+
+  public isQuad() : boolean {
+    return this.quadSet.some(quad => this.data[quad]);
+  }
+
+  public getBackground(item) {
+    return this.data[item] && this.data[item].background ? {'background': this.data[item].background} : {};
+  }
+}
+
+export default class Quadicon implements ng.IComponentOptions {
+  public controller = QuadiconController;
+  public template = require('./quadicon.html');
+  public bindings : any = {
+    data: '<',
+  };
+}

--- a/src/quadicon/components/quaditem/index.ts
+++ b/src/quadicon/components/quaditem/index.ts
@@ -1,0 +1,6 @@
+import * as ng from 'angular';
+import Quaditem from './quaditemComponent';
+
+export default (module: ng.IModule) => {
+  module.component('miqQuaditem', new Quaditem);
+};

--- a/src/quadicon/components/quaditem/quaditem.html
+++ b/src/quadicon/components/quaditem/quaditem.html
@@ -1,0 +1,9 @@
+<div class="fonticon" ng-if="$ctrl.data.fonticon">
+  <i ng-class="$ctrl.data.fonticon"></i>
+</div>
+<div class="fileicon" ng-if="$ctrl.data.fileicon && !$ctrl.data.fonticon">
+  <img ng-src="{{ $ctrl.data.fileicon }}" />
+</div>
+<div class="text" ng-if="$ctrl.data.text">
+  {{ $ctrl.data.text }}
+</div>

--- a/src/quadicon/components/quaditem/quaditemComponent.ts
+++ b/src/quadicon/components/quaditem/quaditemComponent.ts
@@ -1,0 +1,11 @@
+import * as ng from 'angular';
+
+export class QuaditemController {}
+
+export default class Quaditem implements ng.IComponentOptions {
+  public controller = QuaditemController;
+  public template = require('./quaditem.html');
+  public bindings : any = {
+    data: '<'
+  };
+}

--- a/src/quadicon/index.ts
+++ b/src/quadicon/index.ts
@@ -1,0 +1,9 @@
+import components from './components';
+import * as angular from 'angular';
+import * as _ from 'lodash';
+
+module quadicon {
+  export const app = angular.module('miqStaticAssets.quadicon', []);
+  app.filter('kebabCase', _.constant(_.kebabCase));
+  components(app);
+}

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -770,3 +770,96 @@ fieldset[disabled] .pagination > li > span.active {
     display: block;
   }
 }
+
+miq-quadicon {
+  $quad-w: 72px;
+  $quad-h: 80px;
+  $in-border: 1px gray solid;
+  $radius: 15px;
+  $font-size: 20px;
+  $background: black;
+
+  // Clearfix across the component
+  display: flow-root;
+  // Hack for IE11
+  @supports not (display: flow-root) {
+    &::after {
+      content: '';
+      display: block;
+      clear: both;
+    }
+  }
+
+  border-radius: $radius $radius $radius $radius;
+  background: $background;
+  width: $quad-w;
+  height: $quad-h;
+  color: white;
+  overflow: hidden;
+
+  .fileicon {
+    line-height: normal;
+    &> img {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  & > div.quad-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    font-size: $font-size;
+    line-height: #{$quad-h / 2 - 1};
+    text-align: center;
+    vertical-align: middle;
+
+    & > miq-quaditem {
+      flex: 0 0 50%;
+
+      &.top-left {
+        border-right: $in-border;
+        border-bottom: $in-border;
+      }
+
+      &.top-right {
+        border-left: $in-border;
+        border-bottom: $in-border;
+      }
+
+      &.bottom-left {
+        border-right: $in-border;
+        border-top: $in-border;
+      }
+
+      &.bottom-right {
+        border-top: $in-border;
+        border-left: $in-border;
+      }
+
+      &.middle {
+        position: absolute;
+        top: $quad-h / 3;
+        margin-left: $quad-w / 3;
+        margin-right: $quad-w / 3;
+        width: #{$quad-w / 3};
+        height: #{$quad-h / 3};
+        line-height: #{$quad-h / 3};
+      }
+    }
+  }
+
+  & > div.single-wrapper {
+    height: 100%;
+
+    font-size: #{$font-size * 2};
+    line-height: $quad-h - 1;
+    text-align: center;
+    vertical-align: middle;
+
+    & > miq-quaditem {
+      height: 100%;
+    }
+  }
+}
+


### PR DESCRIPTION
This will eventually replace all the ruby-built quadicons across ManageIQ as it requires less work from the server. Usage: `<miq-quadicon data="{}">` where in the data is for example:
```javascript
{
  topLeft: {
    fonticon: 'fa fa-cog',
    tooltip: 'I am a tooltip',
  },
  topRight: {
    fonticon: 'fa fa-play',
    background: 'blue',
  },
  bottomLeft: {
    text: '42',
  },
  bottomRight: {
    fonticon: 'fa fa-shield',
  },
  middle: {
    fileicon: '/assets/100/vendor-hawkular.png',
  }
}
```
That is being rendered into:
![screenshot from 2017-10-05 14-34-00](https://user-images.githubusercontent.com/649130/31227515-66814fb0-a9da-11e7-8a59-449c183bf9dc.png)

The `topLeft`, `topRight`, `bottomLeft`, `bottomRight` and `middle` keys are all optional and all the subkeys can be used across them. The `background`, `fonticon`, `fileicon` and `text` parameters can be used also when creating a single icon:
```javascript
{
  fonticon: 'fa fa-cog',
}
```
Which renders into:
![screenshot from 2017-10-05 14-35-55](https://user-images.githubusercontent.com/649130/31227561-84219afc-a9da-11e7-9453-8489ad507c09.png)

**Please note that the styling/coloring is not final yet**

@epwinchell @himdel @karelhala @martinpovolny 