### PR TITLE
Ensure 'null' default values do not get coerced into 'NaN' for integer type drop downs

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -52,6 +52,26 @@ describe('DialogDataService test', () => {
     expect(configuredField.errorMessage).toBeDefined();
   });
 
+  describe('#setupField', () => {
+    describe('when the field is a drop down list', () => {
+      describe('when the field is an integer type', () => {
+        describe('when the field has no default value', () => {
+          it('stores the values without forcing null into a NaN', () => {
+            let testField = {
+              'data_type': 'integer',
+              'default_value': null,
+              'values': [[null, '<None>'], ['1', 'One'], ['2', 'Two']],
+              'type': 'DialogFieldDropDownList',
+              'options': {'sort_by': 'description', 'sort_order': 'ascending'}
+            };
+            let newField = dialogData.setupField(testField);
+            expect(newField.values[0]).toEqual([null, '<None>']);
+          });
+        });
+      });
+    });
+  });
+
   describe('#setDefaultValue', () => {
     it('should allow a default value to be set', () => {
       let testField = dialogField;

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -25,7 +25,7 @@ export default class DialogDataService {
         if (option[0] === String(field.default_value)) {
           field.selected = option;
         }
-        const value = (field.data_type === 'integer' ? parseInt(option[0], 10) : option[0]);
+        const value = ((field.data_type === 'integer' && option[0] !== null) ? parseInt(option[0], 10) : option[0]);
         const description = (isNaN(option[1]) ? option[1] : parseInt(option[1], 10));
         dropDownValues.push([value, description]);
       }


### PR DESCRIPTION
@AllenBW can probably give a bit more context on this, but basically if you do not set a default value for an integer based drop down, it will default to `null`. Well, this gets converted into "NaN", which does not match `null` as a default value and therefore doesn't end up actually selecting the first value which should be `"<None>"` but instead just shows "Nothing Selected".

Before, the string drop downs work fine with no default, and the integer ones have the "Nothing Selected" text:
<img width="414" alt="screen shot 2018-03-20 at 2 48 30 pm" src="https://user-images.githubusercontent.com/164557/37684595-d13af112-2c4d-11e8-8e57-96c813a44701.png">

After, all of them behave the same:
<img width="416" alt="screen shot 2018-03-20 at 2 48 42 pm" src="https://user-images.githubusercontent.com/164557/37684594-d126ac98-2c4d-11e8-962c-5918a0048bf8.png">

https://bugzilla.redhat.com/show_bug.cgi?id=1557482

@chalettu Can you please review?

@miq-bot assign @himdel 

I'm not tracking the BZ quite as closely as @AllenBW, so Allen, if I got the wrong labels please correct me 👍 

@miq-bot add_label gaprindashvili/yes, bug, blocker