### PR TITLE
Corrected type for initial values

### DIFF
--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -25,7 +25,7 @@
       <select class="form-control" pf-select
               ng-model="vm.modalData.default_value">
         <option value="" translate>None</option>
-        <option ng-repeat="value in vm.modalData.values" value="{{value[1]}}">{{value[0]}}</option>
+        <option ng-repeat="value in vm.modalData.values" value="{{value[0]}}">{{value[1]}}</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -77,7 +77,7 @@ export class ToolboxController {
         'dropdown_list',
         {
           data_type: 'string',
-          values: [[1, 'One'], [2, 'Two'], [3, 'Three']],
+          values: [['1', 'One'], ['2', 'Two'], ['3', 'Three']],
           options: {
             sort_by: 'description',
             sort_order: 'ascending',
@@ -93,7 +93,7 @@ export class ToolboxController {
         'radio_button',
         {
           data_type: 'string',
-          values: [[1, 'One'], [2, 'Two'], [3, 'Three']],
+          values: [['1', 'One'], ['2', 'Two'], ['3', 'Three']],
           options: {sort_by: 'description', sort_order: 'ascending'},
         }
       ),


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1531571

The initial values need to be a string, so the comparison and thus displaying `default_value` works correctly.