### PR TITLE
Use new 'miq-select' directive instead of patternfly

### DIFF
--- a/application-settings.js
+++ b/application-settings.js
@@ -17,6 +17,7 @@ module.exports = {
     quadicon: '/quadicon',
     treeView: '/tree-view',
     treeSelector: '/tree-selector',
+    miqSelect: '/miq-select',
   },
   nodePackages: 'node_modules/',
   get stylesheetPath() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
 
 const webpackConfig = require('./webpack.config');
-const fileGlob = 'src/**/*.spec.ts';
+const fileGlob = 'src/**/*.spec.[jt]s';
 const vendor = 'dist/js/vendor.js';
 const applicationFile = 'dist/js/ui-components.js';
 const jsonGlob = {pattern: 'src/**/*.json', watched: true, served: true, included: false};

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -50,10 +50,11 @@
 
     <div class="col-sm-4" ng-switch-when="DialogFieldDropDownList">
       <!-- Dropdown field where a single value is expected - PF 3 compatible-->
-      <select pf-select
+      <select miq-select
               data-live-search="true"
-              ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
+              ng-if="!vm.dialogField.options.force_multi_value"
               ng-model="vm.dialogField.default_value"
+              watch-model="vm.dialogField.values"
               ng-blur="vm.validateField()"
               ng-change="vm.changesHappened()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
@@ -67,54 +68,18 @@
         </option>
       </select>
 
-      <!-- Dropdown field where a single value is expected - PF 4 compatible-->
-      <select pf-bootstrap-select
-              data-live-search="true"
-              ng-if="!vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
-              ng-model="vm.dialogField.default_value"
-              ng-blur="vm.validateField()"
-              ng-change="vm.changesHappened()"
-              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-              class="form-control"
-              data-container="body"
-              id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
-      </select>
-
-      <!-- PF 3 compatible multiselect -->
-      <select pf-select multiple
+      <select miq-select multiple
               data-live-search="true"
               data-container="body"
-              ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 3"
+              ng-if="vm.dialogField.options.force_multi_value"
               ng-init="vm.convertValuesToArray()"
               ng-model="vm.dialogField.default_value"
+              watch-model="vm.dialogField.values"
               ng-change="vm.changesHappened(item)"
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               input-id="{{ vm.dialogField.name }}">
         <option ng-repeat="value in vm.dialogField.values"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
-      </select>
-
-      <!-- PF 4 compatible multiselect -->
-      <select pf-bootstrap-select multiple
-              data-live-search="true"
-              data-container="body"
-              ng-if="vm.dialogField.options.force_multi_value && vm.patternflyVersion === 4"
-              ng-init="vm.convertValuesToArray()"
-              ng-model="vm.dialogField.default_value"
-              ng-change="vm.changesHappened(item)"
-              ng-blur="vm.validateField()"
-              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-              input-id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
                 data-tokens="{{value[0]}} {{value[1]}}"
                 value="{{value[0]}}">
           {{value[1]}}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ module miqStaticAssets {
     'miqStaticAssets.fonticonPicker',
     'miqStaticAssets.quadicon',
     'miqStaticAssets.treeView',
-    'miqStaticAssets.treeSelector'
+    'miqStaticAssets.treeSelector',
+    'miqStaticAssets.miqSelect'
   ]);
 }

--- a/src/miq-select/index.ts
+++ b/src/miq-select/index.ts
@@ -1,0 +1,7 @@
+import MiqSelect from './miqSelect';
+import * as angular from 'angular';
+
+module miqSelect {
+  export const app = angular.module('miqStaticAssets.miqSelect', []);
+  app.directive('miqSelect', MiqSelect);
+}

--- a/src/miq-select/miqSelect.js
+++ b/src/miq-select/miqSelect.js
@@ -1,0 +1,53 @@
+var miqSelect = function () {
+  'use strict';
+
+  return {
+    restrict: 'A',
+    require: '?ngModel',
+    scope: {
+      selectPickerOptions: '=miqSelect'
+    },
+    link: function (scope, element, attrs, ngModel) {
+      var optionCollectionList, optionCollectionExpr, optionCollection, $render = ngModel.$render;
+
+      var selectpickerRefresh = function (argument) {
+        scope.$applyAsync(function () {
+          element.selectpicker('refresh');
+        });
+      };
+
+      var selectpickerDestroy = function () {
+        element.selectpicker('destroy');
+      };
+
+      element.selectpicker(scope.selectPickerOptions);
+
+      ngModel.$render = function () {
+        $render.apply(this, arguments);
+        selectpickerRefresh();
+      };
+
+      if (attrs.ngOptions) {
+        optionCollectionList = attrs.ngOptions.split('in ');
+        optionCollectionExpr = optionCollectionList[optionCollectionList.length - 1].split(/track by|\|/);
+        optionCollection = optionCollectionExpr[0];
+
+        scope.$parent.$watchCollection(optionCollection, selectpickerRefresh);
+      }
+
+      if (attrs.ngModel) {
+        scope.$parent.$watch(attrs.ngModel, selectpickerRefresh);
+      }
+
+      if (attrs.watchModel) {
+        scope.$parent.$watch(attrs.watchModel, selectpickerRefresh);
+      }
+
+      attrs.$observe('disabled', selectpickerRefresh);
+
+      scope.$on('$destroy', selectpickerDestroy);
+    }
+  };
+};
+
+export default miqSelect;

--- a/src/miq-select/miqSelect.spec.js
+++ b/src/miq-select/miqSelect.spec.js
@@ -1,0 +1,156 @@
+describe('miq-select', function () {
+  var $scope;
+  var $compile;
+
+  beforeEach(angular.mock.module('miqStaticAssets.miqSelect'));
+
+  beforeEach(inject(function (_$rootScope_, _$compile_) {
+    $scope = _$rootScope_;
+    $compile = _$compile_;
+  }));
+
+  describe('Page with miq-select directive', function () {
+    var compileSelect = function (markup, scope) {
+      var el = $compile(markup)(scope);
+      scope.$digest();
+      return el;
+    };
+
+    it('generates correct options from ng-options', function () {
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[1];
+
+      var select = compileSelect('<select miq-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      var bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('b');
+    });
+
+    it('responds to changes in ng-options', function () {
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      var select = compileSelect('<select miq-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      $scope.$apply(function () {
+        $scope.options.push('d');
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abcd');
+
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
+      bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abcd');
+    });
+
+    it('responds to ng-model changes', function () {
+      $scope.options = ['a','b','c'];
+      $scope.modelValue = $scope.options[0];
+      var select = compileSelect('<select miq-select ng-model="modelValue" ng-options="o as o for o in options"></select>', $scope);
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('abc');
+
+      var bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('a');
+
+      $scope.$apply(function () {
+        $scope.modelValue = $scope.options[1];
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('b');
+
+      $scope.$apply(function () {
+        $scope.modelValue = $scope.options[2];
+      });
+
+      $scope.$digest();
+
+      expect(select.text()).toBe('abc');
+
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('c');
+    });
+
+    it('works correctly with ng-repeat', function() {
+      $scope.options = [['1', 'one'], ['2', 'two'], ['3', 'three']];
+      $scope.modelValue = $scope.options[1][0];
+      var select = compileSelect('<select miq-select ng-model="modelValue" watch-model="options"><option ng-repeat="o in options" value="{{o[0]}}">{{o[1]}}</option></select>', $scope);
+
+      $scope.$digest();
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('onetwothree');
+    });
+
+    it('responds to watch-model changes', function() {
+      $scope.options = [['1', 'one'], ['2', 'two'], ['3', 'three']];
+      $scope.modelValue = $scope.options[0][0];
+
+      var select = compileSelect('<select miq-select ng-model="modelValue" watch-model="options"><option ng-repeat="o in options" value="{{o[0]}}">{{o[1]}}</option></select>', $scope);
+
+      $scope.$digest();
+
+      var bsSelect = angular.element(select).siblings('.dropdown-menu');
+      var bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('onetwothree');
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('one');
+
+      $scope.$apply(function () {
+        $scope.options = [['1', 'uno'], ['2', 'dos'], ['3', 'tres']];
+      });
+
+      $scope.$digest();
+
+      bsSelect = angular.element(select).siblings('.dropdown-menu');
+      bsSelItems = bsSelect.find('li');
+      expect(bsSelItems.length).toBe($scope.options.length);
+      expect(bsSelItems.text()).toBe('unodostres');
+      bsSelected = bsSelect.find('li.selected');
+      expect(bsSelected.length).toBe(1);
+      expect(bsSelected.text()).toBe('uno');
+    });
+  });
+});


### PR DESCRIPTION
Tagging @himdel for some assistance on this one.

~~I basically can't seem to get the template to actually convert the `<select>` tags to the way bootstrap does it with the `<ul>` structure. If I'm in the classic UI and I manually call something like `$('select').selectpicker()`, it works, but the directive should be doing that.~~

~~You can even see in the specs, the spec on line 29 that is doing the expect on the `select.text()` isn't the one that fails, it's failing trying to find the length of the "bootstrap" select elements it's supposed to generate, and then failing on all the other specs assessing the other properties of those elements.~~

The issue is kind of a corner case, but the reason for this change is mainly due to the fact that we are using the `data-live-search` feature for dropdowns, which means we need to include `data-token` on the options (which in turn means we cannot use `ng-options`).  Because of this, when the options in the drop down change, but not the values (for example going from `[["1", "one"], ["2", "two"]]` to `[["1", "uno"], ["2", "dos"]]`), the drop down does not trigger a `selectpicker('refresh')` and the user sees incorrect options to choose from until they pick one and then it magically changes, leaving them confused.

This change will allow the user to specify a new option on the select tag called `watch-model` which angular will place a watch on so that when it changes, `selectpicker('refresh')` gets called.

This also has an added benefit that it consolidates the two different patternfly selects into a single one so we don't have to worry about using patternfly v3 on ops UI and v4 on SUI (at least for selects).

https://bugzilla.redhat.com/show_bug.cgi?id=1574668