### PR TITLE
Fix for drop-down selection on dialogs while ordering service catalog having to select an item twice

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -99,9 +99,6 @@ export default class DialogDataService {
     if (data.default_value) {
       defaultValue = data.default_value;
     }
-    if (data.data_type === 'integer') {
-      defaultValue = parseInt(data.default_value, 10);
-    }
 
     return defaultValue;
   }


### PR DESCRIPTION
The main problem here is that we need to use `ng-repeat` to list out the options for a select. This, however, only supports strings for the value field, so when the drop down has a `data_type` of integer, we were coercing the default value into an integer, which would cause a mismatch and nothing would be selected. I'm not exactly sure why the weird double select was happening with this, but removing the integer coercion fixes the issue.

Here's what it looks like before (note that nothing is selected by default because it's trying to match `2` with `'2'`):
![drop_down_not_working](https://user-images.githubusercontent.com/164557/37486272-4133d486-284b-11e8-91a7-e9d0d83e9a12.gif)

Here's what it looks like after:
![drop_down_working](https://user-images.githubusercontent.com/164557/37486273-424a3108-284b-11e8-8d9d-4714417ff308.gif)

I've made sure that on the back end, when we actually do submit the dialog, that the request gets the correct type. It is being coerced on the back end via https://github.com/ManageIQ/manageiq/blob/master/app/models/dialog_field.rb#L108 and therefore I believe the coercion in javascript here can be safely removed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552041

@chalettu Please review.
@miq-bot assign @himdel 
@miq-bot add_label gaprindashvili/yes, bug, blocker