### PR TITLE
Ensure default value for radio button is rendered properly

### DIFF
--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -66,8 +66,7 @@
         <input type="radio"
                name="{{vm.fieldData.name}}"
                ng-model="vm.fieldData.default_value"
-               ng-checked="vm.fieldData.default_value === option"
-               ng-value="option">
+               ng-value="option[0]">
         {{ option[1] }}
       </label>
     </span>

--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -23,9 +23,9 @@
     </div>
     <div pf-form-group pf-label="{{'Default value'|translate}}">
       <select class="form-control" pf-select
-              ng-model="vm.modalData.default_value"
-              ng-options="entry as entry[0] for entry in vm.modalData.values">
-        <option selected="selected" value="" translate>None</option>
+              ng-model="vm.modalData.default_value">
+        <option value="" translate>None</option>
+        <option ng-repeat="value in vm.modalData.values" value="{{value[1]}}">{{value[0]}}</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">


### PR DESCRIPTION
There was a bug in the way that the default value was being sent to the API in that it was trying to send the full value (so for example ["1", "one"] instead of just "1"). The way that the `ng-checked` property works was also not actually as intended, all that needs to be done is to ensure that `ng-value` and the `ng-model` are equivalent and angular will handle selecting the correct value. The `ng-checked` property is for if you want to send up different data than what is contained in the `ng-value` property. This fixed the actual correct default value showing up in the editor, as seen in the below screenshots:

<img width="318" alt="screen shot 2018-02-05 at 12 11 47 pm" src="https://user-images.githubusercontent.com/164557/35826569-f86323c4-0a6d-11e8-8525-a83da7789d43.png">
<img width="303" alt="screen shot 2018-02-05 at 12 12 43 pm" src="https://user-images.githubusercontent.com/164557/35826568-f84e6dee-0a6d-11e8-8838-b2b4611b8765.png">

The other issue was that the "Nothing selected" value was always selected from the dropdown list when editing the default value for radio buttons, and this has been fixed to show which value is actually the default value:

<img width="477" alt="screen shot 2018-02-05 at 12 11 55 pm" src="https://user-images.githubusercontent.com/164557/35826557-ec6083dc-0a6d-11e8-9003-ef25f148e9db.png">
<img width="478" alt="screen shot 2018-02-05 at 12 12 48 pm" src="https://user-images.githubusercontent.com/164557/35826556-ec4a72ea-0a6d-11e8-8635-38bb3e3a39cc.png">


Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1541988

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @himdel 