### PR TITLE
 Adjust the opacity of custom colored icons when they are disabled

### DIFF
--- a/src/common/filters/abbrNumberFilter.spec.ts
+++ b/src/common/filters/abbrNumberFilter.spec.ts
@@ -13,5 +13,5 @@ describe('Filter: abbrNumber', function() {
   it('returns with the same text', function() {
     expect(filter('text')).toBe('text');
     expect(filter('123text')).toBe('123text');
-  })
+  });
 });

--- a/src/common/filters/adjustColorFilter.spec.ts
+++ b/src/common/filters/adjustColorFilter.spec.ts
@@ -1,0 +1,15 @@
+import AdjustColor from './adjustColorFilter';
+
+describe('Filter: adjustColor', function() {
+  let filter = AdjustColor.filter();
+
+  it('does not alter if enabled or undefined', function() {
+    expect(filter(undefined, true)).toBe(undefined);
+    expect(filter(undefined, false)).toBe(undefined);
+    expect(filter("#123456", true)).toBe("#123456");
+  });
+
+  it('returns with an rgba call', function() {
+    expect(filter("#123456", false)).toBe("rgba(18, 52, 86, 0.5)");
+  })
+});

--- a/src/common/filters/adjustColorFilter.spec.ts
+++ b/src/common/filters/adjustColorFilter.spec.ts
@@ -6,10 +6,10 @@ describe('Filter: adjustColor', function() {
   it('does not alter if enabled or undefined', function() {
     expect(filter(undefined, true)).toBe(undefined);
     expect(filter(undefined, false)).toBe(undefined);
-    expect(filter("#123456", true)).toBe("#123456");
+    expect(filter('#123456', true)).toBe('#123456');
   });
 
   it('returns with an rgba call', function() {
-    expect(filter("#123456", false)).toBe("rgba(18, 52, 86, 0.5)");
-  })
+    expect(filter('#123456', false)).toBe('rgba(18, 52, 86, 0.5)');
+  });
 });

--- a/src/common/filters/adjustColorFilter.ts
+++ b/src/common/filters/adjustColorFilter.ts
@@ -1,0 +1,16 @@
+export default class AdjustColor {
+  public static filter() {
+    return (value, enabled) => {
+      // Don't touch the color if it's enabled or unset
+      if (enabled || !value) {
+        return value;
+      } else {
+        let r = parseInt(value.substring(1,3), 16);
+        let g = parseInt(value.substring(3,5), 16);
+        let b = parseInt(value.substring(5,7), 16);
+
+        return `rgba(${r}, ${g}, ${b}, 0.5)`;
+      }
+    };
+  }
+}

--- a/src/common/filters/index.ts
+++ b/src/common/filters/index.ts
@@ -1,5 +1,7 @@
 import AbbrNumber from './abbrNumberFilter';
+import AdjustColor from './adjustColorFilter';
 
 export default (module: ng.IModule) => {
   module.filter('abbrNumber', AbbrNumber.filter);
+  module.filter('adjustColor', AdjustColor.filter);
 };

--- a/src/toolbar/components/toolbar-menu/toolbar-button.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-button.html
@@ -18,10 +18,10 @@
         ng-click="onItemClick({item: toolbarButton, $event: $event})">
   <i ng-if="toolbarButton.icon && toolbarButton.text"
      class="{{toolbarButton.icon}}"
-     ng-style="{color: toolbarButton.color}"></i>
+     ng-style="{color: (toolbarButton.color | adjustColor : toolbarButton.enabled)}"></i>
   <i ng-if="toolbarButton.icon && !toolbarButton.text"
      class="{{toolbarButton.icon}}"
-     ng-style="{color: toolbarButton.color}"></i>
+     ng-style="{color: (toolbarButton.color | adjustColor : toolbarButton.enabled)}"></i>
   <img ng-if="toolbarButton.img_url && !toolbarButton.icon" ng-src="{{toolbarButton.img_url}}"
        data-enabled="{{toolbarButton.img_url}}"
        data-disabled="{{toolbarButton.img_url}}">

--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -28,8 +28,8 @@
          data-prompt="{{item.prompt}}"
          data-popup="{{item.popup}}"
          data-url="{{item.url}}">
-        <i ng-if="item.icon && item.text" class="{{item.icon}}" ng-style="{color: item.color}" style="margin-right: 5px;"></i>
-        <i ng-if="item.icon && !item.text" class="{{item.icon}}" ng-style="{color: item.color}"></i>
+        <i ng-if="item.icon && item.text" class="{{item.icon}}" ng-style="{color: (item.color | adjustColor : item.enabled)}" style="margin-right: 5px;"></i>
+        <i ng-if="item.icon && !item.text" class="{{item.icon}}" ng-style="{color: (item.color | adjustColor : item.enabled)}"></i>
         <img ng-if="item.img_url && !item.icon" ng-src="{{item.img_url}}"
              data-enabled="{{item.img_url}}"
              data-disabled="{{item.img_url}}">

--- a/src/toolbar/components/toolbar-menu/toolbar-view.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-view.html
@@ -11,6 +11,6 @@
           data-popup="{{item.popup}}"
           ng-click="vm.onItemClick({item: item, $event: $event})"
           name="{{item.name}}">
-    <i class="{{item.icon}}" style="" ng-style="{color: item.color}"></i>
+    <i class="{{item.icon}}" style="" ng-style="{color: (item.color | adjustColor : item.enabled)}"></i>
   </button>
 </div>

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -3,7 +3,7 @@ import components from './components';
 import * as angular from 'angular';
 
 module toolbar {
-  export const app = angular.module('miqStaticAssets.toolbar', ['ngSanitize']);
+  export const app = angular.module('miqStaticAssets.toolbar', ['ngSanitize', 'miqStaticAssets.common']);
   services(app);
   components(app);
 }


### PR DESCRIPTION
If a custom color is defined for a toolbar button's icon, the `.disabled` property is not being respected on it. I created a new `adjustColor` filter that has an extra boolean argument. If the boolean is true or the input is unsed, the filter just returns the input, otherwise it converts the hex color into an `rgba(x, y, z, 0.5)` value.

**Before:**
![screenshot from 2018-04-20 15-07-03](https://user-images.githubusercontent.com/649130/39052506-80ca87b6-44ac-11e8-86a5-b73149512e05.png)

**After:**
![screenshot from 2018-04-20 14-44-42](https://user-images.githubusercontent.com/649130/39052510-8590cd78-44ac-11e8-8c27-8fa7022ded83.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot assign @karelhala 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1501114