### PR TITLE
fix refresh button placement in dialog show screen

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -31,12 +31,13 @@
                 ng-change="vm.changesHappened()"
                 ng-model-options="{debounce: {'default': 500}}"
                 class="form-control"
+                style="resize: vertical"
                 uib-tooltip="{{ ::inputTitle }}"
                 rows="4"
                 id="{{ vm.dialogField.name }}">{{ vm.dialogField.default_value }}
       </textarea>
     </div>
-    <div class="col-sm-4" ng-switch-when="DialogFieldCheckBox">
+    <div class="col-sm-1" ng-switch-when="DialogFieldCheckBox">
       <input  ng-model="vm.dialogField.default_value"
               ng-true-value="'t'"
               ng-false-value="'f'"
@@ -144,7 +145,7 @@
                ng-change="vm.changesHappened()"
                is-open="open"
                datepicker-options="vm.dateOptions"
-               close-text="Close"/>
+               close-text="{{'Close'|translate}}"/>
         <span class="input-group-btn">
           <button type="button"
                   class="btn btn-default"
@@ -164,7 +165,7 @@
                  ng-change="vm.dateTimeFieldChanged()"
                  is-open="open"
                  datepicker-options="vm.dateOptions"
-                 close-text="Close"
+                 close-text="{{'Close'|translate}}"
                  id="{{ vm.dialogField.name }}"/>
           <span class="input-group-btn">
             <button type="button"
@@ -181,12 +182,13 @@
   <div class="col-sm-1"
         ng-if="vm.dialogField.dynamic && vm.dialogField.show_refresh_button && vm.inputDisabled===false">
     <button type="button"
-            class="btn"
+            class="btn btn-default"
             ng-click="vm.refreshSingleField()" translate>
-      Refresh
+      <i class="fa fa-refresh" uib-Tooltip="Refresh field"></i>
     </button>
   </div>
   <div class="col-sm-1" ng-show="vm.dialogField.fieldBeingRefreshed">
     <div class="spinner spinner-xs spinner-inline"></div>
   </div>
 </div>
+


### PR DESCRIPTION
This PR fixes a problem where the Refresh button becomes hidden when the text area is expanded.

It also:

* adds missing "btn-default" class
* changes the "Refresh" text to a font icon; adds tooltips
* prevents horizontal expansion of textarea.

This PR is a follow-up to: https://github.com/ManageIQ/ui-components/pull/293

https://bugzilla.redhat.com/show_bug.cgi?id=1602048

Old
<img width="1265" alt="screen shot 2018-07-16 at 1 56 05 pm" src="https://user-images.githubusercontent.com/1287144/42774848-d28a17e0-8900-11e8-9dde-3e60961853ce.png">

New
<img width="1036" alt="screen shot 2018-07-23 at 11 14 31 am" src="https://user-images.githubusercontent.com/1287144/43086108-94011ff4-8e6a-11e8-99e1-046df1a43bc3.png">
