### PR TITLE
Add ability to live-search dialog drop down fields

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -50,20 +50,43 @@
       </div>
 
       <span ng-switch-when="DialogFieldDropDownList">
-        <!-- Dropdown field where a single value is expected -->
+        <!-- Dropdown field where a single value is expected - PF 3 compatible-->
         <select pf-select
-                ng-if="!vm.dialogField.options.force_multi_value"
+                data-live-search="true"
+                ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
                 ng-model="vm.dialogField.default_value"
                 ng-blur="vm.validateField()"
                 ng-change="vm.changesHappened()"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 class="form-control"
                 id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values" value="{{value[0]}}">{{value[1]}}</option>
+          <option ng-repeat="value in vm.dialogField.values"
+                  data-tokens="{{value[0]}} {{value[1]}}"
+                  value="{{value[0]}}">
+            {{value[1]}}
+          </option>
+        </select>
+
+        <!-- Dropdown field where a single value is expected - PF 4 compatible-->
+        <select pf-bootstrap-select
+                data-live-search="true"
+                ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
+                ng-model="vm.dialogField.default_value"
+                ng-blur="vm.validateField()"
+                ng-change="vm.changesHappened()"
+                ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+                class="form-control"
+                id="{{ vm.dialogField.name }}">
+          <option ng-repeat="value in vm.dialogField.values"
+                  data-tokens="{{value[0]}} {{value[1]}}"
+                  value="{{value[0]}}">
+            {{value[1]}}
+          </option>
         </select>
 
         <!-- PF 3 compatible multiselect -->
         <select pf-select multiple
+                data-live-search="true"
                 ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
                 ng-init="vm.convertValuesToArray()"
                 ng-model="vm.dialogField.default_value"
@@ -71,11 +94,16 @@
                 ng-blur="vm.validateField()"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 input-id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values" value="{{value[0]}}">{{value[1]}}</option>
+          <option ng-repeat="value in vm.dialogField.values"
+                  data-tokens="{{value[0]}} {{value[1]}}"
+                  value="{{value[0]}}">
+            {{value[1]}}
+          </option>
         </select>
 
         <!-- PF 4 compatible multiselect -->
         <select pf-bootstrap-select multiple
+                data-live-search="true"
                 ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
                 ng-init="vm.convertValuesToArray()"
                 ng-model="vm.dialogField.default_value"
@@ -83,7 +111,11 @@
                 ng-blur="vm.validateField()"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 input-id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values" value="{{value[0]}}">{{value[1]}}</option>
+          <option ng-repeat="value in vm.dialogField.values"
+                  data-tokens="{{value[0]}} {{value[1]}}"
+                  value="{{value[0]}}">
+            {{value[1]}}
+          </option>
         </select>
       </span>
 


### PR DESCRIPTION
When we switched over to the new dialog-user component, we forgot to include the live-search ability that was on the older bootstrap drop downs. This will put those back into place, and adds the `data-tokens` property to the options so for example if someone has a drop down that submits the value of `3` but the option for selecting is `"Three"`, then they can search by typing either `3` or `three`.

See screenshots:
<img width="429" alt="screen shot 2018-03-08 at 11 00 52 am" src="https://user-images.githubusercontent.com/164557/37170569-030c63ac-22c0-11e8-8ef3-a6faff454311.png">
<img width="425" alt="screen shot 2018-03-08 at 11 00 43 am" src="https://user-images.githubusercontent.com/164557/37170570-0356df86-22c0-11e8-8653-77da4f049b09.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1553347