### PR TITLE
Fix assumption that all field.values are objects

### DIFF
--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -62,6 +62,54 @@ describe('DialogEditor test', () => {
       dialogEditor.setData(dialogData);
     });
 
+    describe('when the values on a field are a string', () => {
+      let dialogData = {
+        content: [{
+          dialog_tabs: [{
+            dialog_groups: [{
+              dialog_fields: [{
+                values: 'nofailure'
+              }]
+            }]
+          }]
+        }]
+      };
+
+      beforeEach(() => {
+        dialogEditor.setData(dialogData);
+      });
+
+      it('sets all of the field values correctly', () => {
+        dialogEditor.getDialogTabs();
+        let fieldValues = dialogEditor.data.content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].values;
+        expect(fieldValues).toEqual('nofailure');
+      });
+    });
+
+    describe('when the values on a field are an object', () => {
+      let dialogData = {
+        content: [{
+          dialog_tabs: [{
+            dialog_groups: [{
+              dialog_fields: [{
+                values: ['0', 'zero']
+              }]
+            }]
+          }]
+        }]
+      };
+
+      beforeEach(() => {
+        dialogEditor.setData(dialogData);
+      });
+
+      it('sets all of the field values based on a filter', () => {
+        dialogEditor.getDialogTabs();
+        let fieldValues = dialogEditor.data.content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].values;
+        expect(fieldValues).toEqual(['zero']);
+      });
+    });
+
     it('returns the dialog_tabs of the dialog', () => {
       expect(dialogEditor.getDialogTabs()).toEqual('dialog_tabs');
     });

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -48,7 +48,9 @@ export default class DialogEditorService {
    */
   public getDialogTabs() {
     this.forEachDialogField((field: any) => {
-      field.values = field.values.filter(value => value[0] && value[1]);
+      if (field.hasOwnProperty('values') && _.isArray(field.values)) {
+        field.values = field.values.filter(value => value[0] && value[1]);
+      }
     });
     return this.data.content[0].dialog_tabs;
   }


### PR DESCRIPTION
This got changed back in https://github.com/ManageIQ/ui-components/pull/223, but it makes it so that when you try to edit anything other than drop down or radio button fields (the ones that use objects for their values), it attempts to call `.filter` on a string and ends up blowing up silently in JS with you unable to edit your fields.

@romanblanco @martinpovolny please review

@miq-bot add_label gaprindashvili/yes