### PR TITLE
Don't rely on the selected binding when reloading with preselect 🦆

### DIFF
--- a/src/tree-view/treeViewComponent.ts
+++ b/src/tree-view/treeViewComponent.ts
@@ -78,7 +78,7 @@ export class TreeViewController {
       this.tree = this.element.treeview(true);
 
       // Initial node selection right after rendering
-      if (this.selected) {
+      if (this.selected && this.tree.getSelected().length === 0) {
         this.selectNode(this.selected);
       }
 


### PR DESCRIPTION
This is a "hack" until we drop the jQuery calls from MIQ which can select nodes outside the angular's scope. It's ugly, it's not a thing we want but there's no better fix :cry: 

🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆
https://bugzilla.redhat.com/show_bug.cgi?id=1500176