### PR TITLE
Remove the picture nodeIcon and prioritize the rest as image > icon

### DIFF
--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -51,7 +51,7 @@
            title="{{row.cells[columnKey].title}}">
           <i ng-if="row.cells[columnKey].icon2" ng-class="row.cells[columnKey].icon2"></i>
         </i>
-        <img ng-if="['picture', 'image'].includes(tableCtrl.getNodeIconType(row, columnKey))"
+        <img ng-if="tableCtrl.getNodeIconType(row, columnKey) === 'image'"
              ng-src="{{row.cells[columnKey].picture || row.cells[columnKey].image}}"
              alt="{{row.cells[columnKey].title}}"
              title="{{row.cells[columnKey].title}}" />

--- a/src/gtl/components/data-table/dataTableComponent.spec.ts
+++ b/src/gtl/components/data-table/dataTableComponent.spec.ts
@@ -23,7 +23,7 @@ describe('DataTable test', () =>  {
     {
       id: 4,
       cells: [
-        {is_checkbox: true}, {picture: 'some_url.jpg', icon: 'fa fa-icon'}, {text: 'second name'}, {text: 'value 2'}
+        {is_checkbox: true}, {icon: 'fa fa-icon'}, {text: 'second name'}, {text: 'value 2'}
       ]
     }
   ];
@@ -97,16 +97,16 @@ describe('DataTable test', () =>  {
       ).toBeTruthy();
     });
 
-    it('should check if column renders an icon', () => {
-      expect(dataTableCtrl.getNodeIconType(rows[0], 1)).toEqual('icon');
+    it('should check if column renders an image when both icon and image are defined', () => {
+      expect(dataTableCtrl.getNodeIconType(rows[0], 1)).toEqual('image');
     });
 
     it('should check if column renders an image', () => {
       expect(dataTableCtrl.getNodeIconType(rows[1], 1)).toEqual('image');
     });
 
-    it('should check if column renders a picture', () => {
-      expect(dataTableCtrl.getNodeIconType(rows[2], 1)).toEqual('picture');
+    it('should check if column renders an icon', () => {
+      expect(dataTableCtrl.getNodeIconType(rows[2], 1)).toEqual('icon');
     });
 
     it('should check if filtered by column', () => {

--- a/src/gtl/components/data-table/dataTableComponent.ts
+++ b/src/gtl/components/data-table/dataTableComponent.ts
@@ -54,10 +54,10 @@ export class DataTableController extends DataViewClass implements IDataTableBind
    * @function getNodeIconType
    * @param row {object} whole row with data.
    * @param columnKey header column key.
-   * @returns {string} picture | icon | image
+   * @returns {string} image | icon
    */
   public getNodeIconType(row, columnKey) {
-    const allowedGraphics = ['picture', 'icon', 'image'];
+    const allowedGraphics = ['image', 'icon'];
     if (row && row.cells) {
       return allowedGraphics.find(item => row.cells[columnKey].hasOwnProperty(item) && !!row.cells[columnKey][item]);
     }


### PR DESCRIPTION
The picture attribute is no longer necessary as I'm reprioritizing the `fileicon` over the `fonticon` in GTLs.

Classic UI PR: https://github.com/ManageIQ/manageiq-ui-classic/pull/4198

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @martinpovolny 
@miq-bot add_labels gaprindashvili/no, GTLs, graphics