### PR TITLE
Display the dialog's JSON in the dialog editor demo page

### DIFF
--- a/demo/views/dialog/editor.html
+++ b/demo/views/dialog/editor.html
@@ -27,6 +27,7 @@
     <div class="editable-fields-container">
       <dialog-editor-tabs></dialog-editor-tabs>
       <dialog-editor-boxes></dialog-editor-boxes>
+      <pre>{{ vm.DialogEditor.data.content[0] | json }}</pre>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Theoretically if someone would want to replace an old dialog with dialogPlayer + JSON, there is no easy way to create the JSON. This one-liner is to fix this problem!

![screenshot from 2018-02-01 16-44-53](https://user-images.githubusercontent.com/649130/35687718-b88b1820-076f-11e8-815a-36121adbfcdf.png)

@karelhala @himdel @romanblanco 