### PR TITLE
Do not sort dropdowns that have sort_by set to 'none'

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -69,6 +69,20 @@ describe('DialogDataService test', () => {
           });
         });
       });
+
+      describe('when the field sort_by is none', () => {
+        it('does not attempt to sort the values', () => {
+          let testField = {
+            'data_type': 'string',
+            'default_value': null,
+            'values': [['2', 'Two'], ['1', 'One'], ['3', 'Three']],
+            'type': 'DialogFieldDropDownList',
+            'options': {'sort_by': 'none', 'sort_order': 'ascending'}
+          };
+          let newField = dialogData.setupField(testField);
+          expect(newField.values).toEqual([['2', 'Two'], ['1', 'One'], ['3', 'Three']]);
+        });
+      });
     });
   });
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -30,7 +30,9 @@ export default class DialogDataService {
         dropDownValues.push([value, description]);
       }
       field.values = dropDownValues;
-      field.values = this.updateFieldSortOrder(field);
+      if (data.options.sort_by !== 'none') {
+        field.values = this.updateFieldSortOrder(field);
+      }
     }
     field.default_value = this.setDefaultValue(field);
 


### PR DESCRIPTION
The dialog-user component was ignoring the fact that the `sort_by` option could be set to none, so it was always either sorting by `value` or `description`, instead of simply leaving the values as they come in. This will need to be combined with [this PR from the main repo](https://github.com/ManageIQ/manageiq/pull/17625) to fully fix the BZ reported, which is also happening during editing of the dialog.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1593874

@miq-bot add_label gaprindashvili/yes, bug, blocker
@d-m-u Please review
@miq-bot assign @himdel 

/cc @tinaafitz