### PR TITLE
Mark numeral.js as an external dependency provided by ui-classic

### DIFF
--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -13,3 +13,5 @@ import 'angular-dragdrop';
 import 'angular-bootstrap-switch';
 import 'ui-select';
 import 'patternfly-bootstrap-treeview';
+import * as numeral from 'numeral';
+window['numeral'] = numeral;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,6 +110,7 @@ module.exports = {
   externals: {
     'angular': 'angular',
     'lodash': '_',
+    'numeral': 'numeral',
     '__': '__'
   }
 };

--- a/webpack.vendor.config.js
+++ b/webpack.vendor.config.js
@@ -10,6 +10,7 @@ var webpack = require('webpack'),
         jQuery: "jquery",
         "window.jQuery": "jquery",
         "angular": "angular",
+        "numeral": "numeral",
         "_": "lodash"
       }),
       new ExtractTextPlugin(settings.stylesheetPath)


### PR DESCRIPTION
@karelhala asked @karelhala gets it, we want this as a dependency in ui-classic.