### PR TITLE
Allow the attribute to be edited in the original scope

### DIFF
--- a/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
+++ b/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
@@ -54,6 +54,6 @@ export default class ModalFieldTemplate {
     treeSelectorData: '<',
     treeSelectorToggle: '<',
     treeSelectorShow: '<',
-    treeSelectorIncludeDomain: '<',
+    treeSelectorIncludeDomain: '=',
   };
 }

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -315,7 +315,7 @@ export default class Modal {
     treeSelectorData: '<',
     treeSelectorToggle: '<',
     treeSelectorShow: '<',
-    treeSelectorIncludeDomain: '<',
+    treeSelectorIncludeDomain: '=',
     modalOptions: '<',
     visible: '<',
     elementInfo: '<'


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518506

The value edited by bootstrap switch was changed in different scope, so the value of `treeSelectorIncludeDomain` in the original scope was still set on `false`.

Making the both-ways binding should fix the issue.

cc/ @h-kataria 