### PR TITLE
i18n string extraction & friends

### DIFF
--- a/locale/ui-components.pot
+++ b/locale/ui-components.pot
@@ -1,0 +1,525 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: \n"
+
+#: ./src/dialog-editor/components/box/box.html:54
+msgid "Add Section"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:17
+msgid "Advanced"
+msgstr ""
+
+#: ./src/fonticon-picker/components/fonticon-picker/fonticon-modal.html:18
+msgid "Apply"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:200
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:54
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:144
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:46
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:57
+msgid "Ascending"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-box/box.html:31
+#: ./src/dialog-editor/components/modal-field/field.html:174
+#: ./src/dialog-editor/components/modal-tab/tab.html:31
+msgid "Cancel"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:24
+msgid "Category"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Category needs to be set for TagControl field"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Check Box"
+msgstr ""
+
+#: ./src/fonticon-picker/components/fonticon-picker/fonticon-modal.html:19
+msgid "Close"
+msgstr ""
+
+#: ./src/dialog-editor/components/tab-list/tab-list.html:15
+msgid "Create Tab"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Datepicker"
+msgstr ""
+
+#: ./src/dialog-editor/components/field/field.html:10
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:3
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:24
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:32
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:24
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:107
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:3
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:132
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:3
+msgid "Default value"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:201
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:55
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:145
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:47
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:58
+msgid "Descending"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+#: ./src/dialog-editor/components/modal-box/box.html:21
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:194
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:48
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:138
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:40
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:50
+#: ./src/dialog-editor/components/modal-tab/tab.html:21
+msgid "Description"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog field needs to have a label"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog field needs to have a name"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog group needs to have a label"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog group needs to have at least one field"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog needs to have a label"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog needs to have at least one tab"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog tab needs to have a label"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dialog tab needs to have at least one group"
+msgstr ""
+
+#: ./src/dialog-editor/components/box/box.html:31
+msgid "Drag items here to add to the dialog. At least one item is required before saving"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dropdown"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Dropdown needs to have entries"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:42
+msgid "Dynamic"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Edit  Field"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:5
+msgid "Edit Field Details"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-box/box.html:5
+msgid "Edit Section Details"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-tab/tab.html:5
+msgid "Edit Tab Details"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Entered text does not match required format."
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:65
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:50
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:61
+msgid "Entries"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:40
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:32
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:117
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:68
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:42
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:54
+msgid "Entry Point"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:11
+msgid "Field Information"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/fields-to-refresh.html:1
+msgid "Fields to refresh"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:35
+msgid "Help"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:78
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:74
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:168
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:112
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:84
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:109
+msgid "Include domain prefix in the path:"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:137
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:41
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:33
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:88
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:42
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:38
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:81
+msgid "Integer"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-box/box.html:17
+#: ./src/dialog-editor/components/modal-field/field.html:26
+#: ./src/dialog-editor/components/modal-tab/tab.html:17
+msgid "Label"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:8
+msgid "Load values on init"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:141
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:58
+msgid "Multiselect"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:31
+msgid "Name"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "New Section"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "New tab"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:16
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:23
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:30
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:56
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:9
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:92
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:99
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:15
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:22
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:45
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:52
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:8
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:88
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:95
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:133
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:146
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:15
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:182
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:189
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:22
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:63
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:8
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:13
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:6
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:126
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:133
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:15
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:22
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:8
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:84
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:15
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:22
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:37
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:8
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:105
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:14
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:21
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:28
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:58
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:98
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:123
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:13
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:130
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:20
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:27
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:34
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:70
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:77
+#: ./src/dialog-editor/components/modal-field/field.html:167
+#: ./src/dialog-editor/components/modal-field/field.html:47
+msgid "No"
+msgstr ""
+
+#: ./src/dialog-user/components/dialog-user/dialog.html:3
+msgid "No Provisioning Dialog Available."
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:193
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:47
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:137
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:27
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:39
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:29
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:49
+msgid "None"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:14
+msgid "Options"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:20
+msgid "Overridable Options"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:72
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:8
+msgid "Protected"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Radio Button"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:18
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:87
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:3
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:83
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:177
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:3
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:121
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:3
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:10
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:16
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:93
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:118
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:22
+msgid "Read only"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field/field.html:162
+msgid "Reconfigurable"
+msgstr ""
+
+#: ./src/dialog-user/components/dialog-user/dialogField.html:183
+msgid "Refresh"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:11
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:51
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:128
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:17
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:17
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:79
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:3
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:53
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:9
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:15
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:65
+msgid "Required"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-box/box.html:32
+#: ./src/dialog-editor/components/modal-field/field.html:175
+#: ./src/dialog-editor/components/modal-tab/tab.html:32
+msgid "Save"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-box/box.html:11
+msgid "Section Information"
+msgstr ""
+
+#: ./src/fonticon-picker/components/fonticon-picker/fonticon-modal.html:2
+msgid "Select an icon"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:17
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:47
+msgid "Show Past Dates"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:40
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:1
+msgid "Show Refresh Button"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:32
+msgid "Single value"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:191
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:45
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:135
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:37
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:46
+msgid "Sort by"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:198
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:52
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:142
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:44
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:54
+msgid "Sort order"
+msgstr ""
+
+#: ./src/dialog-editor/components/box/box.html:50
+msgid "Start with adding a section"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:138
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:42
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:34
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:89
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:43
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:39
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:82
+msgid "String"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-tab/tab.html:11
+msgid "Tab Information"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Tag Control"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Text Area"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Text Box"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "This field is required"
+msgstr ""
+
+#: ./dist/js/ui-components.js:1
+msgid "Timepicker"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:30
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:60
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:42
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:85
+msgid "Validation"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:195
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:49
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:139
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:41
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:51
+msgid "Value"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:135
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:39
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:31
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:86
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:39
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:36
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:79
+msgid "Value type"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:25
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:94
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:10
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:90
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:10
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:184
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:10
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:128
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:17
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:100
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:23
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:125
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:29
+msgid "Visible"
+msgstr ""
+
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:15
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:22
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:29
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:55
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:8
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:91
+#: ./src/dialog-editor/components/modal-field-template/check-box.html:98
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:14
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:21
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:44
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:51
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:7
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:87
+#: ./src/dialog-editor/components/modal-field-template/date-time-control.html:94
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:132
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:14
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:145
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:181
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:188
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:21
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:62
+#: ./src/dialog-editor/components/modal-field-template/drop-down-list.html:7
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:12
+#: ./src/dialog-editor/components/modal-field-template/dynamic-values.html:5
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:125
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:132
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:14
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:21
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:7
+#: ./src/dialog-editor/components/modal-field-template/radio-button.html:83
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:14
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:21
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:36
+#: ./src/dialog-editor/components/modal-field-template/tag-control.html:7
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:104
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:13
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:20
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:27
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:57
+#: ./src/dialog-editor/components/modal-field-template/text-area-box.html:97
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:12
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:122
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:129
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:19
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:26
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:33
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:69
+#: ./src/dialog-editor/components/modal-field-template/text-box.html:76
+#: ./src/dialog-editor/components/modal-field/field.html:166
+#: ./src/dialog-editor/components/modal-field/field.html:46
+msgid "Yes"
+msgstr ""

--- a/locale/zanata.xml
+++ b/locale/zanata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+  <url>https://translate.zanata.org/</url>
+  <project>manageiq-ui-angular-components</project>
+  <project-version>master</project-version>
+  <project-type>gettext</project-type>
+
+</config>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prepublish": "webpack || true",
     "build": "webpack --config webpack.vendor.config.js && webpack -p",
     "build-dev": "webpack --config webpack.vendor.config.js && webpack",
-    "gettext:extract": "yarn run build && angular-gettext-cli --files './+(src|dist)/**/+(*.html|ui-components.js)' --dest './locale/ui-components.pot' --marker-names '__,N_'",
+    "gettext:extract": "yarn run build && angular-gettext-cli --files './+(src|dist)/**/+(*.html|ui-components.js)' --dest './locale/ui-components.pot' --marker-names '__,N_' && yarn gettext:validate",
+    "gettext:validate": "node scripts/validate-gettext-catalog.js",
     "install-vendor": "webpack --config webpack.vendor.config.js",
     "build-docs": "jsdoc -c jsdoc-conf.json"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepublish": "webpack || true",
     "build": "webpack --config webpack.vendor.config.js && webpack -p",
     "build-dev": "webpack --config webpack.vendor.config.js && webpack",
+    "gettext:extract": "yarn run build && angular-gettext-cli --files './+(src|dist)/**/+(*.html|ui-components.js)' --dest './locale/ui-components.pot' --marker-names '__,N_'",
     "install-vendor": "webpack --config webpack.vendor.config.js",
     "build-docs": "jsdoc -c jsdoc-conf.json"
   },
@@ -33,6 +34,7 @@
     "angular": "~1.5.9",
     "angular-animate": "~1.5.9",
     "angular-bootstrap": "^0.12.2",
+    "angular-gettext-cli": "^1.2.0",
     "angular-jsdoc": "~1.5.0",
     "angular-mocks": "~1.5.9",
     "angular-patternfly": "^3.15.0",

--- a/scripts/validate-gettext-catalog.js
+++ b/scripts/validate-gettext-catalog.js
@@ -1,0 +1,14 @@
+const fs = require('fs')
+const path = require('path')
+const potFile = path.join(__dirname, '../locale/ui-components.pot')
+const contents = fs.readFileSync(potFile, 'utf8')
+const re = /<(.|\n)*>|{{(.|\n)*}}/gim // checks for html and also for javascript
+const matches = contents.match(re)
+
+if (matches != null) {
+  console.log('Errors exist in language file')
+  console.log(matches)
+  process.exit(1)
+} else {
+  process.exit(0)
+}

--- a/src/dialog-editor/components/box/box.html
+++ b/src/dialog-editor/components/box/box.html
@@ -50,7 +50,7 @@
       <h1 translate style="cursor: pointer;">Start with adding a section</h1>
     </div>
     <div class="add-section-box nosort">
-      <a ng-click='vm.addBox()' translate>
+      <a ng-click='vm.addBox()'>
         <i class="pficon-add-circle-o"></i>&nbsp;&nbsp;{{ 'Add Section' | translate }}
       </a>
     </div>


### PR DESCRIPTION
What this PR does:
* use `angular-gettext-cli` to extract strings from javascript sources & html markup
* remove extraneous `translate` directive
* add `locale/` subdirectory with `ui-components.pot` catalog
* add gettext catalog validation
* add `zanata.xml`