### PR TITLE
Allow three types of nodeIcons in the order: picture > icon > image

### DIFF
--- a/demo/data/data-table.json
+++ b/demo/data/data-table.json
@@ -41,7 +41,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
+            "image": "assets/100/vendor-hawkular.png",
             "icon": "fa fa-exchange"
           },
           {
@@ -63,8 +63,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
-            "icon": "fa fa-exchange"
+            "image": "assets/100/vendor-hawkular.png"
           },
           {
             "text": "JMS Queue [DLQ]"
@@ -85,7 +84,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
+            "picture": "assets/100/vendor-hawkular.png",
             "icon": "fa fa-exchange"
           },
           {
@@ -107,7 +106,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
+            "image": "assets/100/vendor-hawkular.png",
             "icon": "fa fa-exchange"
           },
           {
@@ -129,7 +128,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
+            "image": "assets/100/vendor-hawkular.png",
             "icon": "fa fa-exchange"
           },
           {
@@ -151,7 +150,7 @@
           },
           {
             "title": "View this item",
-            "image": "100/middleware_messaging.png",
+            "image": "assets/100/vendor-hawkular.png",
             "icon": "fa fa-exchange"
           },
           {

--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -44,13 +44,13 @@
                value="{{row.id}}"
                ng-checked="row.checked"
                class="list-grid-checkbox">
-        <i ng-if="tableCtrl.hasIcon(row, columnKey)"
+        <i ng-if="tableCtrl.getNodeIconType(row, columnKey) === 'icon'"
            class="{{row.cells[columnKey].icon}}"
            title="{{row.cells[columnKey].title}}">
           <i ng-if="row.cells[columnKey].icon2" ng-class="row.cells[columnKey].icon2"></i>
         </i>
-        <img ng-if="!tableCtrl.hasIcon(row, columnKey) && tableCtrl.hasImage(row, columnKey)"
-             ng-src="{{row.img_url}}"
+        <img ng-if="['picture', 'image'].includes(tableCtrl.getNodeIconType(row, columnKey))"
+             ng-src="{{row.cells[columnKey].picture || row.cells[columnKey].image}}"
              alt="{{row.cells[columnKey].title}}"
              title="{{row.cells[columnKey].title}}" />
         <span ng-if="row.cells[columnKey].text && !row.cells[columnKey].is_button">

--- a/src/gtl/components/data-table/dataTableComponent.spec.ts
+++ b/src/gtl/components/data-table/dataTableComponent.spec.ts
@@ -14,7 +14,13 @@ describe('DataTable test', () =>  {
     {
       id: 3,
       cells: [
-        {is_checkbox: true}, {image: 'some_url.jpg', icon: 'fa fa-icon'}, {text: 'second name'}, {text: 'value 2'}
+        {is_checkbox: true}, {image: 'some_url.jpg'}, {text: 'second name'}, {text: 'value 2'}
+      ]
+    },
+    {
+      id: 4,
+      cells: [
+        {is_checkbox: true}, {picture: 'some_url.jpg', icon: 'fa fa-icon'}, {text: 'second name'}, {text: 'value 2'}
       ]
     }
   ];
@@ -88,14 +94,16 @@ describe('DataTable test', () =>  {
       ).toBeTruthy();
     });
 
-    it('should check if column has an icon', () => {
-      expect(dataTableCtrl.hasIcon(rows[0], 1)).toBeTruthy();
-      expect(dataTableCtrl.hasIcon(rows[0], 2)).toBeFalsy();
+    it('should check if column renders an icon', () => {
+      expect(dataTableCtrl.getNodeIconType(rows[0], 1)).toEqual('icon');
     });
 
-    it('should check if column has an image', () => {
-      expect(dataTableCtrl.hasImage(rows[0], 1)).toBeTruthy();
-      expect(dataTableCtrl.hasImage(rows[0], 2)).toBeFalsy();
+    it('should check if column renders an image', () => {
+      expect(dataTableCtrl.getNodeIconType(rows[1], 1)).toEqual('image');
+    });
+
+    it('should check if column renders a picture', () => {
+      expect(dataTableCtrl.getNodeIconType(rows[2], 1)).toEqual('picture');
     });
 
     it('should check if filtered by column', () => {

--- a/src/gtl/components/data-table/dataTableComponent.ts
+++ b/src/gtl/components/data-table/dataTableComponent.ts
@@ -49,12 +49,24 @@ export class DataTableController extends DataViewClass implements IDataTableBind
   }
 
   /**
+   * Public method for retrieving what icon type should be displayed
+   * @memberof DataTableController
+   * @function getNodeIconType
+   * @param row {object} whole row with data.
+   * @param columnKey header column key.
+   * @returns {string} picture | icon | image
+   */
+  public getNodeIconType(row, columnKey) {
+    const allowedGraphics = ['picture', 'icon', 'image'];
+    if (row && row.cells) {
+      return allowedGraphics.find(item => row.cells[columnKey].hasOwnProperty(item) && !!row.cells[columnKey][item]);
+    }
+  }
+
+  /**
    * Public method for checking if column of table has an icon.
    * @memberof DataTableController
    * @function hasIcon
-   * @param row {object} whole row with data.
-   * @param columnKey header column key.
-   * @returns {boolean} true | false, if column has icon or not.
    */
   public hasIcon(row, columnKey): boolean {
     return row && row.cells && row.cells[columnKey].hasOwnProperty('icon') && row.cells[columnKey].icon;


### PR DESCRIPTION
For now we have two types of node images in GTL list views: fonticons and fileicons. The priority is always fonticons first, however, sometimes we have custom uploaded pictures and they should be favored even over fonticons.

My solution is to introduce the new picture type with the highest priority. This will be sent for some nodes only and it should not affect the behavior of screens where there are no custom uploaded pictures. I also dropped the `hasImage` and `hasIcon` functions and introduced `getNodeIconType` that returns with the node image type that should be displayed. Tests and examples have been also adjusted.

There is also a [ui-classic PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/2573) that updates `report_data` to provide the `picture` attribute when necessary but it's not necessary to merge before this one.

https://bugzilla.redhat.com/show_bug.cgi?id=1487056