### PR TITLE
Test values only for non-dynamic dropdown and radio button

### DIFF
--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -32,7 +32,7 @@ export default class DialogValidationService {
                     errorMessage: __('Dialog element needs to have a label') }),
         field => ({ status: ! ((field.type === 'DialogFieldDropDownList' ||
                               field.type === 'DialogFieldRadioButton')
-                             && _.isEmpty(field.values)),
+                             && (!field.dynamic && _.isEmpty(field.values))),
                     errorMessage: __('Dropdown needs to have entries') }),
         field => ({ status: ! (field.type === 'DialogFieldTagControl'
                                && field.category_id === ''),


### PR DESCRIPTION
It was not possible to save a dialog that didn't have values, because it was dynamic.

This PR fixes the issue.