### PR TITLE
Set 'validator_type' correctly in Dialog Editor

### DIFF
--- a/src/dialog-editor/components/modal-field-template/text-area-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-area-box.html
@@ -28,6 +28,21 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Validation'|translate}}">
+      <input bs-switch
+             ng-model="vm.modalData.validator_type"
+             type="checkbox"
+             ng-true-value="'regex'"
+             ng-false-value="undefined"
+             switch-on-text="{{'Yes'|translate}}"
+             switch-off-text="{{'No'|translate}}">
+    </div>
+    <div ng-if="vm.modalData.validator_type === 'regex'"
+         pf-form-group pf-label="{{'Validator'|translate}}">
+      <i class="fa fa-info-circle primary help-icon"
+           tooltip-append-to-body="true"
+           uib-tooltip="{{ 'Regular Expression' }}"
+           tooltip-placement="auto">
+      </i>
       <input id="validator_rule" name="validator_rule"
              ng-model="vm.modalData.validator_rule"/>
     </div>
@@ -58,6 +73,21 @@
                switch-off-text="{{'No'|translate}}">
       </div>
       <div pf-form-group pf-label="{{'Validation'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.validator_type"
+               type="checkbox"
+               ng-true-value="'regex'"
+               ng-false-value="undefined"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate}}">
+      </div>
+      <div ng-if="vm.modalData.validator_type === 'regex'"
+           pf-form-group pf-label="{{'Validator'|translate}}">
+        <i class="fa fa-info-circle primary help-icon"
+             tooltip-append-to-body="true"
+             uib-tooltip="{{ 'Regular Expression' }}"
+             tooltip-placement="auto">
+        </i>
         <input id="validator_rule" name="validator_rule"
                ng-model="vm.modalData.validator_rule"/>
       </div>

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -40,8 +40,23 @@
       </select>
     </div>
     <div pf-form-group pf-label="{{'Validation'|translate}}">
+      <input bs-switch
+             ng-model="vm.modalData.validator_type"
+             type="checkbox"
+             ng-true-value="'regex'"
+             ng-false-value="undefined"
+             switch-on-text="{{'Yes'|translate}}"
+             switch-off-text="{{'No'|translate}}">
+    </div>
+    <div ng-if="vm.modalData.validator_type === 'regex'"
+         pf-form-group pf-label="{{'Validator'|translate}}">
+      <i class="fa fa-info-circle primary help-icon"
+           tooltip-append-to-body="true"
+           uib-tooltip="{{ 'Regular Expression' }}"
+           tooltip-placement="auto">
+      </i>
       <input id="validator_rule" name="validator_rule"
-              ng-model="vm.modalData.validator_rule"/>
+             ng-model="vm.modalData.validator_rule"/>
     </div>
     <dialog-editor-modal-field-template template="fields-to-refresh.html"
                                         modal-data="vm.modalData">
@@ -83,6 +98,21 @@
         </select>
       </div>
       <div pf-form-group pf-label="{{'Validation'|translate}}">
+        <input bs-switch
+               ng-model="vm.modalData.validator_type"
+               type="checkbox"
+               ng-true-value="'regex'"
+               ng-false-value="undefined"
+               switch-on-text="{{'Yes'|translate}}"
+               switch-off-text="{{'No'|translate}}">
+      </div>
+      <div ng-if="vm.modalData.validator_type === 'regex'"
+           pf-form-group pf-label="{{'Validator'|translate}}">
+        <i class="fa fa-info-circle primary help-icon"
+             tooltip-append-to-body="true"
+             uib-tooltip="{{ 'Regular Expression' }}"
+             tooltip-placement="auto">
+        </i>
         <input id="validator_rule" name="validator_rule"
                ng-model="vm.modalData.validator_rule"/>
       </div>

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -53,14 +53,20 @@ export class ToolboxController {
         'DialogFieldTextBox',
         'fa fa-font',
         __('Text Box'),
-        'text_box'
+        'text_box',
+        {
+          validator_type: false,
+        }
       ),
     dialogFieldTextAreaBox:
       new DialogField(
         'DialogFieldTextAreaBox',
         'fa fa-file-text-o',
         __('Text Area'),
-        'textarea_box'
+        'textarea_box',
+        {
+          validator_type: false,
+        }
       ),
     dialogFieldCheckBox:
       new DialogField(


### PR DESCRIPTION
The `validator_rule` is being set only if `validation_type` is set.

https://github.com/ManageIQ/manageiq/blob/328f68895668be400989faff1ebbf98fb8620b49/app/models/dialog_field_text_box.rb#L49

`validation_type` is not getting set by default, this PR fixes it.

