### PR TITLE
Add es6-shim dependency for development and testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "npm": ">= 3.8.1"
   },
   "devDependencies": {
+    "@manageiq/font-fabulous": "^1.0.0",
     "@types/angular-mocks": "^1.5.7",
     "@types/angular-ui-router": "^1.1.35",
     "@types/jasmine": "^2.5.38",
@@ -55,7 +56,6 @@
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^2.0.0-beta.5",
     "file-loader": "^0.9.0",
-    "@manageiq/font-fabulous": "^1.0.0",
     "google-code-prettify": "^1.0.5",
     "html-webpack-plugin": "^2.24.1",
     "jasmine": "2.5.2",
@@ -95,7 +95,7 @@
     "angular-dragdrop": "^1.0.13",
     "angular-ui-sortable": "^0.16.1",
     "babel-eslint": "^7.2.3",
+    "es6-shim": "^0.35.3",
     "eslint": "~3.9.1"
-
   }
 }

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -1,3 +1,4 @@
+import 'es6-shim';
 import 'jquery';
 import 'jquery-ui-bundle';
 import 'bootstrap-switch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,6 +2038,10 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
+es6-shim@^0.35.3:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.3.tgz#9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26"
+
 es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"


### PR DESCRIPTION
This will allow us to use ES6 features in testing (PhantomJS) and in development (IE11).