### PR TITLE
Fix for different behavior of items in regards to default values

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -45,7 +45,6 @@
               ng-change="vm.changesHappened()"
               type="checkbox"
               uib-tooltip="{{ ::inputTitle }}"
-              ng-checked="vm.dialogField.default_value == 't'"
               id="{{ vm.dialogField.name }}">
         <div ng-if="vm.dialogField.fieldValidation===false">{{vm.dialogField.errorMessage}}</div>
       </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -144,7 +144,7 @@
           </p>
         </div>
         <div class="col-sm-6">
-          <uib-timepicker ng-model="vm.dialogField.default_value"></uib-timepicker>
+          <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
         </div>
       </div>
       <span ng-switch-default ng-hide="true"></span>

--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -59,7 +59,7 @@ describe('DialogDataService test', () => {
       let testDefault = dialogData.setDefaultValue(testField);
       expect(testDefault).toBe('test');
     });
-    it('should ensure a checkbox uses value that is set', () => {
+    it('should ensure a checkbox uses default value that is set', () => {
       let testField = {
         default_value: 'f',
         values: 't',
@@ -67,7 +67,7 @@ describe('DialogDataService test', () => {
         type: 'DialogFieldCheckBox'
       };
       let testDefault = dialogData.setDefaultValue(testField);
-      expect(testDefault).toBe('t');
+      expect(testDefault).toBe('f');
     });
     it('should prevent a form from being valid if drop down no option is selected', () => {
       const testDropDown = {

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -84,9 +84,6 @@ export default class DialogDataService {
     if (data.default_value) {
       defaultValue = data.default_value;
     }
-    if(data.type === 'DialogFieldCheckBox' && data.values !== data.default_value) {
-      defaultValue = data.values;
-    }
     if (data.data_type === 'integer') {
       defaultValue = parseInt(data.default_value, 10);
     }


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/3371

This should fix the issue with the timepicker not being visible in the service UI, and also fixes another issue I found with the checkbox not displaying the correct default value on the initial load of ordering the service.

https://bugzilla.redhat.com/show_bug.cgi?id=1540273

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @himdel 