### PR TITLE
Fix lodash "find" call in currentCategoryEntries.

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -236,8 +236,9 @@ class ModalController {
     if (ng.isDefined(this.categories)) {
       return _.find(
         this.categories.resources,
-        'id',
-        this.modalData.options.category_id
+        {
+          'id': this.modalData.options.category_id
+        }
       );
     }
   }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1649527

We need to find by `id` with the value of `this.modalData.options.category_id` and the 2nd arg is supposed to be an object: https://lodash.com/docs/4.17.11#find