### PR TITLE
When settings of pagination changes, set isChecked to false

### DIFF
--- a/src/gtl/components/pagination/pagination.html
+++ b/src/gtl/components/pagination/pagination.html
@@ -5,8 +5,8 @@
     <span class="checkbox span-right-border" style="margin: 0 0 0 5px">
       <label class="checkbox-inline">
         <input type="checkbox"
-               ng-model="isChecked"
-               ng-click="paginationCtrl.onSelectAll({isSelected: isChecked})"
+               ng-model="paginationCtrl.isChecked"
+               ng-click="paginationCtrl.onSelectAll({isSelected: paginationCtrl.isChecked})"
                title="{{paginationCtrl.settings.selectAllTitle}}" />
         {{paginationCtrl.settings.selectAllTitle}}
       </label>

--- a/src/gtl/components/pagination/paginationComponent.spec.ts
+++ b/src/gtl/components/pagination/paginationComponent.spec.ts
@@ -160,6 +160,16 @@ describe('Pagination test', () =>  {
         perPageOptions[1].click();
         expect(onChangePerPage).toHaveBeenCalledWith(perPage.items[1]);
       });
+
+      it('changing settings to uncheck all items', () => {
+        let selectAll = compiledElement[0].querySelectorAll('input[type="checkbox"][title="Select All"]');
+        selectAll[0].click();
+        expect(selectAll[0].checked).toBeTruthy();
+        settings.current = 2;
+        scope.settings = {...settings};
+        scope.$digest();
+        expect(selectAll[0].checked).toBeFalsy();
+      });
     });
   });
 });

--- a/src/gtl/components/pagination/paginationComponent.ts
+++ b/src/gtl/components/pagination/paginationComponent.ts
@@ -5,10 +5,19 @@
  * @name PaginationController
  */
 export class PaginationController {
+  public isChecked: boolean = false;
+  public settings: any;
+
   public onSelectAll: (args: {isSelected: boolean}) => void;
   public onChangeSort: (args: {sortId: number, isAscending: boolean}) => void;
   public onChangePage: (args: {pageNumber: number}) => void;
   public onChangePerPage: (args: {item: number}) => void;
+
+  public $onChanges(changesObj) {
+    if (changesObj.settings && this.settings) {
+      this.isChecked = false;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
### Fixes select all constantly checked when pagination change
Whenever pagination changes (sort order, sort by, number of items etc.) select all stays selected no matter what. With this PR when performing such actions select all will be deselected.

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1501196