### PR TITLE
Use the external DialogEditorHttpService for retrieving categories

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,7 +2,7 @@ import views from './views';
 import controllers from './controllers';
 import * as angular from 'angular';
 import TranslateFilter from './services/translateFilter';
-import APIService from './services/APIService';
+import DialogEditorHttpService from './services/DialogEditorHttpService';
 
 export const app = angular.module('demoApp', [
   'ui.sortable', 'ngDragDrop', 'frapontillo.bootstrap-switch', 'miqStaticAssets', 'ui.bootstrap', 'ui.router',
@@ -11,4 +11,4 @@ export const app = angular.module('demoApp', [
 controllers(app);
 views(app);
 app.filter('translate', TranslateFilter.filter);
-app.service('API', APIService);
+app.service('DialogEditorHttp', DialogEditorHttpService);

--- a/demo/services/APIService.ts
+++ b/demo/services/APIService.ts
@@ -1,5 +1,0 @@
-export default class APIService {
-  public get(): Promise<any[]> {
-    return new Promise(resolve => resolve([]));
-  }
-}

--- a/demo/services/DialogEditorHttpService.ts
+++ b/demo/services/DialogEditorHttpService.ts
@@ -1,0 +1,5 @@
+export default class DialogEditorHttpService {
+  public loadCategories(): Promise<any[]> {
+    return new Promise(resolve => resolve([]));
+  }
+}

--- a/src/dialog-editor/components/modal/modalComponent.spec.ts
+++ b/src/dialog-editor/components/modal/modalComponent.spec.ts
@@ -10,7 +10,7 @@ describe('modalComponentSpec', () => {
       angular.mock.module('miqStaticAssets.dialogEditor');
       angular.mock.module('ui.bootstrap');
       angular.mock.inject($componentController => {
-      modalComponent = $componentController('dialogEditorModal', {API: {} }, bindings);
+      modalComponent = $componentController('dialogEditorModal', {DialogEditorHttp: {} }, bindings);
       });
     });
 

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -20,7 +20,7 @@ class ModalController {
 
   /*@ngInject*/
   constructor(private $uibModal: any,
-              private API: any,
+              private DialogEditorHttp: any,
               private DialogEditor: any) {
   }
 
@@ -97,9 +97,7 @@ class ModalController {
    * @function resolveCategories
    */
   public resolveCategories() {
-    return this.API.get('/api/categories' +
-                        '?expand=resources' +
-                        '&attributes=description,single_value,children');
+    return this.DialogEditorHttp.loadCategories();
   }
 
   /**


### PR DESCRIPTION
We do not want to depend on any specific API in this repo, the preferred way is to use a service that does these things externally.

Original idea: https://github.com/ManageIQ/manageiq-ui-classic/pull/3414 and https://github.com/ManageIQ/ui-components/issues/219
Depends on: https://github.com/ManageIQ/manageiq-ui-classic/pull/3426

@miq-bot assign @romanblanco 