### PR TITLE
Introduce targeted auto refresh logic alongside cascading logic

### DIFF
--- a/demo/data/dialog-data-refresh.json
+++ b/demo/data/dialog-data-refresh.json
@@ -130,6 +130,7 @@
                       "name": "option_1_vm_name",
                       "display": "edit",
                       "display_method_options": {},
+                      "dialog_field_responders": ["tag_1_function"],
                       "required": true,
                       "required_method_options": {},
                       "default_value": "",
@@ -261,7 +262,6 @@
                       "display": "edit",
                       "display_method_options": {},
                       "required": true,
-                      "auto_refresh": true,
                       "required_method_options": {},
                       "values": [
                         [

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -60,8 +60,9 @@ describe('Dialog test', () =>  {
         dialogCtrl.$onInit();
       });
     });
-    it('should have 1 refreshable field', () => {
-        expect(dialogCtrl.refreshableFields.length).toBe(1);
+
+    it('sets up the field associations', () => {
+        expect(dialogCtrl.fieldAssociations["option_1_vm_name"]).toEqual(["tag_1_function"]);
     });
   });
 });


### PR DESCRIPTION
Previously, we had to iterate through the list of refreshable fields and determine which was next to be refreshed, then queuing up requests for each field one after another.

After this change, if the dialog field has responders on it, it will use those instead of relying on the auto refresh logic. This is because right now in the ops UI, dialog fields can be edited either in the old editor or the new editor, and field responders can only be set in the new editor.

https://www.pivotaltracker.com/story/show/149808445

/cc @gmcculloug

@miq-bot add_label enhancement

@chalettu Can you review, please?