### PR TITLE
ci/bower-dev .. use -e, reset locale/ first

### DIFF
--- a/ci/bower-dev.sh
+++ b/ci/bower-dev.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -x
+set -e
+git checkout locale/	# undo changes made by gettext:extract
 HASH=$(git rev-parse HEAD)
 yarn install
 yarn run build


### PR DESCRIPTION
since ManageIQ/ui-components#335, the bower-dev branch didn't work because there was an extra change in locale/ after running the other tests

adding -e so that we can actually see these failures

and cleaning locale/ so that we can checkout the right branch