### PR TITLE
Adjust size of quad icons

### DIFF
--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -419,9 +419,9 @@ miq-fonticon-picker {
 }
 
 miq-quadicon {
-  $quad-w: 80px;
-  $quad-h: 80px;
-  $radius: 8px;
+  $quad-w: 78px;
+  $quad-h: 78px;
+  $radius: 6px;
   $font-size: $quad-w /3;
   $quad-bg: linear-gradient(180deg, rgb(144, 142, 143) 0%, rgb(87, 87, 87) 62%, rgb(64, 64, 65) 100%);
 


### PR DESCRIPTION
This PR adjusts the size of the quad icons from 80px to 78px.

Old
<img width="610" alt="screen shot 2018-03-28 at 9 21 32 am" src="https://user-images.githubusercontent.com/1287144/38032049-ae17500e-326a-11e8-92b7-08e8c1034a3e.png">

New
<img width="640" alt="screen shot 2018-03-28 at 9 20 45 am" src="https://user-images.githubusercontent.com/1287144/38032050-ae255fa0-326a-11e8-88b9-39bbf9e2b432.png">
