### PR TITLE
Ensure refresh button works and calls a single refresh for dialog fields

### DIFF
--- a/src/dialog-user/components/dialog-user/dialog.html
+++ b/src/dialog-user/components/dialog-user/dialog.html
@@ -17,7 +17,7 @@
               </div>
               <div class="panel-body">
                 <div ng-repeat="field in buttonGroup.dialog_fields">
-                  <dialog-field on-update="vm.updateDialogField(dialogFieldName, value)" single-refresh="vm.refreshSingleField(dialogFieldName)" field="vm.dialogFields[field.name]" input-disabled="vm.inputDisabled"></dialog-field>
+                  <dialog-field on-update="vm.updateDialogField(dialogFieldName, value)" single-refresh="vm.refreshSingleField(field)" field="vm.dialogFields[field.name]" input-disabled="vm.inputDisabled"></dialog-field>
                 </div>
               </div>
             </div>

--- a/src/dialog-user/components/dialog-user/dialog.html
+++ b/src/dialog-user/components/dialog-user/dialog.html
@@ -17,7 +17,7 @@
               </div>
               <div class="panel-body">
                 <div ng-repeat="field in buttonGroup.dialog_fields">
-                  <dialog-field on-update="vm.updateDialogField(dialogFieldName, value)" field="vm.dialogFields[field.name]" input-disabled="vm.inputDisabled"></dialog-field>
+                  <dialog-field on-update="vm.updateDialogField(dialogFieldName, value)" single-refresh="vm.refreshSingleField(dialogFieldName)" field="vm.dialogFields[field.name]" input-disabled="vm.inputDisabled"></dialog-field>
                 </div>
               </div>
             </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -153,7 +153,7 @@
           ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
       <button type="button"
               class="btn"
-              ng-click="vm.dialogField.changesHappened()" translate>
+              ng-click="vm.refreshSingleField()" translate>
         Refresh
       </button>
     </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -157,7 +157,7 @@
         Refresh
       </button>
     </div>
-      <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
-        <div class="spinner spinner-xs spinner-inline"></div>
+    <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
+      <div class="spinner spinner-xs spinner-inline"></div>
     </div>
  </div>

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -80,6 +80,11 @@ export class DialogFieldController extends DialogFieldClass {
     this.dialogField.errorMessage = validation.message;
     return validation;
   }
+
+  public refreshSingleField() {
+    this.field.fieldBeingRefreshed = true;
+    this.singleRefresh({ dialogFieldName: this.field.name });
+  }
 }
 
 export default class DialogField {
@@ -91,6 +96,7 @@ export default class DialogField {
   public bindings: any = {
     field: '<',
     onUpdate: '&',
+    singleRefresh: '&',
     options: '=?',
     inputDisabled: '=?'
   };

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -82,8 +82,7 @@ export class DialogFieldController extends DialogFieldClass {
   }
 
   public refreshSingleField() {
-    this.field.fieldBeingRefreshed = true;
-    this.singleRefresh({ dialogFieldName: this.field.name });
+    this.singleRefresh({ field: this.field.name });
   }
 }
 

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -1,4 +1,3 @@
-
 describe('Dialog test', () =>  {
   let bindings;
   const dialogFile = require('../../../../demo/data/dialog-data.json');
@@ -63,6 +62,43 @@ describe('Dialog test', () =>  {
 
     it('sets up the field associations', () => {
         expect(dialogCtrl.fieldAssociations['option_1_vm_name']).toEqual(['tag_1_function']);
+    });
+  });
+
+  describe('#refreshSingleField', () => {
+    let dialogCtrl;
+    let refreshField;
+    const dialogRefreshFile = require('../../../../demo/data/dialog-data-refresh.json');
+    const dialogData = dialogRefreshFile.resources[0].content[0];
+
+    beforeEach(() => {
+      refreshField = {
+        callback: function(value) { }
+      };
+      spyOn(refreshField, 'callback');
+      let bindings = {
+        dialog: dialogData,
+        refreshField: refreshField,
+        onUpdate: () => true,
+        inputDisabled: false
+      };
+      angular.mock.module('miqStaticAssets.dialogUser');
+      angular.mock.inject($componentController =>  {
+        dialogCtrl = $componentController('dialogUser', null, bindings);
+        dialogCtrl.$onInit();
+      });
+    });
+
+    it('returns a promise', () => {
+      let testPromise = new Promise((resolve, reject) => {});
+      expect(dialogCtrl.refreshSingleField('service_name')).toEqual(testPromise);
+    });
+
+    it('makes the callback to refreshField', () => {
+      let promise = dialogCtrl.refreshSingleField('service_name');
+      promise.then(() => {
+        expect(refreshField.callback).toHaveBeenCalledWith({field: dialogData['service_name']});
+      });
     });
   });
 });

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -213,7 +213,7 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
         if (! _.isEmpty(this.fieldAssociations[field])) {
           this.updateTargetedFieldsFrom(field);
-        } else {
+        } else if (this.refreshRequestCount === 0) {
           this.areFieldsBeingRefreshed = false;
         }
 

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -103,10 +103,8 @@ export class DialogUserController extends DialogClass implements IDialogs {
     this.dialogFields[dialogFieldName].default_value = value;
     this.dialogValues[dialogFieldName] = value;
     this.saveDialogData();
-    if (this.fieldAssociations !== {}) {
-      if (this.fieldAssociations[dialogFieldName] !== []) {
-        this.updateTargetedFieldsFrom(dialogFieldName);
-      }
+    if (!_.isEmpty(this.fieldAssociations) && this.fieldAssociations[dialogFieldName].length > 0) {
+      this.updateTargetedFieldsFrom(dialogFieldName);
     } else {
       const refreshable = _.indexOf(this.refreshableFields, dialogFieldName);
       if (refreshable > -1  && !this.areFieldsBeingRefreshed) {
@@ -169,6 +167,25 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
         this.areFieldsBeingRefreshed = false;
       });
+    });
+  }
+
+  public refreshSingleField(field): void {
+    this.areFieldsBeingRefreshed = true;
+
+    this.refreshField({ field: this.dialogFields[field] }).then((data) => {
+      this.dialogFields[field] = this.updateDialogFieldData(field, data);
+      this.dialogValues[field] = data.values;
+      this.dialogFields[field].fieldBeingRefreshed = false;
+
+      this.saveDialogData();
+      this.$scope.$apply();
+
+      if (! _.isEmpty(this.fieldAssociations[field])) {
+        this.updateTargetedFieldsFrom(field);
+      }
+
+      this.areFieldsBeingRefreshed = false;
     });
   }
 

--- a/src/dialog-user/interfaces/abstractDialogFieldClass.ts
+++ b/src/dialog-user/interfaces/abstractDialogFieldClass.ts
@@ -8,6 +8,7 @@ export abstract class DialogFieldClass {
 
   public field: any;
   public onUpdate: any;
+  public singleRefresh: any;
   public options: any;
   public inputDisabled: boolean;
     /*@ngInject*/


### PR DESCRIPTION
The refresh button wasn't really doing anything before, because it was trying to call a `changesHappened` method which actually didn't exist, but even if it did `changesHappened` was the incorrect thing to call. WIP for now as I need to add some specs and address a strange issue I found when I tried to refactor and it ended up breaking.

https://bugzilla.redhat.com/show_bug.cgi?id=1513162

@miq-bot add_label gaprindashvili/yes