### PR TITLE
Setting the default_value for TagControl dialog field

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -33,6 +33,9 @@ export class DialogFieldController extends DialogFieldClass {
     this.dialogField = this.field;
     this.validation = null;
     this.patternflyVersion = this.$window.patternflyVersion || 3;
+    if (this.dialogField.type === 'DialogFieldTagControl') {
+      this.setDefaultValue();
+    }
   }
 
   /**
@@ -94,6 +97,19 @@ export class DialogFieldController extends DialogFieldClass {
 
   public refreshSingleField() {
     this.singleRefresh({ field: this.field.name });
+  }
+
+  /**
+   * This method is setting the default_value for a tag control's select box.
+   * In case the default_value is not set for the ng-model of the component,
+   * an empty value option is displayed
+   * @memberof DialogFieldController
+   * @function setDefaultValue
+   */
+  private setDefaultValue() {
+    let defaultOption = _.find(this.dialogField.values, { id: null })
+    defaultOption.id = 0;
+    this.dialogField.default_value = defaultOption.id
   }
 }
 

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -108,8 +108,10 @@ export class DialogFieldController extends DialogFieldClass {
    */
   private setDefaultValue() {
     let defaultOption = _.find(this.dialogField.values, { id: null })
-    defaultOption.id = 0;
-    this.dialogField.default_value = defaultOption.id
+    if (defaultOption) {
+      defaultOption.id = 0;
+      this.dialogField.default_value = defaultOption.id
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1559159

The problem is the default options `<Choose>` and `<None>` had no id, and so the `default_value` remained unset and so an empty option field was created. (https://stackoverflow.com/a/12654812)

```ruby
   [{:id=>nil, :name=>"<Choose>", :description=>"<Choose>"},
    {:id=>10000000000035, :name=>"silver", :description=>"Silver"},
    {:id=>10000000000036, :name=>"gold", :description=>"Gold"},
    {:id=>10000000000037, :name=>"platinum", :description=>"Platinum"}],
```
In the fix I'm setting a value of the default options to 0, and setting them as default.