### PR TITLE
Added missing checkbox to allow load dynamic dialog values on init

### DIFF
--- a/src/dialog-editor/components/modal-field-template/check-box.html
+++ b/src/dialog-editor/components/modal-field-template/check-box.html
@@ -52,6 +52,13 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate }}"/>
       </div>
+      <div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.load_values_on_init"
+               type="checkbox"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate }}"/>
+      </div>
       <div pf-form-group pf-label="{{'Required'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.required"

--- a/src/dialog-editor/components/modal-field-template/text-area-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-area-box.html
@@ -54,6 +54,13 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate }}"/>
       </div>
+      <div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.load_values_on_init"
+               type="checkbox"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate }}"/>
+      </div>
       <div pf-form-group pf-label="{{'Required'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.required"

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -66,6 +66,13 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate }}"/>
       </div>
+      <div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.load_values_on_init"
+               type="checkbox"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate }}"/>
+      </div>
       <div pf-form-group pf-label="{{'Required'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.required"


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1576107

Basically the same change as in https://github.com/ManageIQ/ui-components/pull/296.

To test this, the dialog element must be dynamic and "Show Refresh Button" option must be turned on.