### PR TITLE
Fix for default value being set incorrectly for non 'DialogFieldSortedItem' field types

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -113,45 +113,149 @@ describe('Dialog test', () =>  {
     const dialogRefreshFile = require('../../../../demo/data/dialog-data-refresh.json');
     const oldDialogData = dialogRefreshFile.resources[0].content[0];
 
-    const newDialogData = {
-      data_type: 'new data_type',
-      options: 'new options',
-      read_only: 'new read_only',
-      required: true,
-      visible: false,
-      values: 'new values',
-      default_value: 'new default_value'
-    };
-
-    beforeEach(() => {
-      bindings = {
-        dialog: oldDialogData,
-        refreshField: () => true,
-        onUpdate: () => true,
-        inputDisabled: false
+    describe('when the dialog data is for a drop down list', () => {
+      const newDialogData = {
+        data_type: 'new data_type',
+        options: 'new options',
+        read_only: 'new read_only',
+        required: true,
+        visible: false,
+        values: 'new values',
+        default_value: 'new default_value',
+        type: 'DialogFieldDropDownList'
       };
 
-      angular.mock.module('miqStaticAssets.dialogUser');
-      angular.mock.inject($componentController =>  {
-        dialogCtrl = $componentController('dialogUser', null, bindings);
-        dialogCtrl.$onInit();
+      beforeEach(() => {
+        bindings = {
+          dialog: oldDialogData,
+          refreshField: () => true,
+          onUpdate: () => true,
+          inputDisabled: false
+        };
+
+        angular.mock.module('miqStaticAssets.dialogUser');
+        angular.mock.inject($componentController =>  {
+          dialogCtrl = $componentController('dialogUser', null, bindings);
+          dialogCtrl.$onInit();
+        });
+
+        dialogCtrl.refreshFieldCallback('service_name', newDialogData);
       });
 
-      dialogCtrl.refreshFieldCallback('service_name', newDialogData);
+      it('updates the field value', () => {
+        expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
+      });
     });
 
-    it('updates the field value', () => {
-      expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
+    describe('when the dialog data is for a radio button', () => {
+      const newDialogData = {
+        data_type: 'new data_type',
+        options: 'new options',
+        read_only: 'new read_only',
+        required: true,
+        visible: false,
+        values: 'new values',
+        default_value: 'new default_value',
+        type: 'DialogFieldRadioButton'
+      };
+
+      beforeEach(() => {
+        bindings = {
+          dialog: oldDialogData,
+          refreshField: () => true,
+          onUpdate: () => true,
+          inputDisabled: false
+        };
+
+        angular.mock.module('miqStaticAssets.dialogUser');
+        angular.mock.inject($componentController =>  {
+          dialogCtrl = $componentController('dialogUser', null, bindings);
+          dialogCtrl.$onInit();
+        });
+
+        dialogCtrl.refreshFieldCallback('service_name', newDialogData);
+      });
+
+      it('updates the field value', () => {
+        expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
+      });
     });
 
-    it('updates properties of the field', () => {
-      expect(dialogCtrl.dialogFields['service_name'].data_type).toBe('new data_type');
-      expect(dialogCtrl.dialogFields['service_name'].options).toBe('new options');
-      expect(dialogCtrl.dialogFields['service_name'].read_only).toBe('new read_only');
-      expect(dialogCtrl.dialogFields['service_name'].required).toBe(true);
-      expect(dialogCtrl.dialogFields['service_name'].visible).toBe(false);
-      expect(dialogCtrl.dialogFields['service_name'].values).toBe('new values');
-      expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
+    describe('when the dialog data is for a tag control', () => {
+      const newDialogData = {
+        data_type: 'new data_type',
+        options: 'new options',
+        read_only: 'new read_only',
+        required: true,
+        visible: false,
+        values: 'new values',
+        default_value: 'new default_value',
+        type: 'DialogFieldTagControl'
+      };
+
+      beforeEach(() => {
+        bindings = {
+          dialog: oldDialogData,
+          refreshField: () => true,
+          onUpdate: () => true,
+          inputDisabled: false
+        };
+
+        angular.mock.module('miqStaticAssets.dialogUser');
+        angular.mock.inject($componentController =>  {
+          dialogCtrl = $componentController('dialogUser', null, bindings);
+          dialogCtrl.$onInit();
+        });
+
+        dialogCtrl.refreshFieldCallback('service_name', newDialogData);
+      });
+
+      it('updates the field value', () => {
+        expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
+      });
+    });
+
+    describe('when the dialog data field type is not a sorted item type', () => {
+      const newDialogData = {
+        data_type: 'new data_type',
+        options: 'new options',
+        read_only: 'new read_only',
+        required: true,
+        visible: false,
+        values: 'new values',
+        default_value: 'new default_value'
+      };
+
+      beforeEach(() => {
+        bindings = {
+          dialog: oldDialogData,
+          refreshField: () => true,
+          onUpdate: () => true,
+          inputDisabled: false
+        };
+
+        angular.mock.module('miqStaticAssets.dialogUser');
+        angular.mock.inject($componentController =>  {
+          dialogCtrl = $componentController('dialogUser', null, bindings);
+          dialogCtrl.$onInit();
+        });
+
+        dialogCtrl.refreshFieldCallback('service_name', newDialogData);
+      });
+
+      it('updates the field value', () => {
+        expect(dialogCtrl.dialogValues['service_name']).toBe('new values');
+      });
+
+      it('updates properties of the field', () => {
+        expect(dialogCtrl.dialogFields['service_name'].data_type).toBe('new data_type');
+        expect(dialogCtrl.dialogFields['service_name'].options).toBe('new options');
+        expect(dialogCtrl.dialogFields['service_name'].read_only).toBe('new read_only');
+        expect(dialogCtrl.dialogFields['service_name'].required).toBe(true);
+        expect(dialogCtrl.dialogFields['service_name'].visible).toBe(false);
+        expect(dialogCtrl.dialogFields['service_name'].values).toBe('new values');
+        expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
+      });
     });
   });
 });

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -219,7 +219,11 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
   private refreshFieldCallback(field, data) {
     this.dialogFields[field] = this.updateDialogFieldData(field, data);
-    this.dialogValues[field] = data.default_value;
+    if (this.isASortedItemDialogField(data.type)) {
+      this.dialogValues[field] = data.default_value;
+    } else {
+      this.dialogValues[field] = data.values;
+    }
     this.dialogFields[field].fieldBeingRefreshed = false;
 
     this.saveDialogData();
@@ -231,6 +235,18 @@ export class DialogUserController extends DialogClass implements IDialogs {
       this.areFieldsBeingRefreshed = false;
       this.saveDialogData();
     }
+  }
+
+  /**
+   * Determines if the given field type is a subclass of DialogFieldSortedItem
+   * @memberof DialogUserController
+   * @function isASortedItemDialogField
+   * @param fieldType {string} This is the field type that should be used for comparison
+   */
+  private isASortedItemDialogField(fieldType) {
+    return fieldType === 'DialogFieldDropDownList' ||
+           fieldType === 'DialogFieldRadioButton' ||
+           fieldType === 'DialogFieldTagControl';
   }
 
   /**


### PR DESCRIPTION
Ok, so it turns out the fix for https://github.com/ManageIQ/ui-components/pull/279 was a bug only for sorted items, because sorted items use a default value to show what is selected. However, for something like a textbox/checkbox/date element, "values" are used. So, this will use default_value for sorted items but values for non-sorted items.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1568440

@chalettu One more review, please? 😄 

@miq-bot assign @himdel 
@miq-bot add_label gaprindashvili/yes, bug, blocker