### PR TITLE
Allow to parse a string with a floating point number

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -25,8 +25,8 @@ export default class DialogDataService {
         if (option[0] === String(field.default_value)) {
           field.selected = option;
         }
-        const value = ((field.data_type === 'integer' && option[0] !== null) ? parseFloat(option[0], 10) : option[0]);
-        const description = (isNaN(option[1]) ? option[1] : parseFloat(option[1], 10));
+        const value = ((field.data_type === 'integer' && option[0] !== null) ? parseInt(option[0], 10) : option[0]);
+        const description = (!Number.isInteger(option[1]) ? option[1] : parseInt(option[1], 10));
         dropDownValues.push([value, description]);
       }
       field.values = dropDownValues;

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -25,8 +25,8 @@ export default class DialogDataService {
         if (option[0] === String(field.default_value)) {
           field.selected = option;
         }
-        const value = ((field.data_type === 'integer' && option[0] !== null) ? parseInt(option[0], 10) : option[0]);
-        const description = (isNaN(option[1]) ? option[1] : parseInt(option[1], 10));
+        const value = ((field.data_type === 'integer' && option[0] !== null) ? parseFloat(option[0], 10) : option[0]);
+        const description = (isNaN(option[1]) ? option[1] : parseFloat(option[1], 10));
         dropDownValues.push([value, description]);
       }
       field.values = dropDownValues;


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1600007

replacing `parseInt()` with `parseFloat()` to allow to parse a string with a floating point number