### PR TITLE
Create a top-level dialog editor component

### DIFF
--- a/demo/controllers/dialogEditorController.ts
+++ b/demo/controllers/dialogEditorController.ts
@@ -33,17 +33,4 @@ export default class DialogEditorController {
     this.DialogEditor.setData(dialog);
     this.dialog = dialog;
   }
-
-  public setupModalOptions(type, tab, box, field) {
-    const components = {
-      tab: 'dialog-editor-modal-tab',
-      box: 'dialog-editor-modal-box',
-      field: 'dialog-editor-modal-field'
-    };
-    this.modalOptions = {
-      component: components[type],
-      size: 'lg',
-    };
-    this.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
-  }
 }

--- a/demo/views/dialog/editor.html
+++ b/demo/views/dialog/editor.html
@@ -17,28 +17,8 @@
     </form>
   </div>
 </div>
-<div class="dialog-designer-container">
-  <dialog-editor-modal
-    modal-options='vm.modalOptions'
-    element-info = 'vm.elementInfo'
-    lazy-load='vm.lazyLoad'
-    on-select='vm.onSelect'
-    show-fully-qualified-name="vm.showFullyQualifiedName"
-    tree-selector-data="vm.treeSelectorData"
-    tree-selector-include-domain="vm.treeSelectorIncludeDomain"
-    tree-selector-show="vm.treeSelectorShow"
-    tree-selector-toggle="vm.treeSelectorToggle"
-  ></dialog-editor-modal>
-  <div class="toolbox-container">
-    <div class="static-field-container" id="toolbox">
-      <div class="draggable">
-        <dialog-editor-field-static></dialog-editor-field-static>
-      </div>
-    </div>
-    <div class="editable-fields-container">
-      <dialog-editor-tabs setup-modal-options="vm.setupModalOptions(type, tab, box, field)"></dialog-editor-tabs>
-      <dialog-editor-boxes setup-modal-options="vm.setupModalOptions(type, tab, box, field)"></dialog-editor-boxes>
-      <pre>{{ vm.DialogEditor.data.content[0] | json }}</pre>
-    </div>
-  </div>
+
+<dialog-editor></dialog-editor>
+<div class="row">
+  <pre class="col-md-push-2 col-md-7">{{ vm.DialogEditor.data.content[0] | json }}</pre>
 </div>

--- a/src/dialog-editor/components/dialog-editor/dialog-editor.html
+++ b/src/dialog-editor/components/dialog-editor/dialog-editor.html
@@ -1,0 +1,24 @@
+<div class="dialog-designer-container">
+  <dialog-editor-modal
+    modal-options='$ctrl.modalOptions'
+    element-info = '$ctrl.elementInfo'
+    lazy-load='$ctrl.treeSelectorLazyLoad'
+    on-select='$ctrl.treeSelectorSelect'
+    show-fully-qualified-name="$ctrl.showFullyQualifiedName"
+    tree-selector-data="$ctrl.treeSelectorData"
+    tree-selector-include-domain="$ctrl.treeSelectorIncludeDomain"
+    tree-selector-show="$ctrl.treeSelectorShow"
+    tree-selector-toggle="$ctrl.treeSelectorToggle"
+  ></dialog-editor-modal>
+  <div class="toolbox-container">
+    <div class="static-field-container" id="toolbox">
+      <div class="draggable">
+        <dialog-editor-field-static></dialog-editor-field-static>
+      </div>
+    </div>
+    <div class="editable-fields-container">
+      <dialog-editor-tabs setup-modal-options="$ctrl.setupModalOptions(type, tab, box, field)"></dialog-editor-tabs>
+      <dialog-editor-boxes setup-modal-options="$ctrl.setupModalOptions(type, tab, box, field)"></dialog-editor-boxes>
+    </div>
+  </div>
+</div>

--- a/src/dialog-editor/components/dialog-editor/dialogEditorComponent.ts
+++ b/src/dialog-editor/components/dialog-editor/dialogEditorComponent.ts
@@ -1,0 +1,67 @@
+import * as ng from 'angular';
+
+export class DialogEditorController {
+  public modalOptions: any;
+  public elementInfo: any;
+  public treeSelectorShow: boolean = false;
+  public treeSelectorIncludeDomain: boolean = false;
+
+  public setupModalOptions(type, tab, box, field) {
+    const components = {
+      tab: 'dialog-editor-modal-tab',
+      box: 'dialog-editor-modal-box',
+      field: 'dialog-editor-modal-field'
+    };
+    this.modalOptions = {
+      component: components[type],
+      size: 'lg',
+    };
+    this.elementInfo = { type: type, tabId: tab, boxId: box, fieldId: field };
+  }
+
+  public treeSelectorToggle() {
+    this.treeSelectorShow = ! this.treeSelectorShow;
+  }
+
+  public treeSelectorSelect(node, elementData) {
+    const fqname = node.fqname.split('/');
+    if (this.treeSelectorIncludeDomain === false) {
+      fqname.splice(1, 1);
+    }
+    elementData.resource_action = {
+      ...elementData.resource_action,
+      ae_instance: fqname.pop(),
+      ae_class: fqname.pop(),
+      ae_namespace: fqname.filter(String).join('/')
+    };
+    this.treeSelectorShow = false;
+  }
+
+  public showFullyQualifiedName(resourceAction) {
+    if (resourceAction.ae_namespace && resourceAction.ae_class && resourceAction.ae_instance) {
+      return `${resourceAction.ae_namespace}/${resourceAction.ae_class}/${resourceAction.ae_instance}`;
+    } else {
+      return '';
+    }
+  }
+}
+
+/**
+ * @memberof miqStaticAssets
+ * @ngdoc component
+ * @name dialogEditor
+ * @description
+ *    Top-level dialog editor component.
+ * @example
+ * <dialog-editor>
+ * </dialog-editor>
+ */
+
+export default class DialogEditor implements ng.IComponentOptions {
+  public controller = DialogEditorController;
+  public template = require('./dialog-editor.html');
+  public bindings = {
+    treeSelectorData: '<',
+    treeSelectorLazyLoad: '<'
+  };
+}

--- a/src/dialog-editor/components/dialog-editor/index.ts
+++ b/src/dialog-editor/components/dialog-editor/index.ts
@@ -1,0 +1,5 @@
+import DialogEditor from './dialogEditorComponent';
+
+export default (module: ng.IModule) => {
+  module.component('dialogEditor', new DialogEditor);
+};

--- a/src/dialog-editor/components/index.ts
+++ b/src/dialog-editor/components/index.ts
@@ -7,6 +7,7 @@ import modalTab from './modal-tab';
 import modalBox from './modal-box';
 import modalField from './modal-field';
 import modalFieldTemplate from './modal-field-template';
+import dialogEditor from './dialog-editor';
 
 export default (module: ng.IModule) => {
   tabList(module);
@@ -18,4 +19,5 @@ export default (module: ng.IModule) => {
   modalBox(module);
   modalField(module);
   modalFieldTemplate(module);
+  dialogEditor(module);
 };


### PR DESCRIPTION
Wrapping the whole dialog editor into a single component. Some bindings have been moved into this component, but in the future they should be moved deeper in the codebase. I renamed the `onSelect` function to `treeSelectorSelect` as this name is more descriptive.

For now marking it as a WIP as the textarea is missing from the demo.

@miq-bot assign @romanblanco 