### PR TITLE
Fix for Catalog Item with Tag Control element cannot be ordered

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -72,6 +72,142 @@ describe('DialogDataService test', () => {
     });
   });
 
+  describe('#validateField', () => {
+    describe('when the field is required', () => {
+      describe('when the field is a tag control', () => {
+        describe('when the field forces a single value', () => {
+          describe('when the field value is 0 (the "choose" option)', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': 0,
+                'required': true,
+                'options': {
+                  'force_single_value': true
+                }
+              };
+            });
+
+            it('does not pass validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(false);
+              expect(validation.message).toEqual('This field is required');
+            });
+          });
+
+          describe('when the field value is null', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': null,
+                'required': true,
+                'options': {
+                  'force_single_value': true
+                }
+              };
+            });
+
+            it('does not pass validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(false);
+              expect(validation.message).toEqual('This field is required');
+            });
+          });
+
+          describe('when the field value is any other number', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': 1234,
+                'required': true,
+                'options': {
+                  'force_single_value': true
+                }
+              };
+            });
+
+            it('passes validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(true);
+              expect(validation.message).toEqual('');
+            });
+          });
+        });
+
+        describe('when the field does not force a single value', () => {
+          describe('when the field value is empty', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': [],
+                'required': true,
+                'options': {
+                  'force_single_value': false
+                }
+              };
+            });
+
+            it('does not pass validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(false);
+              expect(validation.message).toEqual('This field is required');
+            });
+          });
+
+          describe('when the field value is null', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': null,
+                'required': true,
+                'options': {
+                  'force_single_value': false
+                }
+              };
+            });
+
+            it('does not pass validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(false);
+              expect(validation.message).toEqual('This field is required');
+            });
+          });
+
+          describe('when the field value has selected values', () => {
+            let testField;
+
+            beforeEach(() => {
+              testField = {
+                'type': 'DialogFieldTagControl',
+                'default_value': [1234],
+                'required': true,
+                'options': {
+                  'force_single_value': false
+                }
+              };
+            });
+
+            it('passes validation', () => {
+              let validation = dialogData.validateField(testField);
+              expect(validation.isValid).toEqual(true);
+              expect(validation.message).toEqual('');
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('#setDefaultValue', () => {
     it('should allow a default value to be set', () => {
       let testField = dialogField;

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -124,6 +124,11 @@ export default class DialogDataService {
       if (field.type === 'DialogFieldCheckBox' && fieldValue === 'f') {
         validation.isValid = false;
         validation.message = __('This field is required');
+      } else if (field.type === 'DialogFieldTagControl') {
+        if (this.isInvalidTagControl(field.options.force_single_value, fieldValue)) {
+          validation.isValid = false;
+          validation.message = __('This field is required');
+        }
       } else if (_.isEmpty(fieldValue)) {
         validation.isValid = false;
         validation.message = __('This field is required');
@@ -142,5 +147,32 @@ export default class DialogDataService {
     }
 
     return validation;
+  }
+
+  /**
+   * Determines if a value is a tag control and whether or not that value is valid
+   * @memberof DialogDataService
+   * @function isInvalidTagControl
+   * @param forceSingleValue {boolean} Whether or not the field allows multiple selections
+   * @param fieldValue {any} This is the value of the field in question to be validated
+   **/
+  private isInvalidTagControl(forceSingleValue, fieldValue) {
+    let invalid = false;
+
+    if (forceSingleValue) {
+      if (_.isNumber(fieldValue)) {
+        if (fieldValue === 0) {
+          invalid = true;
+        }
+      } else if (_.isEmpty(fieldValue)) {
+        invalid = true;
+      }
+    } else {
+      if (_.isEmpty(fieldValue)) {
+        invalid = true;
+      }
+    }
+
+    return invalid;
   }
 }


### PR DESCRIPTION
Before, we were using lodash's `_.isEmpty` method to determine if something was selected or not, but `_.isEmpty` does not behave the Ruby version we know and love. It only determines if an object is empty, not a variable. So, the problem was that the tag control select was passing in a category id, which was a number, and `_.isEmpty(1234)` returns true. Therefore validation was failing 😢.

This changes the logic so that when a single value is to be selected, we check to see if it's a number. If it's 0 (which is the "choose" value), then we still need to select something, otherwise we should be ok. If it somehow gets set to null, we should still also be failing validation.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1567108

@miq-bot add_label gaprindashvili/yes, bug

@miq-bot assign @himdel 

@himdel It's not currently marked as a blocker but will likely be a blocker for 5.9.3, just so you know.
@chalettu Can you review please?

/cc @gmcculloug