### PR TITLE
Fix travis failing on $.fn.dropdown.Constructor undefined from new bootstrap-select

### DIFF
--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -2,6 +2,7 @@ import 'es6-shim';
 import 'es7-shim';
 import 'jquery';
 import 'jquery-ui-bundle';
+import 'bootstrap';
 import 'bootstrap-switch';
 import 'angular';
 import 'angular-animate';


### PR DESCRIPTION
boostrap-select 1.13 came out, with a [change](https://github.com/snapappointments/bootstrap-select/commit/0029b3dbb2d5218c4ee7872179019f742ab674bd) that requires bootstrap to be included first, before bootstrap-select

This causes travis to fail with

```
PhantomJS 2.1.1 (Linux 0.0.0) ERROR
  TypeError: undefined is not an object (evaluating '$.fn.dropdown.Constructor')
  at dist/js/vendor.js:72739
```

adding a bootstrap import.