### PR TITLE
Validate presence of values for Dropdown list and Radio button

### DIFF
--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -77,7 +77,7 @@ export class ToolboxController {
         'dropdown_list',
         {
           data_type: 'string',
-          values: [],
+          values: [[1, 'One'], [2, 'Two'], [3, 'Three']],
           options: {
             sort_by: 'description',
             sort_order: 'ascending',

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -29,7 +29,11 @@ export default class DialogValidationService {
         field => ({ status: ! _.isEmpty(field.name),
                     errorMessage: __('Dialog element needs to have a name') }),
         field => ({ status: ! _.isEmpty(field.label),
-                    errorMessage: __('Dialog element needs to have a label') })
+                    errorMessage: __('Dialog element needs to have a label') }),
+        field => ({ status: ((field.type === 'DialogFieldDropDownList' ||
+                              field.type === 'DialogFieldRadioButton')
+                             && ! _.isEmpty(field.values)),
+                    errorMessage: __('Dropdown needs to have entries') }),
       ],
     };
   }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1507751

Adding another validation rule to make sure the dialog with dropdown or radio button without values is not sent.

___

One more thing here - I'd expect the same validation to be in the backend, even though normally the user shouldn't be able to send such dialog.

I've checked with @d-m-u and currently, we are setting `[[nil, "<None>"]]` as the initial value ([here](https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog_field_drop_down_list.rb#L16)), and that will stay, if the dialog is submitted with no values.

Is this OK? Or should this be handled differently?

/cc @eclarizio @d-m-u 