### PR TITLE
Send ascending true or false, if undefined set to false for report data

### DIFF
--- a/src/gtl/services/dataTableService.ts
+++ b/src/gtl/services/dataTableService.ts
@@ -141,7 +141,7 @@ export default class DataTableService implements IDataTableService {
       _.assign(params, settings.current && {page: settings.current});
       _.assign(params, settings.perpage && {ppsetting: settings.perpage});
       _.assign(params, settings.sortBy && settings.sortBy.sortObject && {sort_choice: settings.sortBy.sortObject.text});
-      _.assign(params, settings.sortBy && settings.sortBy.isAscending && {is_ascending: settings.sortBy.isAscending});
+      _.assign(params, settings.sortBy && {is_ascending: !!settings.sortBy.isAscending});
     }
     return params;
   }


### PR DESCRIPTION
### Fixes wrong order when switching pages
When switching pages and order of sort is set to DESC it's forgotten and used ASC. This PR fixes such issue by sending `is_ascending` in params, undefined value is mapped to false.

### BZ
https://bugzilla.redhat.com/show_bug.cgi?id=1481840