### PR TITLE
Test that 'id' attribute is missing

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -107,7 +107,7 @@ export class DialogFieldController extends DialogFieldClass {
    * @function setDefaultValue
    */
   private setDefaultValue() {
-    let defaultOption: any = _.find(this.dialogField.values, { id: null });
+    let defaultOption: any = _.find(this.dialogField.values, (value: any) => value.id === undefined);
     if (defaultOption) {
       defaultOption.id = 0;
       this.dialogField.default_value = defaultOption.id;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1578986

behaviour for `nil` attributes is changed in https://github.com/ManageIQ/manageiq-api/pull/253 