### PR TITLE
toolbarSettingsService - fix the build

### DIFF
--- a/src/toolbar/services/toolbarSettingsService.ts
+++ b/src/toolbar/services/toolbarSettingsService.ts
@@ -1,7 +1,6 @@
 import {IToolbarItem, IToolbarSettings, IRequestData} from '../interfaces/toolbar';
 import {ToolbarType} from '../interfaces/toolbarType';
-import * as _ from 'lodash';
-import * as ng from 'angular';
+const _ = window['_'];
 
 export default class ToolbarSettingsService {
   private countSelected: number = 0;
@@ -68,7 +67,7 @@ export default class ToolbarSettingsService {
    * @returns {ng.IPromise<IToolbarSettings>}
    * @param getData
    */
-  public getSettings(getData?: IRequestData): ng.IPromise<IToolbarSettings> {
+  public getSettings(getData?: IRequestData) {
     return this.httpGet(
       this.MiQEndpointsService.rootPoint + this.MiQEndpointsService.endpoints.toolbarSettings,
       getData
@@ -112,7 +111,7 @@ export default class ToolbarSettingsService {
    * @param dataObject
    * @returns {ng.IPromise<Array<Array<IToolbarItem>>>}
    */
-  private httpGet(url: string, dataObject: any): ng.IPromise<Array<Array<IToolbarItem>>> {
+  private httpGet(url: string, dataObject: any) {
     return this.$http.get(url, {params: dataObject})
       .then(dataResponse => dataResponse.data);
   }


### PR DESCRIPTION
This is more likely a typescript bug than any real problem in this file.

But we need to be able to build ui-components more than we need type info :)

Without this:

```
yarn run tsc src/toolbar/services/toolbarSettingsService.ts

(crickets)

--- Last few GCs --->

[26362:0x55c5912ff860]    48909 ms: Mark-sweep 1380.1 (1476.8) -> 1380.0 (1479.3) MB, 1073.6 / 0.0 ms  allocation failure GC in old space requested
[26362:0x55c5912ff860]    50016 ms: Mark-sweep 1380.0 (1479.3) -> 1380.0 (1447.8) MB, 1106.6 / 0.0 ms  last resort GC in old space requested
[26362:0x55c5912ff860]    51121 ms: Mark-sweep 1380.0 (1447.8) -> 1380.0 (1447.8) MB, 1104.7 / 0.0 ms  last resort GC in old space requested

<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x316d48a18fe1 <JSObject>
    1: set(this=0x8638d2f7ca1 <Map map = 0x350f3b193a29>,0x2b0b3898ae09 <String[12]: 9,1048249:15>,0x2b0b3898ae31 <Type map = 0x2995ee514269>)
    2: getUnionTypeFromSortedList [/home/himdel/ui-components/node_modules/typescript/lib/tsc.js:~26367] [pc=0x3a53dc8b811f](this=0x15ac50b080a9 <JSGlobal Object>,types=0x2833040d1e71 <JSArray[16]>,aliasSymbol=0x316d48a02241 <undefined>,aliasTypeArguments...

FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
 1: node::Abort() [node]
 2: 0x55c58fa1adb1 [node]
 3: v8::Utils::ReportOOMFailure(char const*, bool) [node]
 4: v8::internal::V8::FatalProcessOutOfMemory(char const*, bool) [node]
 5: v8::internal::Factory::NewFixedArray(int, v8::internal::PretenureFlag) [node]
 6: v8::internal::OrderedHashTable<v8::internal::OrderedHashMap, 2>::Allocate(v8::internal::Isolate*, int, v8::internal::PretenureFlag) [node]
 7: v8::internal::OrderedHashTable<v8::internal::OrderedHashMap, 2>::Rehash(v8::internal::Handle<v8::internal::OrderedHashMap>, int) [node]
 8: v8::internal::Runtime_MapGrow(int, v8::internal::Object**, v8::internal::Isolate*) [node]
 9: 0x3a53dc5040bd
Aborted (core dumped)
```

With this:

```
yarn run tsc src/toolbar/services/toolbarSettingsService.ts
Done in 1.78s.
```

(Also, running `webpack` or `yarn build` fails with the same error without this.)


Cc @karelhala 