### PR TITLE
toolbar - fix includes of undefined for custom buttons

### DIFF
--- a/src/toolbar/components/toolbar-menu/toolbarComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarComponent.ts
@@ -127,16 +127,19 @@ export class ToolbarController {
   }
 
   public collapseButtons() {
-    let buttonsIndex;
-    if (this.toolbarItems) {
-      buttonsIndex = _.findLastIndex(
-        this.toolbarItems,
-        (itemGroup: any) => itemGroup.filter(item => item.id.includes(CUSTOM_ID) !== false).length !== 0
-      );
-      if(buttonsIndex !== -1) {
-        this.toolbarItems[buttonsIndex] = ToolbarController.createKebabFromItems(this.toolbarItems[buttonsIndex]);
-      }
+    if (! this.toolbarItems) {
+      return;
     }
+
+    const isCustomButton = (item) => item && item.id && item.id.includes(CUSTOM_ID);
+    const hasCustomButtons = (itemGroup) => _.some(itemGroup, isCustomButton);
+
+    let buttonsIndex = _.findLastIndex(this.toolbarItems, hasCustomButtons);
+    if (buttonsIndex === -1) {
+      return;
+    }
+
+    this.toolbarItems[buttonsIndex] = ToolbarController.createKebabFromItems(this.toolbarItems[buttonsIndex]);
   }
 
   private $onChanges(changesObj) {


### PR DESCRIPTION
in ui-classic, go to CI > Dashboard

You'll see:

```
angular.self-f52e962…a54.js?body=1:14962 TypeError: Cannot read property 'includes' of undefined
    at toolbarComponent.ts:154
    at Array.filter (<anonymous>)
    at toolbarComponent.ts:154
    at baseFindIndex (lodash.js:802)
    at Function.findLastIndex (lodash.js:7308)
    at e.collapseButtons (toolbarComponent.ts:154)
    at e.$onChanges (ui-components.js:4660)
    at angular.self-f52e962…a54.js?body=1:10023
    at forEach (angular.self-f52e962…27a54.js?body=1:427)
    at nodeLinkFn (angular.self-f52e962…a54.js?body=1:10019)
```

that's because the logic introduced in https://github.com/ManageIQ/ui-components/pull/281 to modify custom buttons fails when that button doesn't have an id

the button this is failing on:

```
{
  name: "custom",
  args: {
    partial: "dashboard/dropdownbar",
    html: "&lt;div id=&quot;dashboard_dropdown&quot;&gt;↵&lt;…tton&gt;↵&lt;/div&gt;↵↵&lt;/div&gt;↵&lt;/div&gt;↵",
  },
}
```

(so, the problem is the no `id` field)

---

This only really changes `item.id.includes(CUSTOM_ID)` to `item && item.id && item.id.includes(CUSTOM_ID)`, but I took the liberty of fixing a few antipatterns:

* whole function wrapped in an `if`
* using `filter().length != 0` => replaced by `_.some`
* named the predicates (`isCustomButton`, `hasCustomButtons`) for context