### PR TITLE
Style correction for dialog dropdowns

### DIFF
--- a/src/dialog-editor/components/box/box.html
+++ b/src/dialog-editor/components/box/box.html
@@ -30,7 +30,7 @@
               <i class="fa fa-object-group"></i>
               {{ 'Drag items here to add to the dialog. At least one item is required before saving' | translate }}
             </div>
-            <div ng-repeat='field in box.dialog_fields' class="draggable-field">
+            <div ng-repeat='field in box.dialog_fields' class="draggable-field draggable-field-dropdown">
               <form class="form-horizontal">
                 <dialog-editor-field box-position="box.position"
                                      field-data='field'

--- a/src/styles/dialog-editor-boxes.scss
+++ b/src/styles/dialog-editor-boxes.scss
@@ -133,3 +133,7 @@
     cursor: pointer;
   }
 }
+
+.draggable-field-dropdown {
+  z-index: initial;
+}


### PR DESCRIPTION
Fixing a CSS style, so the values in the dropdown are visible.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1557508

Before:
![screenshot from 2018-03-19 14-31-06](https://user-images.githubusercontent.com/1187051/37598346-42f3bc0c-2b82-11e8-9557-cf279ada5961.png)

After:
![screenshot from 2018-03-19 14-29-32](https://user-images.githubusercontent.com/1187051/37598350-468133f4-2b82-11e8-8756-9a6d59bc111a.png)


/cc @dtaylor113 

Thanks for the help, @Hyperkid123 