### PR TITLE
Add quadicon into report data, small tile and big tile

### DIFF
--- a/demo/data/data-table.json
+++ b/demo/data/data-table.json
@@ -53,7 +53,26 @@
           {
             "text": "server-one"
           }
-        ]
+        ],
+        "quad": {
+          "topLeft": {
+            "fileicon": "/assets/vendor-centos.svg",
+            "tooltip": "Hello, I am a very useful tooltip in the first quadrant!"
+          },
+          "topRight": {
+            "text": "T",
+            "background": "#336699",
+            "tooltip": "Hello, I am a very useful tooltip in the second quadrant!"
+          },
+          "bottomLeft": {
+            "fileicon": "/assets/vendor-vmware.svg",
+            "tooltip": "Hello, I am a very useful tooltip in the third quadrant!"
+          },
+          "bottomRight": {
+            "text": "0",
+            "tooltip": "Hello, I am a very useful tooltip in the fourth quadrant!"
+          }
+        }
       },
       {
         "id": "14",
@@ -74,7 +93,12 @@
           {
             "text": "Local"
           }
-        ]
+        ],
+        "quad": {
+          "fonticon": "pficon pficon-server",
+          "color": "#0099cc",
+          "tooltip": "Hello, I am a very useful tooltip!"
+        }
       },
       {
         "id": "10",

--- a/src/gtl/components/tile-view/tile-view.html
+++ b/src/gtl/components/tile-view/tile-view.html
@@ -22,7 +22,8 @@
         </div>
         <div class="miq-quadicon">
           <a href="javascript:void(0)" ng-click="config.onItemClick(item, $event)">
-            <div ng-bind-html="config.trustAsHtmlQuadicon(item)"></div>
+            <div ng-if="!item.quad" ng-bind-html="config.trustAsHtmlQuadicon(item)"></div>
+            <miq-quadicon ng-if="item.quad" data="item.quad"></miq-quadicon>
           </a>
         </div>
       </ng-switch-when>
@@ -31,7 +32,8 @@
         <div class="row miq-row-margin-only-top ">
           <div class="col-md-3 col-lg-3 col-xs-3 miq-icon-section">
             <a href="javascript:void(0)" ng-click="config.onItemClick(item, $event)">
-              <div ng-bind-html="config.trustAsHtmlQuadicon(item)"></div>
+              <div ng-if="!item.quad" ng-bind-html="config.trustAsHtmlQuadicon(item)"></div>
+              <miq-quadicon ng-if="item.quad" data="item.quad"></miq-quadicon>
             </a>
           </div>
           <div class="col-md-9 col-lg-9 col-xs-9 miq-info-section">


### PR DESCRIPTION
### Introduces quadicons as part of report_data component
When rendering report_data tile (small/big) show quadicon instead of using HTML when possible.

### UI changes
![screenshot from 2018-02-19 17-04-37](https://user-images.githubusercontent.com/3439771/36386723-0671728e-1597-11e8-8313-a497befe2f48.png)
