### PR TITLE
Add bootstrap-select to vendor dependencies

### DIFF
--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -11,5 +11,6 @@ import 'angular-patternfly';
 import 'angular-ui-sortable';
 import 'angular-dragdrop';
 import 'angular-bootstrap-switch';
+import 'bootstrap-select';
 import 'ui-select';
 import 'patternfly-bootstrap-treeview';


### PR DESCRIPTION
### Fixes #260
When adding selectbox in demo page for dialog editor, there was an error with missing selectpicker. This was caused due to missing dependency in vendors.

### UI changes
**none**