### PR TITLE
Update Bower dev CI to install dependencies before releasing

### DIFF
--- a/ci/bower-dev.sh
+++ b/ci/bower-dev.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -x
 HASH=$(git rev-parse HEAD)
+yarn install
 yarn run build
 mv -f dist tmp
 mv bower.json bower.json.tmp


### PR DESCRIPTION
### Fixes problem with bower releases
When releasing new version to bower it does not install dependencies which causes error, this PR fixes such issue and before releasing new version to bower it installs required dependencies.