### PR TITLE
When headers change for pagination, clear fields so they don't multiply

### DIFF
--- a/src/common/components/sortItemsComponent.ts
+++ b/src/common/components/sortItemsComponent.ts
@@ -26,6 +26,7 @@ export class SortItemsController {
    */
   public $onChanges(changesObj: any) {
     if (changesObj.headers) {
+      this.options.fields = [];
       this.fillFields();
       if (this.sortObject) {
         this.setSortItem();


### PR DESCRIPTION
### FIXES https://github.com/ManageIQ/manageiq-ui-classic/issues/2216
Fields based on which can be sorted out no longer multiply after clicking on pagination, sort etc.

#### Before
![screenshot from 2017-10-16 16-27-13](https://user-images.githubusercontent.com/3439771/31617211-f279e2ae-b28e-11e7-98f2-cb6cac791eb6.png)

#### After
![screenshot from 2017-10-16 16-26-05](https://user-images.githubusercontent.com/3439771/31617098-bcb08204-b28e-11e7-9b02-30154e385334.png)
