### PR TITLE
Use separate 'changesHappened' update call for datetimepicker

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -160,8 +160,8 @@
         <p class="input-group">
           <input uib-datepicker-popup type="text"
                  class="form-control"
-                 ng-model="vm.dialogField.default_value"
-                 ng-change="vm.changesHappened()"
+                 ng-model="vm.dialogField.dateField"
+                 ng-change="vm.dateTimeFieldChanged()"
                  is-open="open"
                  datepicker-options="vm.dateOptions"
                  close-text="Close"
@@ -174,7 +174,7 @@
           </span>
         </p>
       </div>
-      <div uib-timepicker ng-model="vm.dialogField.default_value"></div>
+      <div uib-timepicker ng-model="vm.dialogField.timeField" ng-change="vm.dateTimeFieldChanged()"></div>
     </div>
     <span ng-switch-default ng-hide="true"></span>
   </div>

--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -101,4 +101,33 @@ describe('Dialog field test', () => {
       expect(dialogCtrl.onUpdate).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('#dateTimeFieldChanged', () => {
+    let bindings;
+    let dialogCtrl;
+    let testDate = new Date(2018, 6, 11, 7, 30);
+    const dateTimeDialogField = {
+      'name': 'dateTest',
+      'type': 'DialogFieldDateTimeControl',
+      'dateField': testDate,
+      'timeField': testDate,
+    };
+
+    it('calls onUpdate with the correct full date', () => {
+      bindings = {
+        field: dateTimeDialogField,
+        onUpdate: jasmine.createSpy('onUpdate', (dialogFieldName: any, value: any) => true),
+        inputDisabled: false
+      };
+      angular.mock.module('miqStaticAssets.dialogUser');
+      angular.mock.inject($componentController => {
+        dialogCtrl = $componentController('dialogField', null, bindings);
+        dialogCtrl.$onInit();
+      });
+
+      dialogCtrl.dateTimeFieldChanged();
+      expect(dialogCtrl.onUpdate.calls.mostRecent().args[0].dialogFieldName).toEqual('dateTest');
+      expect(dialogCtrl.onUpdate.calls.mostRecent().args[0].value).toEqual(testDate);
+    });
+  });
 });

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -73,6 +73,29 @@ export class DialogFieldController extends DialogFieldClass {
   }
 
   /**
+   * This method is a 'changesHappened' method specific to dateTime fields.
+   * It joins the two date and time models to then delegate to changesHappened.
+   * @memberof DialogFieldController
+   * @function dateTimeFieldChanged
+   */
+  public dateTimeFieldChanged() {
+    let dateField = this.dialogField.dateField;
+    let fullYear = dateField.getFullYear();
+    let month = dateField.getMonth();
+    let date = dateField.getDate();
+
+    if (this.dialogField.timeField === undefined) {
+      this.dialogField.timeField = new Date();
+    }
+
+    let hours = this.dialogField.timeField.getHours();
+    let minutes = this.dialogField.timeField.getMinutes();
+
+    let fullDate = new Date(fullYear, month, date, hours, minutes);
+    this.changesHappened([fullDate]);
+  }
+
+  /**
    * This will convert the values stored in dialogField.default_value to an array
    * for use with a multiple-select field because by default it comes in as a string
    * @memberof DialogFieldController

--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -83,6 +83,41 @@ describe('DialogDataService test', () => {
           expect(newField.values).toEqual([['2', 'Two'], ['1', 'One'], ['3', 'Three']]);
         });
       });
+
+      describe('when the field is a date time control', () => {
+        describe('when the field has values', () => {
+          it('assigns the date and time fields to the given date', () => {
+            let testField = {
+              'values': 'Wed Jul 11 2018 07:30:00',
+              'type': 'DialogFieldDateTimeControl',
+            };
+
+            let newField = dialogData.setupField(testField);
+            expect(newField.dateField.getMonth()).toEqual(6);
+            expect(newField.dateField.getDate()).toEqual(11);
+            expect(newField.dateField.getFullYear()).toEqual(2018);
+            expect(newField.timeField.getHours()).toEqual(7);
+            expect(newField.timeField.getMinutes()).toEqual(30);
+          });
+        });
+
+        describe('when the field does not have values', () => {
+          it('assigns the date and time fields to a new date', () => {
+            let testField = {
+              'values': null,
+              'type': 'DialogFieldDateTimeControl',
+            };
+            let comparisonDate = new Date();
+
+            let newField = dialogData.setupField(testField);
+            expect(newField.dateField.getMonth()).toEqual(comparisonDate.getMonth());
+            expect(newField.dateField.getDate()).toEqual(comparisonDate.getDate());
+            expect(newField.dateField.getFullYear()).toEqual(comparisonDate.getFullYear());
+            expect(newField.timeField.getHours()).toEqual(comparisonDate.getHours());
+            expect(newField.timeField.getMinutes()).toEqual(comparisonDate.getMinutes());
+          });
+        });
+      });
     });
   });
 
@@ -216,6 +251,26 @@ describe('DialogDataService test', () => {
               expect(validation.isValid).toEqual(true);
               expect(validation.message).toEqual('');
             });
+          });
+        });
+      });
+    });
+
+    describe('when the field is not required', () => {
+      describe('when the field is a date time control', () => {
+        describe('when the field does not have a date filled out', () => {
+          let testField;
+
+          beforeEach(() => {
+            testField = {
+              'type': 'DialogFieldDateTimeControl',
+            };
+          });
+
+          it('fails validation', () => {
+            let validation = dialogData.validateField(testField);
+            expect(validation.isValid).toEqual(false);
+            expect(validation.message).toEqual('Select a valid date');
           });
         });
       });

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -34,6 +34,15 @@ export default class DialogDataService {
         field.values = this.updateFieldSortOrder(field);
       }
     }
+
+    if (field.type === 'DialogFieldDateTimeControl') {
+      if (_.isNull(field.values) || _.isUndefined(field.values)) {
+        field.dateField = field.timeField = new Date();
+      } else {
+        field.dateField = field.timeField = new Date(data.values);
+      }
+    }
+
     field.default_value = this.setDefaultValue(field);
 
     return field;
@@ -154,6 +163,13 @@ export default class DialogDataService {
         const regexValidates = regex.test(fieldValue);
         validation.isValid = regexValidates;
         validation.message = __('Entered text does not match required format.');
+      }
+    }
+
+    if (field.type === 'DialogFieldDateTimeControl') {
+      if (field.dateField === undefined) {
+        validation.isValid = false;
+        validation.message = __('Select a valid date');
       }
     }
 


### PR DESCRIPTION
Date & time picker was trying to use one model for both input fields, so when the date would change, the time would basically get reset, and when the time changed, the date would get reset so the user could never actually pick the time and date they wanted to pick.

This PR separates the date field and the time field into separate models but joins them back up when changes are made so that the correct value is sent to the API when the user presses 'submit'.

Ultimately, I think we should probably look into a whole "datetimepicker" solution, such as https://www.npmjs.com/package/angular-ui-bootstrap-datetimepicker.

Interestingly enough, patternfly *does* have a datetimepicker that I found (https://www.patternfly.org/pattern-library/forms-and-controls/date-and-time/), however, I don't think it's angular supported yet as I couldn't find much information about it.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1583177

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @himdel 
@chalettu Can you review, please?