### PR TITLE
Don't render the treeview before the angular template is fully ready

### DIFF
--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -20,7 +20,18 @@ export class TreeViewController {
     this.errorHandlers = this.errorHandlers || {};
   }
 
+  public $postLink() {
+    // It's necessary to wait for the template to be ready as the treeview requires an element ID
+    this.$timeout(() => {
+      this.renderTree();
+    });
+  }
+
   public $onChanges(changes) {
+    // For the first time render the tree with $postLink
+    if (!this.rendered) {
+      return;
+    }
     // Render the tree after the data has attribute been altered
     // WARNING: Do not use this for lazy-loading!
     if (changes.data && changes.data.currentValue !== undefined) {
@@ -237,7 +248,7 @@ export class TreeViewController {
 
 export default class TreeView implements ng.IComponentOptions {
   public controller = TreeViewController;
-  public template = '<div class="treeview treeview-pf-select"></div>';
+  public template = '<div class="treeview treeview-pf-select" ng-attr-id="treeview-{{ $ctrl.name }}"></div></div>';
   public bindings: any = {
     name: '@',
     data: '<',


### PR DESCRIPTION
The treeview requires an element ID for the proper styling setup. Without it the styling of nodes might be ignored if you have more than one treeview on a single page. I added a dynamic ID to the component's template, however, it was necessary to delay the tree rendering until the ID is set properly.

The best way to test this is through the *Automate -> Customization -> Buttons* tree, where you can have colored icons.

**Before:**
![screenshot from 2017-10-12 13-27-14](https://user-images.githubusercontent.com/649130/31493918-816ecc90-af51-11e7-8685-52ee37aa3393.png)


**After:**
![screenshot from 2017-10-12 13-26-43](https://user-images.githubusercontent.com/649130/31493924-84e326b4-af51-11e7-9ac9-912c53190e1e.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1498052