### PR TITLE
[WIP] Add auto-release support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ before_install:
 
 script: ./scripts/.build.sh
 
-after_success: ./scripts/.coverage.sh
+after_success:
+  - ./scripts/.coverage.sh
+  - ./scripts/.release.sh
 
 notifications:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "UI components for ManageIQ project",
   "main": "index.js",
   "scripts": {
-    "start": "webpack --watch",
-    "test": "karma start",
-    "prepublish": "webpack || true",
     "build": "webpack --config webpack.vendor.config.js && webpack -p",
     "build-dev": "webpack --config webpack.vendor.config.js && webpack",
+    "build-docs": "jsdoc -c jsdoc-conf.json",
     "gettext:extract": "yarn run build && angular-gettext-cli --files './+(src|dist)/**/+(*.html|ui-components.js)' --dest './locale/ui-components.pot' --marker-names '__,N_' && yarn gettext:validate",
     "gettext:validate": "node scripts/validate-gettext-catalog.js",
     "install-vendor": "webpack --config webpack.vendor.config.js",
-    "build-docs": "jsdoc -c jsdoc-conf.json"
+    "prepublish": "webpack || true",
+    "release": "semantic-release",
+    "start": "webpack --watch",
+    "test": "karma start"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,10 @@
     "npm": ">= 3.8.1"
   },
   "devDependencies": {
+    "@khala/commit-analyzer-wildcard": "~1.0.4",
     "@manageiq/font-fabulous": "^1.0.0",
+    "@semantic-release/git": "~7.0.4",
+    "@semantic-release/npm": "~5.0.4",
     "@types/angular-mocks": "^1.5.7",
     "@types/angular-ui-router": "^1.1.35",
     "@types/jasmine": "^2.5.38",
@@ -82,6 +86,7 @@
     "rx-angular": "^1.1.3",
     "sass": "^0.5.0",
     "sass-loader": "^4.0.2",
+    "semantic-release": "~15.9.17",
     "style-loader": "^0.13.1",
     "tslint": "4.0.2",
     "tslint-loader": "3.2.0",
@@ -100,5 +105,18 @@
     "es7-shim": "^6.0.0",
     "eslint": "~3.9.1",
     "sprintf-js": "^1.1.1"
+  },
+  "release": {
+    "analyzeCommits": "@khala/commit-analyzer-wildcard/analyzer",
+    "prepare": [
+      "@semantic-release/npm",
+      {
+        "path": "@semantic-release/git",
+        "assets": [
+          "package.json"
+        ],
+        "message": "Release of new version: ${nextRelease.version} <no> [skip ci]"
+      }
+    ]
   }
 }

--- a/scripts/.release.sh
+++ b/scripts/.release.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export GH_TOKEN=$GITHUB_AUTH
+npm run release


### PR DESCRIPTION
Add semantic-release, enables npm autorelease on master merges.

Modelled after what ManageIQ/react-ui-components does:
https://github.com/ManageIQ/react-ui-components/pull/38 - description and config
https://github.com/ManageIQ/react-ui-components/pull/84 - autotooling

Fixes #189

---

This will not affect merges on gaprindashvili or hammer branches, only master.
This will not do anything with bower, only a npm package.

---

If you don't do anything special, merged PR will mean a patch release.
If you add `<no>` (case insensitive) to the commit message, no release will happen.
Otherwise, you can use `<x.?.?>` to release a major version, `<?.x.?>` for a minor one, and `<?.?.x>` for a patch release (the default).