### PR TITLE
Add support for displaying simple CSS piecharts in quadicons

### DIFF
--- a/demo/controllers/quadiconController.ts
+++ b/demo/controllers/quadiconController.ts
@@ -122,7 +122,7 @@ export default class QuadiconController {
         fonticon: 'fa fa-shield',
         color: '#ffcc33',
       }
-    },
+    }
   ];
 
   public numbers = ((function() {
@@ -148,6 +148,21 @@ export default class QuadiconController {
       bottomRight: item
     })));
   })());
+
+  public piecharts = (function() {
+    let examples : any = [];
+
+    for (let i = 0; i < 5; i++) {
+      examples.push(i);
+    }
+
+    return [{piechart: 0}, {piechart: 10}, {piechart: 20}].concat(examples.map(item => ({
+      topLeft: { piechart: item * 4  },
+      topRight: { piechart: item * 4 + 1 },
+      bottomLeft: { piechart: item * 4 + 2 },
+      bottomRight: { piechart: item * 4 + 3 },
+    })));
+  })();
 
   public hosts = [
     {

--- a/demo/styles/demo-app.scss
+++ b/demo/styles/demo-app.scss
@@ -59,3 +59,35 @@ table .narrow {
   margin-left: 147px;
   margin-top: 25px;
 }
+
+.piechart {
+  $chart-empty: yellowgreen !default;
+  $chart-fill: blue !default;
+
+  border-radius: 50%;
+  background: $chart-empty;
+  background-image: linear-gradient(to right, transparent 50%, $chart-fill 0);
+
+  &::before {
+    content: '';
+    display: block;
+    margin-left: 50%;
+    height: 100%;
+    border-radius: 0 100% 100% 0 / 50%;
+    background-color: inherit;
+    transform-origin: left;
+  }
+
+  @for $i from 0 through 10 {
+    &.fill-#{$i}::before {
+      transform: rotate(#{$i / 20}turn);
+    }
+  }
+
+  @for $i from 11 through 20 {
+    &.fill-#{$i}::before {
+      background: $chart-fill;
+      transform: rotate(#{($i - 10) / 20}turn);
+    }
+  }
+}

--- a/demo/views/quadicon/basic.html
+++ b/demo/views/quadicon/basic.html
@@ -9,6 +9,12 @@
 </div>
 <div class="clearfix"></div>
 <hr>
+<h2>Pie charts</h2>
+<div class="pull-left" style="padding: 10px;" ng-repeat="quad in vm.piecharts">
+  <miq-quadicon data="quad"></miq-quadicon>
+</div>
+<div class="clearfix"></div>
+<hr>
 <h2>ManageIQ Examples</h2>
 
 <h3>Hosts</h3>

--- a/src/quadicon/components/quaditem/quaditem.html
+++ b/src/quadicon/components/quaditem/quaditem.html
@@ -7,3 +7,4 @@
 <div class="text" ng-if="$ctrl.data.text" ng-class="$ctrl.fontSize()">
   {{ $ctrl.data.text | abbrNumber }}
 </div>
+<div class="piechart fill-{{ $ctrl.data.piechart }}" ng-if="$ctrl.data.piechart || $ctrl.data.piechart === 0"></div>

--- a/src/quadicon/components/quaditem/quaditemComponent.ts
+++ b/src/quadicon/components/quaditem/quaditemComponent.ts
@@ -1,6 +1,17 @@
 import * as ng from 'angular';
 
 export class QuaditemController {
+  /*
+   * The data object can contain the following keys:
+   * - fonticon
+   * - fileicon
+   * - text
+   * - tooltip
+   * - background - background color of the given quadrant
+   * - color - color of text/fonticon
+   * - piechart - numeric value between 0..20, requires the .piechart CSS class from the demo to be extracted
+   */
+
   public data : any;
 
   /* @ngInject */

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -428,6 +428,8 @@ miq-quadicon {
   $radius: 6px;
   $font-size: $quad-w /3;
   $quad-bg: linear-gradient(180deg, rgb(144, 142, 143) 0%, rgb(87, 87, 87) 62%, rgb(64, 64, 65) 100%);
+  $piechart-small: 30px;
+  $piechart-large: 60px;
 
   // Clearfix across the component
   display: block;
@@ -463,6 +465,11 @@ miq-quadicon {
 
       position: relative;
       height: $quad-h / 2;
+
+      .piechart {
+        width: $piechart-small;
+        height: $piechart-small;
+      }
 
       .fileicon img{
         height: $quad-h / 3 + ($quad-h / 14);
@@ -529,6 +536,12 @@ miq-quadicon {
           height: $quad-h / 2 + ($quad-h / 4);
           width: $quad-w / 2 + ($quad-w / 4);
         }
+
+        .piechart {
+          width: $piechart-large;
+          height: $piechart-large;
+        }
+
         .fonticon, .text {
           font-size: $font-size * 2;
         }


### PR DESCRIPTION
Currently we have 20 PNG images for displaying pie charts, so I dynamically generated 20 CSS classes that mimic the behavior of the PNGs. The solution is intended to be universal, i.e. to use them not just in quadicons, so the full styling will go into `ui-classic`.

![screenshot from 2018-06-06 16-11-44](https://user-images.githubusercontent.com/649130/41043509-5fab5944-69a4-11e8-9744-95c7b1495cf5.png)

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @epwinchell 
