### PR TITLE
When no checkboxes are visible in GTL hide select all

### DIFF
--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -5,6 +5,7 @@
     <miq-pagination settings="tableCtrl.settings"
                     per-page="tableCtrl.perPage"
                     on-select-all="tableCtrl.onCheckAll(isSelected)"
+                    has-checkboxes="tableCtrl.countCheckboxes() > 0"
                     on-change-sort="tableCtrl.onSortClick(sortId, isAscending)"
                     on-change-page="tableCtrl.setPage(pageNumber)"
                     on-change-per-page="tableCtrl.perPageClick(item)"></miq-pagination>

--- a/src/gtl/components/data-table/dataTableComponent.spec.ts
+++ b/src/gtl/components/data-table/dataTableComponent.spec.ts
@@ -136,6 +136,26 @@ describe('DataTable test', () =>  {
       dataTableCtrl.setTablePage('d');
       expect(dataTableCtrl.settings.current).toBe(1);
     });
+
+    it('should count checkboxes', () => {
+      expect(dataTableCtrl.countCheckboxes()).toBe(3);
+
+      dataTableCtrl.rows = dataTableCtrl.rows.map(oneRow => {
+        oneRow.cells[0].is_checkbox = false;
+        return oneRow;
+      });
+
+      expect(dataTableCtrl.countCheckboxes()).toBe(0);
+    });
+
+    it('should count checkboxes for rows with cells', () => {
+      dataTableCtrl.rows = dataTableCtrl.rows.map(oneRow => {
+        oneRow.cells = undefined;
+        return oneRow;
+      });
+
+      expect(dataTableCtrl.countCheckboxes()).toBe(0);
+    });
   });
 
   describe('component', () => {

--- a/src/gtl/components/pagination/pagination.html
+++ b/src/gtl/components/pagination/pagination.html
@@ -2,8 +2,9 @@
 
   <div class="form-group">
     <!-- Select all start -->
-    <span class="checkbox span-right-border" style="margin: 0 0 0 5px">
-      <label class="checkbox-inline">
+    <span class="checkbox span-right-border"
+          style="margin: 0 0 0 5px">
+      <label ng-if="paginationCtrl.hasCheckboxes" class="checkbox-inline">
         <input type="checkbox"
                ng-model="paginationCtrl.isChecked"
                ng-click="paginationCtrl.onSelectAll({isSelected: paginationCtrl.isChecked})"

--- a/src/gtl/components/pagination/paginationComponent.spec.ts
+++ b/src/gtl/components/pagination/paginationComponent.spec.ts
@@ -104,6 +104,7 @@ describe('Pagination test', () =>  {
 
       scope.settings = settings;
       scope.perPage = perPage;
+      scope.hasCheckboxes = true;
       scope.onSelectAll = onSelectAll;
       scope.onChangeSort = onChangeSort;
       scope.onChangePage = onChangePage;
@@ -113,6 +114,7 @@ describe('Pagination test', () =>  {
         angular.element(
           `<miq-pagination  settings="settings"
                             per-page="perPage"
+                            has-checkboxes="hasCheckboxes"
                             on-select-all="onSelectAll(isSelected)"
                             on-change-sort="onChangeSort(sortId, isAscending)"
                             on-change-page="onChangePage(pageNumber)"
@@ -141,6 +143,12 @@ describe('Pagination test', () =>  {
       it('pager', () => {
         expect(compiledElement[0].querySelectorAll('miq-paging').length).toBe(1);
         expect(compiledElement[0].querySelectorAll('miq-paging ul li').length).toBe(5);
+      });
+
+      it('should not render check all', () => {
+        scope.hasCheckboxes = false;
+        scope.$apply();
+        expect(compiledElement[0].querySelectorAll('.checkbox-inline').length).toBe(0)
       });
     });
 

--- a/src/gtl/components/pagination/paginationComponent.ts
+++ b/src/gtl/components/pagination/paginationComponent.ts
@@ -7,6 +7,7 @@
 export class PaginationController {
   public isChecked: boolean = false;
   public settings: any;
+  public hasCheckboxes: boolean;
 
   public onSelectAll: (args: {isSelected: boolean}) => void;
   public onChangeSort: (args: {sortId: number, isAscending: boolean}) => void;
@@ -57,6 +58,7 @@ export default class Pagination implements ng.IComponentOptions {
   public bindings: any = {
     settings: '<',
     perPage: '<',
+    hasCheckboxes: '<',
     onSelectAll: '&',
     onChangeSort: '&',
     onChangePage: '&',

--- a/src/gtl/components/tile-view/tile-view.html
+++ b/src/gtl/components/tile-view/tile-view.html
@@ -4,6 +4,7 @@
          ng-if="tileCtrl.settings && tileCtrl.settings.sortBy && (tileCtrl.settings.isLoading || tileCtrl.rows.length !== 0)">
       <miq-pagination settings="tileCtrl.settings"
                       per-page="tileCtrl.perPage"
+                      has-checkboxes="tileCtrl.countCheckboxes() > 0"
                       on-select-all="tileCtrl.onCheckAll(isSelected)"
                       on-change-sort="tileCtrl.onSortClick(sortId, isAscending)"
                       on-change-page="tileCtrl.setPage(pageNumber)"

--- a/src/gtl/components/tile-view/tileViewComponent.spec.ts
+++ b/src/gtl/components/tile-view/tileViewComponent.spec.ts
@@ -140,6 +140,26 @@ describe('tile component test', () =>  {
       tileController.rows[0].checked = true;
       expect(angular.equals([rows[0]],tileController.filterSelected())).toBeTruthy();
     });
+
+    it('should count checkboxes', () => {
+      expect(tileController.countCheckboxes()).toBe(2);
+
+      tileController.rows = tileController.rows.map(oneRow => {
+        oneRow.cells[0].is_checkbox = false;
+        return oneRow;
+      });
+
+      expect(tileController.countCheckboxes()).toBe(0);
+    });
+
+    it('should count checkboxes for rows with cells', () => {
+      tileController.rows = tileController.rows.map(oneRow => {
+        oneRow.cells = undefined;
+        return oneRow;
+      });
+
+      expect(tileController.countCheckboxes()).toBe(0);
+    });
   });
 
   describe('component', () => {

--- a/src/gtl/interfaces/abstractDataViewClass.ts
+++ b/src/gtl/interfaces/abstractDataViewClass.ts
@@ -81,6 +81,22 @@ export abstract class DataViewClass implements IDataTableBinding {
       `${start} - ${end} of ${total}`;
   }
 
+  /**
+   * Helper method to count all checkboxes in rows data.
+   * Checkboxes are stored under each row's cells.
+   */
+  public countCheckboxes() {
+    return this.rows.reduce(
+      (curr: number, next) => {
+        if (next.cells) {
+          curr += next.cells.filter(oneCell => oneCell && oneCell.is_checkbox).length;
+        }
+        return curr;
+      },
+      0
+    );
+  }
+
   public onItemButtonClick(item: any, $event: any) {
     $event.stopPropagation();
     if (item.hasOwnProperty('onclick')) {


### PR DESCRIPTION
### If no checkboxes in GTL remove select all
When user is in GTL view screen and no checkboxes are available select all is still present, this is wrong. This PR fixes such issue by adding new method in `src/gtl/interfaces/abstractDataViewClass.ts` and setting one way data bounded `hasCheckboxes` in `src/gtl/components/pagination/paginationComponent.ts`

### UI changes
#### Before
![screenshot from 2018-03-09 14-07-07](https://user-images.githubusercontent.com/3439771/37209095-2ebae458-23a4-11e8-9d2f-de2f5ed22f48.png)

#### After
![screenshot from 2018-03-09 14-07-14](https://user-images.githubusercontent.com/3439771/37209096-2ed3110e-23a4-11e8-92ea-b197a4f51f27.png)

### Merge before core
This PR is multiple PR work, it needs to be merged and new version released before merging TODO ui-classic.
