### PR TITLE
Remove name -> id translation as it is done in ui-classic now

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -39,14 +39,6 @@ class ModalController {
       if (elem.type === 'field') {
         this.modalData.dynamicFieldList = this.DialogEditor.getDynamicFields(this.modalData.id);
 
-        const dialogFieldResponderIds = _.map(this.modalData.dynamicFieldList, (field) => {
-          if (_.includes(this.modalData.dialog_field_responders, field['name'])) {
-            return field['id'];
-          }
-        });
-
-        this.modalData.dialog_field_responders = dialogFieldResponderIds;
-
         // load categories from API, if the field is Tag Control
         if (this.modalData.type === 'DialogFieldTagControl') {
           this.resolveCategories().then(


### PR DESCRIPTION
This has a change that is needed in order to be able to edit the field associations in the editor properly. UI-classic PR that contains the necessary code: https://github.com/ManageIQ/manageiq-ui-classic/pull/2067/files#diff-7f0e7be06cf6602a0477d7092bce6ad2R28

https://www.pivotaltracker.com/story/show/149808445

@romanblanco Can you take a look at this and the corresponding part in ui-classic to make sure I'm not missing anything?

@chriskacerguis This will need to be merged around the same time as the ui-classic PR otherwise I'd expect some strange behavior.

@miq-bot add_label enhancement
@miq-bot assign @chriskacerguis 