### PR TITLE
Fix for dynamic checkbox not updating properly

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -215,16 +215,7 @@ describe('DialogDataService test', () => {
       let testDefault = dialogData.setDefaultValue(testField);
       expect(testDefault).toBe('test');
     });
-    it('should ensure a checkbox uses default value that is set', () => {
-      let testField = {
-        default_value: 'f',
-        values: 't',
-        name: 'test',
-        type: 'DialogFieldCheckBox'
-      };
-      let testDefault = dialogData.setDefaultValue(testField);
-      expect(testDefault).toBe('f');
-    });
+
     it('should prevent a form from being valid if drop down no option is selected', () => {
       const testDropDown = {
         required: true,
@@ -245,6 +236,38 @@ describe('DialogDataService test', () => {
       const validation = dialogData.validateField(testDropDown, '');
       expect(validation).toEqual(validateFailure);
     });
+
+    describe('when the data type is a check box', () => {
+      let testField = {
+        default_value: 'f',
+        values: 't',
+        name: 'test',
+        type: 'DialogFieldCheckBox'
+      }
+
+      describe('when the field is dynamic', () => {
+        beforeEach(() => {
+          testField['dynamic'] = true;
+        });
+
+        it('ensures the checkbox uses the values that are set', () => {
+          let testDefault = dialogData.setDefaultValue(testField);
+          expect(testDefault).toBe('t');
+        });
+      });
+
+      describe('when the field is not dynamic', () => {
+        beforeEach(() => {
+          testField['dynamic'] = false;
+        });
+
+        it('ensures the checkbox uses the default value that is set', () => {
+          let testDefault = dialogData.setDefaultValue(testField);
+          expect(testDefault).toBe('f');
+        });
+      });
+    });
+
     describe('when the data type is a date control', () => {
       let dateField = {'type': 'DialogFieldDateControl'};
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -96,11 +96,20 @@ export default class DialogDataService {
         defaultValue = data.values;
       }
     }
+
     if (data.default_value) {
       defaultValue = data.default_value;
     }
 
+    if (this.checkboxNeedsNewDefaultValue(data)) {
+      defaultValue = data.values;
+    }
+
     return defaultValue;
+  }
+
+  private checkboxNeedsNewDefaultValue(data): boolean {
+    return (data.type === 'DialogFieldCheckBox' && data.dynamic && data.values !== data.default_value);
   }
 
   /**


### PR DESCRIPTION
When a checkbox has a `default_value` set, it was preferring to use that instead of the value coming back from a dynamic method call. This could happen when importing a dialog with a checkbox field and a `default_value` set in the yaml, or when perhaps converting an originally static checkbox field into a dynamic one.

https://bugzilla.redhat.com/show_bug.cgi?id=1570152

/cc @chalettu Please review

@miq-bot add_label bug, blocker, gaprindashvili/yes
@miq-bot assign @himdel 