### PR TITLE
Removed obsolete ng-if that made the name field disappear

### DIFF
--- a/src/dialog-editor/components/modal-field/field.html
+++ b/src/dialog-editor/components/modal-field/field.html
@@ -27,8 +27,7 @@
         <input id="label" name="label"
                ng-model="vm.modalData.label" type="text" required/>
       </div>
-      <div ng-if="vm.element === 'field'"
-           pf-form-group
+      <div pf-form-group
            pf-label="{{'Name'|translate}}" required>
         <input id="name" name="name"
                ng-model="vm.modalData.name" type="text" required/>


### PR DESCRIPTION
A mistake caused by rewriting modal. After this change, the `name` field should be available again.


![screenshot from 2017-11-01 14-27-37](https://user-images.githubusercontent.com/1187051/32276882-df6111ae-bf10-11e7-97f3-7630457bb2cc.png)
