### PR TITLE
Do not display cardview if no data available

### DIFF
--- a/src/gtl/components/tile-view/tile-view.html
+++ b/src/gtl/components/tile-view/tile-view.html
@@ -1,7 +1,7 @@
 <div class="miq-tile-section">
     <div ng-if="tileCtrl.settings.isLoading" class="spinner spinner-lg"></div>
     <div class="miq-pagination"
-         ng-if="tileCtrl.settings && tileCtrl.settings.sortBy && (tileCtrl.settings.isLoading || tileCtrl.rows.length !== 0)">
+         ng-if="tileCtrl.isVisible()">
       <miq-pagination settings="tileCtrl.settings"
                       per-page="tileCtrl.perPage"
                       has-checkboxes="tileCtrl.countCheckboxes() > 0"
@@ -15,6 +15,7 @@
        config="tileCtrl.options"
        items="tileCtrl.rows"
        class="miq-tile-view"
+       ng-if="tileCtrl.isVisible()"
        ng-class="tileCtrl.tileClass()">
     <div ng-switch="config.type">
       <ng-switch-when ng-switch-when="small">

--- a/src/gtl/interfaces/abstractDataViewClass.ts
+++ b/src/gtl/interfaces/abstractDataViewClass.ts
@@ -46,6 +46,10 @@ export abstract class DataViewClass implements IDataTableBinding {
     this.onSort({headerId: sortId, isAscending: isAscending});
   }
 
+  public isVisible(): boolean {
+    return this.settings && this.settings.sortBy && (this.settings.isLoading || this.rows.length !== 0);
+  }
+
   /**
    * Helper method for calculating loading more items after selecting how many items per page should be visible.
    * @memberof DataViewClass

--- a/src/gtl/interfaces/dataTable.ts
+++ b/src/gtl/interfaces/dataTable.ts
@@ -31,6 +31,7 @@ export interface ITableSettings {
   startIndex?: number;
   endIndex?: number;
   hideSelect?: boolean;
+  isLoading?: boolean;
   translateTotalOf?: (start: number, end: number, total: number) => string;
 }
 


### PR DESCRIPTION
### Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1559478
When in Grid/Tile view and no records are available gray stripe is visible on above message "No records found"

### Before
![screenshot from 2018-06-13 13-18-45](https://user-images.githubusercontent.com/3439771/41348275-743c8dde-6f0c-11e8-8528-730d219f3242.png)

### After
![screenshot from 2018-06-13 13-19-24](https://user-images.githubusercontent.com/3439771/41348276-7455ba70-6f0c-11e8-8256-38f11efe2ed9.png)
