### PR TITLE
DialogEditor - getDynamicFields - don't skip fields without id

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -37,7 +37,7 @@ class ModalController {
         _.cloneDeep(elements[elem.type]);
 
       if (elem.type === 'field') {
-        this.modalData.dynamicFieldList = this.DialogEditor.getDynamicFields(this.modalData.id);
+        this.modalData.dynamicFieldList = this.DialogEditor.getDynamicFields(this.modalData.name);
 
         // load categories from API, if the field is Tag Control
         if (this.modalData.type === 'DialogFieldTagControl') {

--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -118,16 +118,19 @@ describe('DialogEditor test', () => {
   describe('#getDynamicFields', () => {
     let field1 = {
       id: 1,
+      name: 'field_1',
       dynamic: true
     };
 
     let field2 = {
       id: 2,
+      name: 'field_2',
       dynamic: true
     };
 
     let field3 = {
       id: 3,
+      name: 'field_3',
       dynamic: false
     };
 
@@ -147,13 +150,13 @@ describe('DialogEditor test', () => {
 
     describe('when the list of dynamic field contains the given field id', () => {
       it('returns the dynamic fields without the given field', () => {
-        expect(dialogEditor.getDynamicFields(2)).toEqual([field1]);
+        expect(dialogEditor.getDynamicFields('field_2')).toEqual([field1]);
       });
     });
 
     describe('when the list of dynamic field does not contain the given field id', () => {
       it('returns the full list of dynamic fields', () => {
-        expect(dialogEditor.getDynamicFields(4)).toEqual([field1, field2]);
+        expect(dialogEditor.getDynamicFields('field_4')).toEqual([field1, field2]);
       });
     });
   });

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -58,7 +58,11 @@ export default class DialogEditorService {
   public getDynamicFields(idToExclude) {
     let dynamicFields = [];
     this.forEachDialogField((field) => {
-      if (field.dynamic === true && field.id !== idToExclude) {
+      if (idToExclude && (field.id === idToExclude)) {
+        return;
+      }
+
+      if (field.dynamic === true) {
         dynamicFields.push(field);
       }
     });

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -55,10 +55,10 @@ export default class DialogEditorService {
     return this.data.content[0].dialog_tabs;
   }
 
-  public getDynamicFields(idToExclude) {
+  public getDynamicFields(nameToExclude) {
     let dynamicFields = [];
     this.forEachDialogField((field) => {
-      if (idToExclude && (field.id === idToExclude)) {
+      if (nameToExclude && (field.name === nameToExclude)) {
         return;
       }
 


### PR DESCRIPTION
Create a new dialog, add a dynamic field, add a non-dynamic field and edit that one.
In the list of fields to refresh, the first field should be visible.

Without this, it's not, because the freshly created field has no id, and passing undefined to `getDynamicFields` would cause it to skip all the fields with undefined id.

..updated to skip undefined
..and changed to use `name` instead of `id` to keep in line with https://github.com/ManageIQ/ui-components/pull/228

(Two-part fix, this PR should go first, so that the [ui-classic PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/3302) can be tested :).)

Cc @romanblanco @eclarizio 

https://bugzilla.redhat.com/show_bug.cgi?id=1536528