### PR TITLE
Fix the number abbreviation in quadicons when hitting 6 characters

### DIFF
--- a/demo/controllers/quadiconController.ts
+++ b/demo/controllers/quadiconController.ts
@@ -133,6 +133,7 @@ export default class QuadiconController {
       420,
       4200,
       42000,
+      112081, // this is an edge case
       420000,
       4200000,
       42000000,

--- a/src/common/filters/abbrNumberFilter.ts
+++ b/src/common/filters/abbrNumberFilter.ts
@@ -8,9 +8,15 @@ export default class AbbrNumber {
       if (!num.value() || num.value().toString() !== value.toString()) {
         return value;
       }
+
       let abbr = num.format('0.0a');
-      // Drop the .0 as we want to save the space
-      return (abbr.match(/\d\.0[a-z]?$/) ? num.format('0a') : abbr).toUpperCase();
+
+      if (abbr.match(/\d\.0[a-z]?$/) || abbr.length > 5) {
+        // Drop the .0 as we want to save the space
+        abbr = num.format('0a');
+      }
+
+      return abbr.toUpperCase();
     };
   }
 }


### PR DESCRIPTION
In some cases it is possible that the number abbreviation filter returns 6 characters, which is an unwanted behavior and breaks the styling of quadicons. For example `112081` returns with `112.1K`. The solution is to drop the decimal point and the number afterwards.

@miq-bot add_reviewer @epwinchell 
@miq-bot add_label bug, gaprindashvili/no

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1613355