### PR TITLE
Added option to load values on initialization

### DIFF
--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -80,6 +80,13 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate }}"/>
       </div>
+      <div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.load_values_on_init"
+               type="checkbox"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate }}"/>
+      </div>
       <div pf-form-group pf-label="{{'Required'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.required"


### PR DESCRIPTION
radio button, being a subclass of `DialogFieldSortedItem` should have an option to load values on init as well:

https://github.com/ManageIQ/manageiq/blob/79305c792da2315968940910f00da36f6863a61e/spec/models/dialog_field_sorted_item_spec.rb#L8

/cc @d-m-u 