### PR TITLE
Add missing code to make the dialog editor working in the demo

### DIFF
--- a/demo/controllers/dialogEditorController.ts
+++ b/demo/controllers/dialogEditorController.ts
@@ -9,6 +9,10 @@ import {ComponentDemo} from '../services/availableComponentBuilder';
 })
 export default class DialogEditorController {
   public dialog: any;
+  public modalOptions: any;
+  public elementInfo: any;
+  public visible: any;
+
   /* @ngInject */
   constructor(private DialogEditor: DialogEditorService) {
     this.init({
@@ -29,5 +33,19 @@ export default class DialogEditorController {
   public init(dialog) {
     this.DialogEditor.setData(dialog);
     this.dialog = dialog;
+  }
+
+  public setupModalOptions(type, tab, box, field) {
+    const components = {
+      tab: 'dialog-editor-modal-tab',
+      box: 'dialog-editor-modal-box',
+      field: 'dialog-editor-modal-field'
+    };
+    this.modalOptions = {
+      component: components[type],
+      size: 'lg',
+    };
+    this.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
+    this.visible = true;
   }
 }

--- a/demo/views/dialog/editor.html
+++ b/demo/views/dialog/editor.html
@@ -18,6 +18,18 @@
   </div>
 </div>
 <div class="dialog-designer-container">
+  <dialog-editor-modal
+    modal-options='vm.modalOptions'
+    element-info = 'vm.elementInfo'
+    lazy-load='vm.lazyLoad'
+    on-select='vm.onSelect'
+    show-fully-qualified-name="vm.showFullyQualifiedName"
+    tree-selector-data="vm.treeSelectorData"
+    tree-selector-include-domain="vm.treeSelectorIncludeDomain"
+    tree-selector-show="vm.treeSelectorShow"
+    tree-selector-toggle="vm.treeSelectorToggle"
+    visible="vm.modalVisible"
+  ></dialog-editor-modal>
   <div class="toolbox-container">
     <div class="static-field-container" id="toolbox">
       <div class="draggable">
@@ -25,8 +37,8 @@
       </div>
     </div>
     <div class="editable-fields-container">
-      <dialog-editor-tabs></dialog-editor-tabs>
-      <dialog-editor-boxes></dialog-editor-boxes>
+      <dialog-editor-tabs setup-modal-options="vm.setupModalOptions(type, tab, box, field)"></dialog-editor-tabs>
+      <dialog-editor-boxes setup-modal-options="vm.setupModalOptions(type, tab, box, field)"></dialog-editor-boxes>
       <pre>{{ vm.DialogEditor.data.content[0] | json }}</pre>
     </div>
   </div>


### PR DESCRIPTION
Some copy-pasted code from ui-classic's `dialog_editor_controller.js` and `editor.html` that will make the modals work in the demo.