### PR TITLE
Enable to use disabled buttons in GTLs, add optionalData to ajax and enable bindTo for buttons in GTL

### DIFF
--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -58,6 +58,7 @@
         </span>
         <button ng-if="row.cells[columnKey].is_button && row.cells[columnKey].onclick"
                 class="btn btn-primary"
+                ng-disabled="row.cells[columnKey].disabled"
                 title="{{row.cells[columnKey].title}}"
                 alt="{{row.cells[columnKey].title}}"
                 ng-click="tableCtrl.onItemButtonClick(row.cells[columnKey])">

--- a/src/gtl/components/tile-view/tile-view.html
+++ b/src/gtl/components/tile-view/tile-view.html
@@ -45,6 +45,7 @@
               <button class="btn btn-primary"
                       title="{{item.cells[columnKey].title}}"
                       alt="{{item.cells[columnKey].title}}"
+                      ng-disabled="item.cells[columnKey].disabled"
                       ng-click="config.onButtonItemClick(item.cells[columnKey])">
                 {{item.cells[columnKey].text}}
               </button>

--- a/src/gtl/interfaces/abstractDataViewClass.ts
+++ b/src/gtl/interfaces/abstractDataViewClass.ts
@@ -83,7 +83,8 @@ export abstract class DataViewClass implements IDataTableBinding {
 
   public onItemButtonClick(item: any) {
     if (item.hasOwnProperty('onclick')) {
-      new Function(item.onclick)();
+      let onClickFunction = new Function(item.onclick);
+      onClickFunction.bind(item.bindTo)();
     }
   }
 

--- a/src/gtl/services/dataTableService.ts
+++ b/src/gtl/services/dataTableService.ts
@@ -35,8 +35,15 @@ export default class DataTableService implements IDataTableService {
                                        id?: string,
                                        isExplorer?: string,
                                        settings?: any,
-                                       records?: any): ng.IPromise<IRowsColsResponse> {
-    return this.fetchData(DataTableService.generateConfig(modelName, activeTree, id, isExplorer, settings, records))
+                                       records?: any,
+                                       additionalOptions?: any): ng.IPromise<IRowsColsResponse> {
+    return this.fetchData(DataTableService.generateConfig(modelName,
+                                                          activeTree,
+                                                          id,
+                                                          isExplorer,
+                                                          settings,
+                                                          records,
+                                                          additionalOptions))
       .then(responseData => {
         this.columns = responseData.data.data.head;
         this.rows = responseData.data.data.rows;
@@ -71,6 +78,7 @@ export default class DataTableService implements IDataTableService {
    * @param isExplorer
    * @param settings
    * @param records
+   * @param additionalOptions
    * @returns {{params: {}}} config object with params set.
    */
   public static generateConfig(modelName?: string,
@@ -78,7 +86,8 @@ export default class DataTableService implements IDataTableService {
                                parentId?: string,
                                isExplorer?: string,
                                settings?: any,
-                               records?: any) {
+                               records?: any,
+                               additionalOptions?: any) {
     let config = {};
     _.assign(config, DataTableService.generateModelNameConfig(modelName));
     _.assign(config, DataTableService.generateActiveTreeConfig(activeTree));
@@ -86,6 +95,7 @@ export default class DataTableService implements IDataTableService {
     _.assign(config, DataTableService.generateExplorerConfig(isExplorer));
     _.assign(config, DataTableService.generateParamsFromSettings(settings));
     _.assign(config, DataTableService.generateRecords(records));
+    _.assign(config, DataTableService.generateAdditionalOptions(additionalOptions));
     return config;
   }
 
@@ -138,5 +148,9 @@ export default class DataTableService implements IDataTableService {
 
   private static generateRecords(records) {
     return records && records !== null && {'records[]': records, records: records};
+  }
+
+  private static generateAdditionalOptions(additionalOptions) {
+    return additionalOptions && additionalOptions !== null && {'additional_options': additionalOptions};
   }
 }


### PR DESCRIPTION
### Additional Options
This PR allows us to add additional options to report data requests. This was required by multiple people in core repo, and would allow us to easily add new options when filtering for data.

### GTL improvements
* `bindTo` property in buttons - When someone would like to use button in GTL (on rows) now he can also add `bindTo` property to such table column and bind specific object to it. So when button is clicked it can access functions related to bound object.
* `disabled` buttons - When button is rendered in table or big tile it can be disabled by property `disabled`.

Example of how to use `bindTo`
```Typescript
class SomeComponentClass {
  public rows: any[];

  public function onButtonClick(item) {
     //do some action with item
  }

  public addButtonToTable() {
    this.rows.each(oneRow => {
      oneRow.cells = [...oneRow.cells, {
        is_button: true,
        title: __('Some Action'),
        text: __('Some Action'),
        onclick: `this.onButtonClick("${row}")`,
        disabled: false,
        bindTo: this
      }]
    })
  }

  public onDataload(data) {
    this.rows = data.rows;
    this.addButtonToTable();
  }
}
```