### PR TITLE
Add es7-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "angular-ui-sortable": "^0.16.1",
     "babel-eslint": "^7.2.3",
     "es6-shim": "^0.35.3",
+    "es7-shim": "^6.0.0",
     "eslint": "~3.9.1"
   }
 }

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -1,4 +1,5 @@
 import 'es6-shim';
+import 'es7-shim';
 import 'jquery';
 import 'jquery-ui-bundle';
 import 'bootstrap-switch';


### PR DESCRIPTION
Array.includes is still not supported by IE10/11 (and PhantomJS)

That breaks specs in #209.

Adding es7-shim too.

Cc @romanblanco 