### PR TITLE
Change ng-if to ng-show for visibility dialogField property

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -1,4 +1,4 @@
-<div ng-if="vm.dialogField.visible"
+<div ng-show="vm.dialogField.visible"
      class="form-group"
      ng-class="{'has-error': vm.dialogField.fieldValidation===false}">
   <div class="col-md-2 col-lg-4 col-xl-2 col-sm-2 dialog-label">


### PR DESCRIPTION
I think this was an oversight by @chalettu, we still need invisible fields to be there in the data, but the visible flag is just so that they aren't actually shown to the end user. They still need to be rendered in HTML so that their values are stored in the data structure and sent to the API when the user submits the form.

@mkanoor This should fix the issue you found with visible fields.

@miq-bot assign @chriskacerguis 