### PR TITLE
Ensure DialogFieldDateTimeControl fields are properly initialized

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -36,6 +36,10 @@ export class DialogFieldController extends DialogFieldClass {
     if (this.dialogField.type === 'DialogFieldTagControl') {
       this.setDefaultValue();
     }
+
+    if (this.dialogField.type === 'DialogFieldDateTimeControl') {
+      this.dateTimeFieldChanged();
+    }
   }
 
   /**


### PR DESCRIPTION
This adds an additional step to initialization when the field type is `DialogFieldDateTimeControl` since trying to submit the "default" for this resulted in submitting the time of the epoch even though the UI shows the current date/time.

https://bugzilla.redhat.com/show_bug.cgi?id=1583177

@miq-bot add_label gaprindashvili/yes, bug, blocker
@miq-bot assign @himdel 
@miq-bot add_reviewer @himdel, @chalettu 