### PR TITLE
Use '.name' instead of '.id' for refresh field list

### DIFF
--- a/src/dialog-editor/components/modal-field-template/check-box.html
+++ b/src/dialog-editor/components/modal-field-template/check-box.html
@@ -29,12 +29,9 @@
              switch-on-text="{{'Yes'|translate}}"
              switch-off-text="{{'No'|translate}}">
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -62,12 +59,9 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate}}">
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">

--- a/src/dialog-editor/components/modal-field-template/date-time-control.html
+++ b/src/dialog-editor/components/modal-field-template/date-time-control.html
@@ -21,12 +21,9 @@
              switch-on-text="{{'Yes'|translate}}"
              switch-off-text="{{'No'|translate}}">
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -54,12 +51,9 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate}}">
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">

--- a/src/dialog-editor/components/modal-field-template/drop-down-list.html
+++ b/src/dialog-editor/components/modal-field-template/drop-down-list.html
@@ -82,12 +82,9 @@
       </div>
       <a ng-click='vm.addEntry()'><i class='pficon-add-circle-o'></i></a>
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -135,12 +132,9 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate}}">
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">

--- a/src/dialog-editor/components/modal-field-template/fields-to-refresh.html
+++ b/src/dialog-editor/components/modal-field-template/fields-to-refresh.html
@@ -1,0 +1,8 @@
+<div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
+  <select class="form-control"
+          ng-model="vm.modalData.dialog_field_responders"
+          ng-options="dynamicField.name as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
+          multiple
+          pf-select>
+  </select>
+</div>

--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -57,12 +57,9 @@
       </div>
       <a ng-click='vm.addEntry()'><i class='pficon-add-circle-o'></i></a>
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -96,12 +93,9 @@
           <option selected="selected" value="string" translate>String</option>
         </select>
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">

--- a/src/dialog-editor/components/modal-field-template/tag-control.html
+++ b/src/dialog-editor/components/modal-field-template/tag-control.html
@@ -63,11 +63,8 @@
                ng-model="entry.description" type="text" placeholder="Key" readonly/>
       </div>
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>

--- a/src/dialog-editor/components/modal-field-template/text-area-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-area-box.html
@@ -31,12 +31,9 @@
       <input id="validator_rule" name="validator_rule"
              ng-model="vm.modalData.validator_rule"/>
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -68,12 +65,9 @@
         <input id="validator_rule" name="validator_rule"
                ng-model="vm.modalData.validator_rule"/>
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -43,12 +43,9 @@
       <input id="validator_rule" name="validator_rule"
               ng-model="vm.modalData.validator_rule"/>
     </div>
-    <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-      <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-              ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-              multiple pf-select>
-      </select>
-    </div>
+    <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                        modal-data="vm.modalData">
+    </dialog-editor-modal-field-template>
   </form>
 </div>
 <div ng-if="vm.modalTabIsSet('options') && vm.modalData.dynamic">
@@ -93,12 +90,9 @@
         <input id="validator_rule" name="validator_rule"
                ng-model="vm.modalData.validator_rule"/>
       </div>
-      <div pf-form-group pf-label="{{'Fields to refresh'|translate}}">
-        <select class="form-control" ng-model="vm.modalData.dialog_field_responders"
-                ng-options="dynamicField.id as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
-                multiple pf-select>
-        </select>
-      </div>
+      <dialog-editor-modal-field-template template="fields-to-refresh.html"
+                                          modal-data="vm.modalData">
+      </dialog-editor-modal-field-template>
     </div>
     <div ng-show="vm.treeSelectorShow">
       <div class="pull-right">


### PR DESCRIPTION
The problem is that when creating or editing dialogs, if you add a new field, the field is not saved before the associations are created, and so there is no id to send up. Therefore we have to send up the name and have the backend handle the association creation by name instead.

This will need to be combined with [this main repo PR](https://github.com/ManageIQ/manageiq/pull/16753) in order to fully fix the bug.

https://bugzilla.redhat.com/show_bug.cgi?id=1518942

@miq-bot add_label gaprindashvili/yes, bug

@romanblanco @himdel Please review
  