### PR TITLE
Fix Dialog Editor styling issues

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -1,33 +1,36 @@
 <div ng-show="vm.dialogField.visible"
      class="form-group"
      ng-class="{'has-error': vm.dialogField.fieldValidation===false}">
-  <div class="col-md-2 col-lg-4 col-xl-2 col-sm-2 dialog-label">
-    <label class="control-label">{{ ::vm.dialogField.label }}</label>
+
+  <label class=" col-sm-3 control-label">{{ ::vm.dialogField.label }}
     <i class="fa fa-info-circle primary help-icon"
          ng-if="vm.dialogField.description" 
          tooltip-append-to-body="true"
          uib-tooltip="{{ vm.dialogField.description }}" 
-         tooltip-placement="auto top"
-    >
+         tooltip-placement="auto top">
     </i>
-  </div>
-    <div ng-switch on="vm.dialogField.type"
-         class="col-sm-5 col-lg-5">
-      <div ng-switch-when="DialogFieldTextBox">
-        <input ng-model="vm.dialogField.default_value"
-               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-               ng-change="vm.changesHappened()"
-               ng-blur="vm.validateField()"
-               ng-model-options="{debounce: {'default': 500}}"
-               class="form-control"
-               type="{{ vm.dialogField.options.protected ? 'password' : 'text' }}"
-               uib-tooltip="{{ ::inputTitle }}"
-               value="{{ vm.dialogField.default_value }}"
-               id="{{ vm.dialogField.name }}">
-        <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
-      </div>
-      <textarea ng-switch-when="DialogFieldTextAreaBox"
-                ng-model="vm.dialogField.default_value"
+  </label>
+
+
+
+  <div ng-switch on="vm.dialogField.type">
+
+    <div class="col-sm-4" ng-switch-when="DialogFieldTextBox">
+      <input ng-model="vm.dialogField.default_value"
+             ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+             ng-change="vm.changesHappened()"
+             ng-blur="vm.validateField()"
+             ng-model-options="{debounce: {'default': 500}}"
+             class="form-control"
+             type="{{ vm.dialogField.options.protected ? 'password' : 'text' }}"
+             uib-tooltip="{{ ::inputTitle }}"
+             value="{{ vm.dialogField.default_value }}"
+             id="{{ vm.dialogField.name }}">
+      <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
+    </div>
+
+    <div class="col-sm-8" ng-switch-when="DialogFieldTextAreaBox">
+      <textarea ng-model="vm.dialogField.default_value"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 ng-change="vm.changesHappened()"
                 ng-model-options="{debounce: {'default': 500}}"
@@ -36,91 +39,91 @@
                 rows="4"
                 id="{{ vm.dialogField.name }}">{{ vm.dialogField.default_value }}
       </textarea>
-      <div ng-switch-when="DialogFieldCheckBox">
-        <input
+    </div>
+
+    <div class="col-sm-4" ng-switch-when="DialogFieldCheckBox">
+      <input
+            ng-model="vm.dialogField.default_value"
+            ng-true-value="'t'"
+            ng-false-value="'f'"
+            ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+            ng-change="vm.changesHappened()"
+            type="checkbox"
+            uib-tooltip="{{ ::inputTitle }}"
+            id="{{ vm.dialogField.name }}">
+      <div ng-if="vm.dialogField.fieldValidation===false">{{vm.dialogField.errorMessage}}</div>
+    </div>
+
+    <div class="col-sm-4" ng-switch-when="DialogFieldDropDownList">
+      <!-- Dropdown field where a single value is expected - PF 3 compatible-->
+      <select pf-select
+              data-live-search="true"
+              ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
               ng-model="vm.dialogField.default_value"
-              ng-true-value="'t'"
-              ng-false-value="'f'"
-              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              ng-blur="vm.validateField()"
               ng-change="vm.changesHappened()"
-              type="checkbox"
-              uib-tooltip="{{ ::inputTitle }}"
+              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              class="form-control"
               id="{{ vm.dialogField.name }}">
-        <div ng-if="vm.dialogField.fieldValidation===false">{{vm.dialogField.errorMessage}}</div>
-      </div>
+        <option ng-repeat="value in vm.dialogField.values"
+                data-tokens="{{value[0]}} {{value[1]}}"
+                value="{{value[0]}}">
+          {{value[1]}}
+        </option>
+      </select>
+      <!-- Dropdown field where a single value is expected - PF 4 compatible-->
+      <select pf-bootstrap-select
+              data-live-search="true"
+              ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
+              ng-model="vm.dialogField.default_value"
+              ng-blur="vm.validateField()"
+              ng-change="vm.changesHappened()"
+              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              class="form-control"
+              id="{{ vm.dialogField.name }}">
+        <option ng-repeat="value in vm.dialogField.values"
+                data-tokens="{{value[0]}} {{value[1]}}"
+                value="{{value[0]}}">
+          {{value[1]}}
+        </option>
+      </select>
+      <!-- PF 3 compatible multiselect -->
+      <select pf-select multiple
+              data-live-search="true"
+              ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
+              ng-init="vm.convertValuesToArray()"
+              ng-model="vm.dialogField.default_value"
+              ng-change="vm.changesHappened(item)"
+              ng-blur="vm.validateField()"
+              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              input-id="{{ vm.dialogField.name }}">
+        <option ng-repeat="value in vm.dialogField.values"
+                data-tokens="{{value[0]}} {{value[1]}}"
+                value="{{value[0]}}">
+          {{value[1]}}
+        </option>
+      </select>
+      <!-- PF 4 compatible multiselect -->
+      <select pf-bootstrap-select multiple
+              data-live-search="true"
+              ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
+              ng-init="vm.convertValuesToArray()"
+              ng-model="vm.dialogField.default_value"
+              ng-change="vm.changesHappened(item)"
+              ng-blur="vm.validateField()"
+              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              input-id="{{ vm.dialogField.name }}">
+        <option ng-repeat="value in vm.dialogField.values"
+                data-tokens="{{value[0]}} {{value[1]}}"
+                value="{{value[0]}}">
+          {{value[1]}}
+        </option>
+      </select>
+    </div>
 
-      <span ng-switch-when="DialogFieldDropDownList">
-        <!-- Dropdown field where a single value is expected - PF 3 compatible-->
-        <select pf-select
-                data-live-search="true"
-                ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
-                ng-model="vm.dialogField.default_value"
-                ng-blur="vm.validateField()"
-                ng-change="vm.changesHappened()"
-                ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-                class="form-control"
-                id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values"
-                  data-tokens="{{value[0]}} {{value[1]}}"
-                  value="{{value[0]}}">
-            {{value[1]}}
-          </option>
-        </select>
-
-        <!-- Dropdown field where a single value is expected - PF 4 compatible-->
-        <select pf-bootstrap-select
-                data-live-search="true"
-                ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
-                ng-model="vm.dialogField.default_value"
-                ng-blur="vm.validateField()"
-                ng-change="vm.changesHappened()"
-                ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-                class="form-control"
-                id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values"
-                  data-tokens="{{value[0]}} {{value[1]}}"
-                  value="{{value[0]}}">
-            {{value[1]}}
-          </option>
-        </select>
-
-        <!-- PF 3 compatible multiselect -->
-        <select pf-select multiple
-                data-live-search="true"
-                ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
-                ng-init="vm.convertValuesToArray()"
-                ng-model="vm.dialogField.default_value"
-                ng-change="vm.changesHappened(item)"
-                ng-blur="vm.validateField()"
-                ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-                input-id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values"
-                  data-tokens="{{value[0]}} {{value[1]}}"
-                  value="{{value[0]}}">
-            {{value[1]}}
-          </option>
-        </select>
-
-        <!-- PF 4 compatible multiselect -->
-        <select pf-bootstrap-select multiple
-                data-live-search="true"
-                ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
-                ng-init="vm.convertValuesToArray()"
-                ng-model="vm.dialogField.default_value"
-                ng-change="vm.changesHappened(item)"
-                ng-blur="vm.validateField()"
-                ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-                input-id="{{ vm.dialogField.name }}">
-          <option ng-repeat="value in vm.dialogField.values"
-                  data-tokens="{{value[0]}} {{value[1]}}"
-                  value="{{value[0]}}">
-            {{value[1]}}
-          </option>
-        </select>
-      </span>
-
+    <div class="col-sm-6" ng-switch-when="DialogFieldTagControl">
       <select ng-if="vm.dialogField.options.force_single_value"
-              ng-switch-when="DialogFieldTagControl"
+              
               ng-model="vm.dialogField.default_value"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               ng-change="vm.changesHappened()"
@@ -128,11 +131,11 @@
               ng-options="fieldValue.id as fieldValue.description for fieldValue in vm.dialogField.values"
               id="{{ vm.dialogField.name }}">
       </select>
-
       <!-- Somewhat of a hack, but open angular issue using ng-att-multiple, so this is the workaround -->
+
+    <div class="col-sm-6" ng-switch-when="DialogFieldTagControl">
       <select ng-if="!vm.dialogField.options.force_single_value"
               multiple
-              ng-switch-when="DialogFieldTagControl"
               ng-model="vm.dialogField.default_value"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               ng-change="vm.changesHappened()"
@@ -140,14 +143,17 @@
               ng-options="fieldValue.id as fieldValue.description for fieldValue in vm.dialogField.values"
               id="{{ vm.dialogField.name }}">
       </select>
-
+    </div>
+    
+    <div class="col-sm-6" ng-switch-when="DialogFieldRadioButton">
       <span ng-if="vm.dialogField.read_only || vm.inputDisabled"
-            ng-switch-when="DialogFieldRadioButton"
             class="btn-group">
         <label>{{ vm.parsedOptions[vm.dialogField.name] }}</label>
       </span>
+    </div>
+
+    <div class="col-sm-6" ng-switch-when="DialogFieldRadioButton">
       <span ng-if="vm.dialogField.read_only === false || vm.inputDisabled === false"
-            ng-switch-when="DialogFieldRadioButton"
             class="btn-group">
         <label class="btn btn-primary"
                ng-repeat="fieldValue in vm.dialogField.values">
@@ -161,8 +167,11 @@
           {{ ::fieldValue[1] }}
         </label>
       </span>
+    </div>
 
-      <p ng-switch-when="DialogFieldDateControl" class="input-group">
+
+    <div class="col-sm-4" ng-switch-when="DialogFieldDateControl">
+      <p class="input-group">
         <input uib-datepicker-popup
                type="text"
                class="form-control"
@@ -179,40 +188,41 @@
           </button>
         </span>
       </p>
-      <div ng-switch-when="DialogFieldDateTimeControl">
-        <div class="col-sm-6 dateTimePadding">
-          <p class="input-group">
-            <input uib-datepicker-popup type="text"
-                   class="form-control"
-                   ng-model="vm.dialogField.default_value"
-                   ng-change="vm.changesHappened()"
-                   is-open="open"
-                   datepicker-options="vm.dateOptions"
-                   close-text="Close"
-                   id="{{ vm.dialogField.name }}"/>
-            <span class="input-group-btn">
-              <button type="button"
-                      class="btn btn-default"
-                      ng-click="open = !open">
-                <i class="fa fa-calendar"></i></button>
-            </span>
-          </p>
-        </div>
-        <div class="col-sm-6">
-          <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
-        </div>
+    </div>
+
+    <div class="col-sm-4" ng-switch-when="DialogFieldDateTimeControl">
+      <div class="col-sm-2 dateTimePadding">
+        <p class="input-group">
+          <input uib-datepicker-popup type="text"
+                 class="form-control"
+                 ng-model="vm.dialogField.default_value"
+                 ng-change="vm.changesHappened()"
+                 is-open="open"
+                 datepicker-options="vm.dateOptions"
+                 close-text="Close"
+                 id="{{ vm.dialogField.name }}"/>
+          <span class="input-group-btn">
+            <button type="button"
+                    class="btn btn-default"
+                    ng-click="open = !open">
+              <i class="fa fa-calendar"></i></button>
+          </span>
+        </p>
+      </div>
+      <div class="col-sm-2">
+        <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
       </div>
       <span ng-switch-default ng-hide="true"></span>
-    </div>
-    <div class="col-sm-1"
-          ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
-      <button type="button"
-              class="btn"
-              ng-click="vm.refreshSingleField()" translate>
-        Refresh
-      </button>
-    </div>
-    <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
-      <div class="spinner spinner-xs spinner-inline"></div>
+      <div class="col-sm-1"
+            ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
+        <button type="button"
+                class="btn"
+                ng-click="vm.refreshSingleField()" translate>
+          Refresh
+        </button>
+      </div>
+      <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
+        <div class="spinner spinner-xs spinner-inline"></div>
+      </div>
     </div>
  </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -11,10 +11,7 @@
     </i>
   </label>
 
-
-
   <div ng-switch on="vm.dialogField.type">
-
     <div class="col-sm-4" ng-switch-when="DialogFieldTextBox">
       <input ng-model="vm.dialogField.default_value"
              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
@@ -28,7 +25,6 @@
              id="{{ vm.dialogField.name }}">
       <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
     </div>
-
     <div class="col-sm-8" ng-switch-when="DialogFieldTextAreaBox">
       <textarea ng-model="vm.dialogField.default_value"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
@@ -40,17 +36,15 @@
                 id="{{ vm.dialogField.name }}">{{ vm.dialogField.default_value }}
       </textarea>
     </div>
-
     <div class="col-sm-4" ng-switch-when="DialogFieldCheckBox">
-      <input
-            ng-model="vm.dialogField.default_value"
-            ng-true-value="'t'"
-            ng-false-value="'f'"
-            ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-            ng-change="vm.changesHappened()"
-            type="checkbox"
-            uib-tooltip="{{ ::inputTitle }}"
-            id="{{ vm.dialogField.name }}">
+      <input  ng-model="vm.dialogField.default_value"
+              ng-true-value="'t'"
+              ng-false-value="'f'"
+              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
+              ng-change="vm.changesHappened()"
+              type="checkbox"
+              uib-tooltip="{{ ::inputTitle }}"
+              id="{{ vm.dialogField.name }}">
       <div ng-if="vm.dialogField.fieldValidation===false">{{vm.dialogField.errorMessage}}</div>
     </div>
 
@@ -64,6 +58,7 @@
               ng-change="vm.changesHappened()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               class="form-control"
+              data-container="body"
               id="{{ vm.dialogField.name }}">
         <option ng-repeat="value in vm.dialogField.values"
                 data-tokens="{{value[0]}} {{value[1]}}"
@@ -71,6 +66,7 @@
           {{value[1]}}
         </option>
       </select>
+
       <!-- Dropdown field where a single value is expected - PF 4 compatible-->
       <select pf-bootstrap-select
               data-live-search="true"
@@ -80,16 +76,19 @@
               ng-change="vm.changesHappened()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               class="form-control"
+              data-container="body"
               id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values"
+        <option ng-repeat="value in vm.dialogField.values track by $index"
                 data-tokens="{{value[0]}} {{value[1]}}"
                 value="{{value[0]}}">
           {{value[1]}}
         </option>
       </select>
+
       <!-- PF 3 compatible multiselect -->
       <select pf-select multiple
               data-live-search="true"
+              data-container="body"
               ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
               ng-init="vm.convertValuesToArray()"
               ng-model="vm.dialogField.default_value"
@@ -103,9 +102,11 @@
           {{value[1]}}
         </option>
       </select>
+
       <!-- PF 4 compatible multiselect -->
       <select pf-bootstrap-select multiple
               data-live-search="true"
+              data-container="body"
               ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
               ng-init="vm.convertValuesToArray()"
               ng-model="vm.dialogField.default_value"
@@ -113,7 +114,7 @@
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               input-id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values"
+        <option ng-repeat="value in vm.dialogField.values track by $index"
                 data-tokens="{{value[0]}} {{value[1]}}"
                 value="{{value[0]}}">
           {{value[1]}}
@@ -123,7 +124,6 @@
 
     <div class="col-sm-6" ng-switch-when="DialogFieldTagControl">
       <select ng-if="vm.dialogField.options.force_single_value"
-              
               ng-model="vm.dialogField.default_value"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               ng-change="vm.changesHappened()"
@@ -131,8 +131,9 @@
               ng-options="fieldValue.id as fieldValue.description for fieldValue in vm.dialogField.values"
               id="{{ vm.dialogField.name }}">
       </select>
-      <!-- Somewhat of a hack, but open angular issue using ng-att-multiple, so this is the workaround -->
+    </div>
 
+    <!-- Somewhat of a hack, but open angular issue using ng-att-multiple, so this is the workaround -->
     <div class="col-sm-6" ng-switch-when="DialogFieldTagControl">
       <select ng-if="!vm.dialogField.options.force_single_value"
               multiple
@@ -144,7 +145,7 @@
               id="{{ vm.dialogField.name }}">
       </select>
     </div>
-    
+
     <div class="col-sm-6" ng-switch-when="DialogFieldRadioButton">
       <span ng-if="vm.dialogField.read_only || vm.inputDisabled"
             class="btn-group">
@@ -169,7 +170,6 @@
       </span>
     </div>
 
-
     <div class="col-sm-4" ng-switch-when="DialogFieldDateControl">
       <p class="input-group">
         <input uib-datepicker-popup
@@ -191,7 +191,7 @@
     </div>
 
     <div class="col-sm-4" ng-switch-when="DialogFieldDateTimeControl">
-      <div class="col-sm-2 dateTimePadding">
+      <div class="dateTimePadding">
         <p class="input-group">
           <input uib-datepicker-popup type="text"
                  class="form-control"
@@ -209,20 +209,20 @@
           </span>
         </p>
       </div>
-      <div class="col-sm-2">
-        <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
-      </div>
-      <span ng-switch-default ng-hide="true"></span>
-      <div class="col-sm-1"
-            ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
-        <button type="button"
-                class="btn"
-                ng-click="vm.refreshSingleField()" translate>
-          Refresh
-        </button>
-      </div>
-      <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
-        <div class="spinner spinner-xs spinner-inline"></div>
-      </div>
+      <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
     </div>
- </div>
+    <span ng-switch-default ng-hide="true"></span>
+  </div>
+  <div class="col-sm-1"
+        ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
+    <button type="button"
+            class="btn"
+            ng-click="vm.refreshSingleField()" translate>
+      Refresh
+    </button>
+  </div>
+  <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
+    <div class="spinner spinner-xs spinner-inline"></div>
+  </div>
+</div>
+


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ManageIQ/manageiq-ui-classic/pull/3668 and addresses the following requests:

-  correctly applies form-horizontal class for label positioning
-  decrease size of label column 
-  increase size of text area
-  decrease size of dropdowns
-  move refresh button below text area

https://bugzilla.redhat.com/show_bug.cgi?id=1553697

Old (Classic UI)
![screen shot 2018-03-27 at 2 22 15 pm](https://user-images.githubusercontent.com/1287144/37986755-4c9e7488-31ca-11e8-817e-01719226d288.png)

New (Classic UI)
![screen shot 2018-03-27 at 2 20 51 pm](https://user-images.githubusercontent.com/1287144/37986756-4cad7a50-31ca-11e8-8e3e-93948653cfc8.png)

Old (Classic UI)
<img width="1015" alt="screen shot 2018-05-02 at 12 55 48 pm" src="https://user-images.githubusercontent.com/1287144/39582972-1443a6fc-4ebd-11e8-87f8-91f84fd34f47.png">

New (Classic UI)
<img width="901" alt="screen shot 2018-05-03 at 10 25 26 am" src="https://user-images.githubusercontent.com/1287144/39582938-00a2aea4-4ebd-11e8-9a34-f14260b1deda.png">

Old (Service UI)
<img width="1130" alt="screen shot 2018-04-11 at 1 38 03 pm" src="https://user-images.githubusercontent.com/1287144/38633516-f1876f12-3d8d-11e8-8dc3-2974c1e6f5a7.png">

New (Service UI)
<img width="1192" alt="screen shot 2018-04-11 at 1 07 21 pm" src="https://user-images.githubusercontent.com/1287144/38633517-f1969302-3d8d-11e8-8255-6e3b4b66798b.png">