### PR TITLE
Update dynamic fields responders after change

### DIFF
--- a/src/dialog-editor/components/abstractModal.ts
+++ b/src/dialog-editor/components/abstractModal.ts
@@ -27,6 +27,7 @@ export default class AbstractModal {
     removeEntry: '=?',
     currentCategoryEntries: '=?',
     setupCategoryOptions: '=?',
+    updateDialogFieldResponders: '=?',
     resolveCategories: '=?',
     modalTabIsSet: '<',
     modalTabSet: '<',

--- a/src/dialog-editor/components/box/box.html
+++ b/src/dialog-editor/components/box/box.html
@@ -34,6 +34,7 @@
               <form class="form-horizontal">
                 <dialog-editor-field box-position="box.position"
                                      field-data='field'
+                                     update-dialog-field-responders="vm.updateDialogFieldResponders"
                                      setup-modal-options="vm.onFieldEdit(type, tab, box, field)"></dialog-editor-field>
               </form>
             </div>

--- a/src/dialog-editor/components/modal-field/field.html
+++ b/src/dialog-editor/components/modal-field/field.html
@@ -42,6 +42,7 @@
            pf-label="{{'Dynamic'|translate}}">
         <input bs-switch
                ng-model="vm.modalData.dynamic"
+               ng-change="vm.updateDialogFieldResponders(vm.modalData.name)"
                type="checkbox"
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate}}"/>

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -243,6 +243,21 @@ class ModalController {
   }
 
   /**
+   * Updates fields associated with dynamic fields after
+   * changing the dynamic field to static
+   * @memberof ModalController
+   * @function updateDialogFieldResponders
+   */
+  public updateDialogFieldResponders(changedFieldName) {
+    this.DialogEditor.forEachDialogField((field) => {
+      if (field.dialog_field_responders.includes(changedFieldName)) {
+        let index = field.dialog_field_responders.indexOf(changedFieldName);
+        field.dialog_field_responders.splice(index, 1);
+      }
+    });
+  }
+
+  /**
    * Finds entries for the selected TagControl and sets them.
    * @memberof ModalController
    * @function setupCategoryOptions
@@ -307,6 +322,7 @@ class ModalController {
       tree-selector-show="modalCtrl.parent.treeSelectorShow"
       tree-selector-include-domain="modalCtrl.parent.treeSelectorIncludeDomain"
       on-select="modalCtrl.parent.onSelect"
+      update-dialog-field-responders="modalCtrl.parent.updateDialogFieldResponders"
       setup-category-options="modalCtrl.parent.setupCategoryOptions"
       ></${component}>`;
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1614436

Removing field changed from dynamic to static from the list of responders for each associated field.


Steps to reproduce: 


![screencast from 2018-09-13 23-55-38](https://user-images.githubusercontent.com/1187051/45893030-472d6180-bdca-11e8-93de-b54f05ab39b2.gif)
