### PR TITLE
Make possible to add values after dropdown is changed to static

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -210,6 +210,9 @@ class ModalController {
    * @function addEntry
    */
   public addEntry() {
+    if (this.modalData.values == null) {
+      this.modalData.values = [];
+    }
     this.modalData.values.push(['', '']);
   }
 


### PR DESCRIPTION
If the dialog is saved with a dynamic dropdown, there are no values in it, therefore `modalData.values` is `null` and makes it impossible to add any entries.

The fix tests if the `modalData.values` is `null`, and if so, it initializes it with empty array

Fixes: https://github.com/ManageIQ/ui-components/issues/301

/cc @d-m-u 