### PR TITLE
Added 'Load values on init' option for dynamic dropdown field

### DIFF
--- a/src/dialog-editor/components/modal-field-template/drop-down-list.html
+++ b/src/dialog-editor/components/modal-field-template/drop-down-list.html
@@ -99,6 +99,13 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate }}"/>
       </div>
+      <div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.load_values_on_init"
+               type="checkbox"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate }}"/>
+      </div>
       <div pf-form-group pf-label="{{'Required'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.required"


### PR DESCRIPTION
The switch should be visible for dynamic dropdown field, and only when the “show refresh button” checkbox is checked:

![screencast from 2017-12-13 14-58-56](https://user-images.githubusercontent.com/1187051/33942443-399bc76a-e016-11e7-9c8f-484f21f83a02.gif)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1514584

@karelhala @eclarizio 
