### PR TITLE
Test for presence of 'validator_rule' instead of testing 'validator_type'

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -118,7 +118,7 @@ export default class DialogDataService {
       }
     }
     // Run check if someone has specified a regex.  Make sure if its required it is not blank
-    if (field.validator_type === 'regex' && validation.isValid === true) {
+    if (field.validator_rule && validation.isValid === true) {
       if (angular.isDefined(fieldValue) && fieldValue !== '') {
         // This use case ensures that an optional field doesnt check a regex if field is blank
         const regexPattern = field.validator_rule.replace(/\\A/i, '^').replace(/\\Z/i,'$');


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518971

Instead of testing for value of `validator_type`, test for presence of the attribute that actually has the validation rules.

/cc @chalettu 