### PR TITLE
Enable loading of SVGs with file loader so we can use them in styles

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -37,3 +37,4 @@ vendor.css
 *.iml
 
 coverage
+!dist/*.svg

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "!dist/*",
     "!dist/js/*",
     "!dist/css/*",
+    "!dist/*.svg",
     "!LICENSE",
     "!README.md"
   ],

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -107,8 +107,9 @@ class BoxController {
    * @param {number} ui jQuery object
    */
   public droppableOptions(e: any, ui: any) {
-    let droppedItem: any = ng.element(e.target).scope().dndDragItem;
-    let droppedPlace: any = ng.element(e.target).scope().box;
+    let targetScope: any = ng.element(e.target).scope();
+    let droppedItem: any = targetScope.dndDragItem;
+    let droppedPlace: any = targetScope.box;
     // update name for the dropped field
     this.updateFieldName(droppedItem);
     // update indexes of other boxes after changing their order

--- a/src/styles/helpers.scss
+++ b/src/styles/helpers.scss
@@ -1,0 +1,4 @@
+// Helper functions for loading images from the src/images folder
+@function uic-image-url($path) {
+  @return url('./../images/#{$path}')
+}

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -2,6 +2,7 @@
 @import 'dialog-editor';
 @import 'dialog-editor-toolbox';
 @import 'dialog-editor-boxes';
+@import 'helpers';
 
 .miq-sand-paper, .miq-sand-paper > div { /* emulates "cards-pf" background color */
   background: #f5f5f5;
@@ -34,7 +35,7 @@
 
 .miq-custom-html {
   .form-group.text, .form-group.has-clear {
-    padding-right: 20px; 
+    padding-right: 20px;
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,8 @@ module.exports = {
           loader: 'css-loader!sass-loader'
         }
       )},
-      {test: /\.(png|jpg|gif|svg|woff|ttf|eot)/, loader:  'url-loader?limit=20480'},
+      {test: /images.*\.svg/, loader:  'file-loader', options: {name: './[hash].[ext]'}},
+      {test: /\.(png|jpg|gif|woff|ttf|eot)/, loader: 'url-loader?limit=20480'},
       {test: /\.json$/,  loader: 'json-loader'}
     ]
   },


### PR DESCRIPTION
### Enables using svgs as background images in styles
To use this just create any svg file inside css folder. Load such file as `background-image` for some class and use such class for any element.

```sass
.some-class {
  background-image: @uic-image-url('someimage.svg')
}
```

```html
<some-element>
  <div class="some-class"></div>
</some-element>
```

**important**
File has to be placed in `src/images` folder.
  