### PR TITLE
Fix for inability to change a value in a dialog field's drop down list

### DIFF
--- a/demo/data/dialog-data.json
+++ b/demo/data/dialog-data.json
@@ -48,7 +48,7 @@
                       "display_method_options": {},
                       "required": true,
                       "required_method_options": {},
-                      "default_value": "",
+                      "default_value": "service_default",
                       "values_method_options": {},
                       "options": {
                         "protected": false

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -29,6 +29,11 @@ describe('Dialog test', () =>  {
         dialogCtrl.updateDialogField('service_name', 'Test');
         expect(dialogCtrl.dialogValues['service_name']).toBe('Test');
     });
+    it('does not attempt to alter the default value of a stored dialog field', () => {
+        expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('service_default');
+        dialogCtrl.updateDialogField('service_name', 'Test');
+        expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('service_default');
+    });
     it('should allow properties on a dialog field to be updated', () => {
         const testChanges = {
             data_type: 'string',

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -112,7 +112,6 @@ export class DialogUserController extends DialogClass implements IDialogs {
     if (!_.isEmpty(this.fieldAssociations) && this.fieldAssociations[dialogFieldName].length > 0) {
       this.hasFieldsToUpdate = true;
     }
-    this.dialogFields[dialogFieldName].default_value = value;
     this.dialogValues[dialogFieldName] = value;
     if (this.hasFieldsToUpdate) {
       this.determineRefreshRequestCount(dialogFieldName);


### PR DESCRIPTION
This fix removes the assignment of default_value when updating field values, as it is not necessary since the `ng-model` property on the element already binds to the correct value that gets sent when the submit button is pressed.

Here's a gif of the issue that this fix solves:
![dialog-field-drop-down-broken](https://user-images.githubusercontent.com/164557/35115737-0b1e4cf2-fc3e-11e7-9925-89d31a370c03.gif)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1530319

Thanks @syncrou for helping me debug this one, whew what an adventure!
/cc @gmcculloug

@chalett, @himdel Can you review? I tried to find a reason for the line I deleted but ultimately I don't think we need to assign the `default_value`.