### PR TITLE
dialogField - Remove patternflyVersion

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -16,7 +16,6 @@ export class DialogFieldController extends DialogFieldClass {
   public dialogField: any;
   public validation: any;
   public clonedDialogField: any;
-  public patternflyVersion: number;
   /*@ngInject*/
   constructor(private DialogData: any, private $window: any) {
     super();
@@ -32,7 +31,6 @@ export class DialogFieldController extends DialogFieldClass {
     this.clonedDialogField = _.cloneDeep(this.field);
     this.dialogField = this.field;
     this.validation = null;
-    this.patternflyVersion = this.$window.patternflyVersion || 3;
     if (this.dialogField.type === 'DialogFieldTagControl') {
       this.setDefaultValue();
     }


### PR DESCRIPTION
this is a remnant from before [miq-select](https://github.com/ManageIQ/ui-components/pull/295), when we had a ng-if on patternflyVersion to determine whether to use pf-select of pf-bootstrap-select

now this is dead, removing

(also, https://github.com/ManageIQ/manageiq-ui-service/pull/1472)