### PR TITLE
Toolbar - add send_checked?: boolean to toolbar buttons, listitems and viewbuttons

### DIFF
--- a/src/toolbar/components/toolbar-menu/toolbar-button.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-button.html
@@ -10,6 +10,7 @@
         data-click="{{toolbarButton.id}}"
         data-url="{{toolbarButton.url}}"
         data-url_parms="{{toolbarButton.url_parms}}"
+        data-send_checked="{{toolbarButton.send_checked ? 'true' : ''}}"
         data-prompt="{{toolbarButton.prompt}}"
         data-popup="{{toolbarButton.popup}}"
         ng-class="{active: toolbarButton.selected, disabled: !toolbarButton.enabled}"

--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -24,6 +24,7 @@
          name="{{item.id}}"
          id="{{item.id}}"
          data-url_parms="{{item.url_parms}}"
+         data-send_checked="{{item.send_checked ? 'true' : ''}}"
          data-prompt="{{item.prompt}}"
          data-popup="{{item.popup}}"
          data-url="{{item.url}}">

--- a/src/toolbar/components/toolbar-menu/toolbar-view.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-view.html
@@ -6,6 +6,7 @@
           id="{{item.id}}"
           data-url="{{item.url}}"
           data-url_parms="{{item.url_parms}}"
+          data-send_checked="{{item.send_checked ? 'true' : ''}}"
           data-prompt="{{item.prompt}}"
           data-popup="{{item.popup}}"
           ng-click="vm.onItemClick({item: item, $event: $event})"

--- a/src/toolbar/components/toolbar-menu/toolbarButton.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarButton.spec.ts
@@ -31,7 +31,7 @@ describe('ToolbarButton test', () =>  {
       scope.$digest();
     });
 
-    it('creates button and checks for {name, confirm-tb, explorer, title, url, click, url_parms}', () => {
+    it('creates button and checks for {name, confirm-tb, explorer, title, url, click, url_parms, send_checked}', () => {
       expect(compiledElement.attr('name')).toBe(scope.toolbarButtonData.name);
       expect(compiledElement.attr('data-confirm-tb')).toBe(scope.toolbarButtonData.confirm);
       expect(JSON.parse(compiledElement.attr('data-explorer'))).toBe(scope.toolbarButtonData.explorer);
@@ -39,6 +39,7 @@ describe('ToolbarButton test', () =>  {
       expect(compiledElement.attr('data-url')).toBe(scope.toolbarButtonData.url);
       expect(compiledElement.attr('data-click')).toBe(scope.toolbarButtonData.name);
       expect(compiledElement.attr('data-url_parms')).toBe(scope.toolbarButtonData.url_parms);
+      expect(compiledElement.attr('data-send_checked')).toBe(scope.toolbarButtonData.send_checked ? 'true' : '');
       expect(compiledElement.attr('data-prompt')).toBe(scope.toolbarButtonData.prompt);
     });
 

--- a/src/toolbar/components/toolbar-menu/toolbarList.sample.json
+++ b/src/toolbar/components/toolbar-menu/toolbarList.sample.json
@@ -30,7 +30,8 @@
       "title": "Reload these Middleware Servers",
       "text": "Reload Server",
       "confirm": "Do you want to reload selected servers?",
-      "url_parms": "main_div"
+      "url_parms": "main_div",
+      "send_checked": true
     },
     {
       "child_id": "middleware_server_stop",
@@ -55,6 +56,7 @@
       "text": "Stop Server",
       "confirm": "Do you want to stop selected servers?",
       "url_parms": "main_div",
+      "send_checked": true,
       "img_url": "data/some_img.png"
     }
   ]

--- a/src/toolbar/components/toolbar-menu/toolbarListComponent.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarListComponent.spec.ts
@@ -66,6 +66,7 @@ describe('ToolbarButton test', () =>  {
         expect(linkItem.attr('data-click')).toBe(currItem.id);
         expect(linkItem.attr('data-url') ? linkItem.attr('data-url') : undefined).toBe(currItem.url);
         expect(linkItem.attr('data-url_parms')).toBe(currItem.url_parms);
+        expect(linkItem.attr('data-send_checked')).toBe(currItem.send_checked ? 'true' : '');
         expect(linkItem.attr('name')).toBe(currItem.name);
         expect(linkItem.attr('id')).toBe(currItem.id);
       });

--- a/src/toolbar/components/toolbar-menu/toolbarViewComponent.spec.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarViewComponent.spec.ts
@@ -52,6 +52,7 @@ describe('ToolbarButton test', () =>  {
         expect(btnElem.attr('id')).toBe(scope.toolbarViews[key].id);
         expect(btnElem.attr('data-url')).toBe(scope.toolbarViews[key].url);
         expect(btnElem.attr('data-url_parms')).toBe(scope.toolbarViews[key].url_parms);
+        expect(btnElem.attr('data-send_checked')).toBe(scope.toolbarViews[key].send_checked ? 'true' : '');
         expect(btnElem.attr('name')).toBe(scope.toolbarViews[key].name);
       });
     });

--- a/src/toolbar/interfaces/toolbar.ts
+++ b/src/toolbar/interfaces/toolbar.ts
@@ -29,6 +29,7 @@ export interface IToolbarItem {
   enabled?: boolean;
   hidden?: boolean;
   url_parms?: string;
+  send_checked?: boolean;
   url?: string;
   img?: string;
   icon?: string;


### PR DESCRIPTION
Serves to replace the `url_params =~ /_div$/` (and `url_params =~ /id=LIST/`) hacks used to trigger sending a list of checked items before.

part of ManageIQ/manageiq-ui-classic#588

Cc @karelhala 