### PR TITLE
Return correct value from anyDialogFields

### DIFF
--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -56,9 +56,11 @@ describe('DialogEditor test', () => {
                 show_refresh_button: null,
                 load_values_on_init: null,
                 reconfigurable: null,
-                show_past_days: null,
-                protected: null,
-                force_multi_value: null,
+                options: {
+                  show_past_days: null,
+                  protected: null,
+                  force_multi_value: null,
+                },
               }]
             }]
           }]
@@ -75,9 +77,11 @@ describe('DialogEditor test', () => {
           show_refresh_button: false,
           load_values_on_init: false,
           reconfigurable: false,
-          show_past_days: false,
-          protected: false,
-          force_multi_value: false,
+          options: {
+              show_past_days: false,
+              protected: false,
+              force_multi_value: false,
+          },
         };
         expect(fieldValues).toEqual(falseValues);
       });

--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -44,6 +44,45 @@ describe('DialogEditor test', () => {
       });
     });
 
+    describe('when the values on a field are null', () => {
+      let dialogData = {
+        content: [{
+          dialog_tabs: [{
+            dialog_groups: [{
+              dialog_fields: [{
+                required: null,
+                visible: null,
+                read_only: null,
+                show_refresh_button: null,
+                load_values_on_init: null,
+                reconfigurable: null,
+                show_past_days: null,
+                protected: null,
+                force_multi_value: null,
+              }]
+            }]
+          }]
+        }]
+      };
+
+      it('sets all fields with null value  to false', () => {
+        dialogEditor.setData(dialogData);
+        let fieldValues = dialogEditor.data.content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0];
+        let falseValues = {
+          required: false,
+          visible: false,
+          read_only: false,
+          show_refresh_button: false,
+          load_values_on_init: false,
+          reconfigurable: false,
+          show_past_days: false,
+          protected: false,
+          force_multi_value: false,
+        };
+        expect(fieldValues).toEqual(falseValues);
+      });
+    });
+
     describe('when the values on a field are an object', () => {
       let dialogData = {
         content: [{

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -122,14 +122,15 @@ export default class DialogEditorService {
    * @function anyDialogFields
    */
   private anyDialogFields() {
+    let ret = false;
     _.forEach(this.data.content[0].dialog_tabs, (tab: any) => {
       _.forEach(tab.dialog_groups, (group: any) => {
         if (!_.isEmpty(group.dialog_fields)) {
-          return true;
+          ret = true;
         }
       });
     });
-    return false;
+    return ret;
   }
 
   /**

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -158,11 +158,13 @@ export default class DialogEditorService {
           field[attr] = false;
         }
       });
-      optionalAttributes.forEach(function(attr) {
-        if (field['options'][attr] == null) {
-          field['options'][attr] = false;
-        }
-      });
+      if (field['options']) {
+        optionalAttributes.forEach(function(attr) {
+          if (field['options'][attr] == null) {
+            field['options'][attr] = false;
+          }
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1557488

Steps to reproduce:
1. Import the dialog that has one `null` value like one below and edit the dialog
2. Edit the location element and click on options tab.
3. The `Load values on init` button is half cut (it doesn't have `true`/`false` value)

```
---
- description: 
  buttons: submit,cancel
  label: dynamic_refresh
  blueprint_id: 
  dialog_tabs:
  - description: 
    display: edit
    label: Tab
    display_method: 
    display_method_options: 
    position: 0
    dialog_groups:
    - description: 
      display: edit
      label: Box
      display_method: 
      display_method_options: 
      position: 0
      dialog_fields:
      - name: contract
        description: 
        data_type: string
        notes: 
        notes_display: 
        display: edit
        display_method: 
        display_method_options: {}
        required: true
        required_method: 
        required_method_options: {}
        default_value: a
        values:
        - - 
          - "<Choose>"
        - - a
          - Contract A
        - - b
          - Contract B
        values_method: 
        values_method_options: {}
        options:
          :sort_by: :description
          :sort_order: :ascending
          :force_multi_value: false
        label: Contract
        position: 0
        validator_type: 
        validator_rule: 
        reconfigurable: 
        dynamic: false
        show_refresh_button: 
        load_values_on_init: 
        read_only: false
        auto_refresh: 
        trigger_auto_refresh: true
        visible: true
        type: DialogFieldDropDownList
        resource_action:
          action: 
          resource_type: DialogField
          ae_namespace: 
          ae_class: 
          ae_instance: 
          ae_message: 
          ae_attributes: {}
```

@miq-bot add_label bug, hammer/yes, gaprindashvili/yes