### PR TITLE
Do not open browser when running tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = function(config) {
       [jsonGlob]: ['webpack'],
       [applicationFile]: ['webpack', 'coverage']
     },
-    webpack: webpackConfig,
+    webpack: webpackConfig({test: true}),
     webpackMiddleware: {noInfo: true},
 
     // enable / disable colors in the output (reporters addnd logs)


### PR DESCRIPTION
### No browser window for tests
When running tests new window is opened in browser which is then unresposnive, because server terminates itself once tests are done. This PR fixes such issue by changeing webpack config to allow passing variables