### PR TITLE
Remove underlined text from quads

### DIFF
--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -173,6 +173,9 @@ table.miq-table-with-footer { /* not currently used */
       }
       a {
         word-wrap: break-word;
+        &:hover {
+          text-decoration: none;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR corrects an issue where text within the quad icons was underlined on hover.

Old
<img width="156" alt="screen shot 2018-04-17 at 2 53 08 pm" src="https://user-images.githubusercontent.com/1287144/38892519-721eac8c-4255-11e8-8ca7-a7d8d92994c9.png">

New
<img width="144" alt="screen shot 2018-04-17 at 3 35 15 pm" src="https://user-images.githubusercontent.com/1287144/38892518-72118174-4255-11e8-961c-28237b405346.png">