### PR TITLE
Use the name of the category that comes from the API as category_name

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.spec.ts
+++ b/src/dialog-editor/components/modal/modalComponent.spec.ts
@@ -16,9 +16,10 @@ describe('modalComponentSpec', () => {
 
     describe('#setupCategoryOptions', () => {
       it('sets the id, name and description entries for the selected tag control', () => {
-        modalComponent.categories = { resources : [{'id': '10', 'description': 'CategoryName'}] };
+        modalComponent.categories = { resources : [{'id': '10', 'description': 'CategoryName', 'name': 'cc'}] };
         modalComponent.setupCategoryOptions();
-        expect(modalComponent.modalData.options.category_name).toEqual('category_name');
+        expect(modalComponent.modalData.options.category_id).toEqual('10');
+        expect(modalComponent.modalData.options.category_name).toEqual('cc');
         expect(modalComponent.modalData.options.category_description).toEqual('CategoryName');
       });
     });

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -249,7 +249,7 @@ class ModalController {
     _.forEach(this.categories.resources, function (name) {
       if(name['id'] === item) {
         vm.modalData.options.category_description = name['description'];
-        vm.modalData.options.category_name = _.snakeCase(name['description']);
+        vm.modalData.options.category_name = name['name'];
       }
     });
   }


### PR DESCRIPTION
Certain categories have different names than their description, and so sometimes it was failing when trying to choose them to use. This fixes the issue with [this PR from the classic UI](https://github.com/ManageIQ/manageiq-ui-classic/pull/3865) so that we get the correct name from the API in the first place.

The Classic UI PR needs to be merged first.

https://bugzilla.redhat.com/show_bug.cgi?id=1570613

/cc @gmcculloug @d-m-u 

@miq-bot assign @himdel  
@miq-bot add_label gaprindashvili/yes, bug