### PR TITLE
Fix for default value containing all values of a list instead of single value

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -106,4 +106,52 @@ describe('Dialog test', () =>  {
       });
     });
   });
+
+  describe('#refreshFieldCallback', () => {
+    let dialogCtrl;
+
+    const dialogRefreshFile = require('../../../../demo/data/dialog-data-refresh.json');
+    const oldDialogData = dialogRefreshFile.resources[0].content[0];
+
+    const newDialogData = {
+      data_type: 'new data_type',
+      options: 'new options',
+      read_only: 'new read_only',
+      required: true,
+      visible: false,
+      values: 'new values',
+      default_value: 'new default_value'
+    };
+
+    beforeEach(() => {
+      bindings = {
+        dialog: oldDialogData,
+        refreshField: () => true,
+        onUpdate: () => true,
+        inputDisabled: false
+      };
+
+      angular.mock.module('miqStaticAssets.dialogUser');
+      angular.mock.inject($componentController =>  {
+        dialogCtrl = $componentController('dialogUser', null, bindings);
+        dialogCtrl.$onInit();
+      });
+
+      dialogCtrl.refreshFieldCallback('service_name', newDialogData);
+    });
+
+    it('updates the field value', () => {
+      expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
+    });
+
+    it('updates properties of the field', () => {
+      expect(dialogCtrl.dialogFields['service_name'].data_type).toBe('new data_type');
+      expect(dialogCtrl.dialogFields['service_name'].options).toBe('new options');
+      expect(dialogCtrl.dialogFields['service_name'].read_only).toBe('new read_only');
+      expect(dialogCtrl.dialogFields['service_name'].required).toBe(true);
+      expect(dialogCtrl.dialogFields['service_name'].visible).toBe(false);
+      expect(dialogCtrl.dialogFields['service_name'].values).toBe('new values');
+      expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
+    });
+  });
 });

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -203,23 +203,34 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
     return new Promise((resolve, reject) => {
       this.refreshField({ field: this.dialogFields[field] }).then((data) => {
-        this.dialogFields[field] = this.updateDialogFieldData(field, data);
-        this.dialogValues[field] = data.values;
-        this.dialogFields[field].fieldBeingRefreshed = false;
-
-        this.saveDialogData();
-        this.$scope.$apply();
-
-        if (! _.isEmpty(this.fieldAssociations[field])) {
-          this.updateTargetedFieldsFrom(field);
-        } else if (this.refreshRequestCount === 0) {
-          this.areFieldsBeingRefreshed = false;
-          this.saveDialogData();
-        }
-
+        this.refreshFieldCallback(field, data);
         resolve(data);
       });
     });
+  }
+
+  /**
+   *  Handles all of the necessary functions after a field has been refreshed
+   *  @memberof DialogUserController
+   *  @function refreshFieldCallback
+   *  @param field {any} This is the field to update and read associations from
+   *  @param data {any} This is the data being returned from refreshField
+   */
+
+  private refreshFieldCallback(field, data) {
+    this.dialogFields[field] = this.updateDialogFieldData(field, data);
+    this.dialogValues[field] = data.default_value;
+    this.dialogFields[field].fieldBeingRefreshed = false;
+
+    this.saveDialogData();
+    this.$scope.$apply();
+
+    if (! _.isEmpty(this.fieldAssociations[field])) {
+      this.updateTargetedFieldsFrom(field);
+    } else if (this.refreshRequestCount === 0) {
+      this.areFieldsBeingRefreshed = false;
+      this.saveDialogData();
+    }
   }
 
   /**


### PR DESCRIPTION
The change is very simple but I broke it out into a function refactor as well since it becomes much easier to test this way.

The effective change is:
```
-    this.dialogValues[field] = data.values;
+    this.dialogValues[field] = data.default_value;
```
In the code below, it's line 207 that gets changed for line 222

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568440

@miq-bot add_label gaprindashvili/yes, bug
@miq-bot assign @himdel 

@chalettu Can you review please?