### PR TITLE
Disable the Apply button in the fonticon picker when necessary

### DIFF
--- a/src/fonticon-picker/components/fonticon-picker/fonticon-modal.html
+++ b/src/fonticon-picker/components/fonticon-picker/fonticon-modal.html
@@ -15,6 +15,6 @@
   </uib-tabset>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-primary" ng-click="$ctrl.parent.closeModal(true);" translate>Apply</button>
+  <button class="btn btn-primary" ng-click="$ctrl.parent.closeModal(true);" ng-disabled="$ctrl.parent.isDisabled();" translate>Apply</button>
   <button class="btn btn-default" ng-click="$ctrl.parent.closeModal(false);" translate>Close</button>
 </div>

--- a/src/fonticon-picker/components/fonticon-picker/fonticonPickerComponent.ts
+++ b/src/fonticon-picker/components/fonticon-picker/fonticonPickerComponent.ts
@@ -48,6 +48,10 @@ export class FonticonPickerController {
   public markToSelect(icon) {
     this.toSelect = icon;
   }
+
+  public isDisabled(): boolean {
+    return !this.toSelect || this.toSelect === this.selected;
+  }
 }
 
 export default class FonticonPicker implements ng.IComponentOptions {


### PR DESCRIPTION
According to the BZ below, the `Apply` button needs to be disabled when:
* There is no fonticon selected in the modal
* There are no changes against the previous selection

@miq-bot add_label bug

https://bugzilla.redhat.com/show_bug.cgi?id=1501247