### PR TITLE
Convert all pf-select directives to miq-select

### DIFF
--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -44,14 +44,14 @@
     <!-- drop down list -->
     <div ng-switch-when="DialogFieldDropDownList">
       <div ng-if="!vm.fieldData.options.force_multi_value">
-        <select class="form-control" pf-select
+        <select class="form-control" miq-select
                 ng-model="vm.fieldData.default_value">
           <option value="" translate>None</option>
           <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
         </select>
       </div>
       <div ng-if="vm.fieldData.options.force_multi_value">
-        <select class="form-control" multiple pf-select
+        <select class="form-control" multiple miq-select
                 ng-init="vm.convertValuesToArray()"
                 ng-model="vm.fieldData.default_value">
           <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
@@ -73,7 +73,7 @@
 
     <!-- tag control -->
     <select ng-switch-when="DialogFieldTagControl"
-            pf-select
+            miq-select
             class="form-control">
       <option ng-repeat="option in vm.fieldData.values"
               value="{{ option[0] }}">

--- a/src/dialog-editor/components/modal-field-template/drop-down-list.html
+++ b/src/dialog-editor/components/modal-field-template/drop-down-list.html
@@ -23,7 +23,7 @@
     </div>
     <div pf-form-group pf-label="{{'Default value'|translate}}"
          ng-if="!vm.modalData.options.force_multi_value">
-      <select class="form-control" pf-select ng-attr-title="{{'Nothing Selected'|translate}}"
+      <select class="form-control" miq-select ng-attr-title="{{'Nothing Selected'|translate}}"
               ng-model="vm.modalData.default_value">
         <option value="" translate>None</option>
         <option ng-repeat="value in vm.modalData.values" value="{{value[0]}}">{{value[1]}}</option>
@@ -31,26 +31,26 @@
     </div>
     <div pf-form-group pf-label="{{'Default value'|translate}}"
          ng-if="vm.modalData.options.force_multi_value">
-      <select class="form-control" multiple pf-select
+      <select class="form-control" multiple miq-select
               ng-model="vm.modalData.default_value">
         <option ng-repeat="value in vm.modalData.values" value="{{value[0]}}">{{value[1]}}</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+      <select class="form-control" miq-select ng-model="vm.modalData.data_type">
         <option value="integer" translate>Integer</option>
         <option selected="selected" value="string" translate>String</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort by'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_by">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_by">
         <option value="none" translate>None</option>
         <option value="description" translate>Description</option>
         <option value="value" translate>Value</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort order'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_order">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_order">
         <option selected="selected" value="ascending" translate>Ascending</option>
         <option value="descending" translate>Descending</option>
       </select>
@@ -133,7 +133,7 @@
                switch-off-text="{{'No'|translate}}">
       </div>
       <div pf-form-group pf-label="{{'Value type'|translate}}">
-        <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+        <select class="form-control" miq-select ng-model="vm.modalData.data_type">
           <option value="integer" translate>Integer</option>
           <option selected="selected" value="string" translate>String</option>
         </select>
@@ -193,14 +193,14 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Sort by'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_by">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_by">
         <option value="none" translate>None</option>
         <option value="description" translate>Description</option>
         <option value="value" translate>Value</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort order'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_order">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_order">
         <option selected="selected" value="ascending" translate>Ascending</option>
         <option value="descending" translate>Descending</option>
       </select>

--- a/src/dialog-editor/components/modal-field-template/fields-to-refresh.html
+++ b/src/dialog-editor/components/modal-field-template/fields-to-refresh.html
@@ -4,6 +4,6 @@
           ng-options="dynamicField.name as dynamicField.label for dynamicField in vm.modalData.dynamicFieldList"
           multiple
           ng-attr-title="{{'Nothing Selected'|translate}}"
-          pf-select>
+          miq-select>
   </select>
 </div>

--- a/src/dialog-editor/components/modal-field-template/radio-button.html
+++ b/src/dialog-editor/components/modal-field-template/radio-button.html
@@ -22,27 +22,27 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Default value'|translate}}">
-      <select class="form-control" pf-select
+      <select class="form-control" miq-select
               ng-model="vm.modalData.default_value">
         <option value="" translate>None</option>
         <option ng-repeat="value in vm.modalData.values" value="{{value[0]}}">{{value[1]}}</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+      <select class="form-control" miq-select ng-model="vm.modalData.data_type">
         <option value="integer" translate>Integer</option>
         <option selected="selected" value="string" translate>String</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort by'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_by">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_by">
         <option value="none" translate>None</option>
         <option value="description" translate>Description</option>
         <option value="value" translate>Value</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort order'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_order">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_order">
         <option selected="selected" value="ascending" translate>Ascending</option>
         <option value="descending" translate>Descending</option>
       </select>
@@ -84,7 +84,7 @@
                switch-off-text="{{'No'|translate}}">
       </div>
       <div pf-form-group pf-label="{{'Value type'|translate}}">
-        <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+        <select class="form-control" miq-select ng-model="vm.modalData.data_type">
           <option value="integer" translate>Integer</option>
           <option selected="selected" value="string" translate>String</option>
         </select>
@@ -137,14 +137,14 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Sort by'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_by">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_by">
         <option value="none" translate>None</option>
         <option value="description" translate>Description</option>
         <option value="value" translate>Value</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort order'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.options.sort_order">
+      <select class="form-control" miq-select ng-model="vm.modalData.options.sort_order">
         <option selected="selected" value="ascending" translate>Ascending</option>
         <option value="descending" translate>Descending</option>
       </select>

--- a/src/dialog-editor/components/modal-field-template/tag-control.html
+++ b/src/dialog-editor/components/modal-field-template/tag-control.html
@@ -22,7 +22,7 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Category'|translate}}">
-      <select class="form-control" pf-select ng-attr-title="{{'Nothing Selected'|translate}}"
+      <select class="form-control" miq-select ng-attr-title="{{'Nothing Selected'|translate}}"
               ng-change="vm.setupCategoryOptions()"
               ng-model="vm.modalData.options.category_id"
               ng-options="category.id.toString() as category.description for category in vm.categories.resources">
@@ -38,14 +38,14 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">
-      <select class="form-control" pf-select
+      <select class="form-control" miq-select
               ng-model="vm.modalData.data_type">
         <option value="integer" translate>Integer</option>
         <option selected="selected" value="string" translate>String</option>
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort by'|translate}}">
-      <select class="form-control" pf-select
+      <select class="form-control" miq-select
               ng-model="vm.modalData.options.sort_by">
         <option value="none" translate>None</option>
         <option value="description" translate>Description</option>
@@ -53,7 +53,7 @@
       </select>
     </div>
     <div pf-form-group pf-label="{{'Sort order'|translate}}">
-      <select class="form-control" pf-select
+      <select class="form-control" miq-select
               ng-model="vm.modalData.options.sort_order">
         <option selected="selected" value="ascending" translate>Ascending</option>
         <option value="descending" translate>Descending</option>

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -34,7 +34,7 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Value type'|translate}}">
-      <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+      <select class="form-control" miq-select ng-model="vm.modalData.data_type">
         <option value="integer" translate>Integer</option>
         <option selected="selected" value="string" translate>String</option>
       </select>
@@ -77,7 +77,7 @@
                switch-off-text="{{'No'|translate }}"/>
       </div>
       <div pf-form-group pf-label="{{'Value type'|translate}}">
-        <select class="form-control" pf-select ng-model="vm.modalData.data_type">
+        <select class="form-control" miq-select ng-model="vm.modalData.data_type">
           <option value="integer" translate>Integer</option>
           <option selected="selected" value="string" translate>String</option>
         </select>

--- a/src/dialog-editor/index.ts
+++ b/src/dialog-editor/index.ts
@@ -6,7 +6,8 @@ module dialogEditor {
   export const app = angular.module('miqStaticAssets.dialogEditor', [
     'ui.sortable',
     'ngDragDrop',
-    'frapontillo.bootstrap-switch'
+    'frapontillo.bootstrap-switch',
+    'miqStaticAssets.miqSelect'
   ]);
   services(app);
   components(app);


### PR DESCRIPTION
If we want to move to angular-patternfly v4, this is necessary and according to @himdel the safest solution that can even be backported if needed.

@miq-bot assign @himdel