### PR TITLE
Update field name only when the field (not a box) is dropped

### DIFF
--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -110,7 +110,9 @@ class BoxController {
     let droppedItem: any = ng.element(e.target).scope().dndDragItem;
     let droppedPlace: any = ng.element(e.target).scope().box;
     // update name for the dropped field
-    this.updateFieldName(droppedItem);
+    if (!_.isEmpty(droppedItem)) {
+      this.updateFieldName(droppedItem);
+    }
     // update indexes of other boxes after changing their order
     this.DialogEditor.updatePositions(
       droppedPlace.dialog_fields

--- a/src/dialog-editor/components/box/boxComponent.ts
+++ b/src/dialog-editor/components/box/boxComponent.ts
@@ -107,8 +107,9 @@ class BoxController {
    * @param {number} ui jQuery object
    */
   public droppableOptions(e: any, ui: any) {
-    let droppedItem: any = ng.element(e.target).scope().dndDragItem;
-    let droppedPlace: any = ng.element(e.target).scope().box;
+    const elementScope: any = ng.element(e.target).scope();
+    let droppedItem: any = elementScope.dndDragItem;
+    let droppedPlace: any = elementScope.box;
     // update name for the dropped field
     if (!_.isEmpty(droppedItem)) {
       this.updateFieldName(droppedItem);


### PR DESCRIPTION
Drag&Drop of a box was causing an error of calling method for `undefined`