### PR TITLE
Update nodejs version that should be used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - '6'
+  - '8'
 
 npm:
   - '3'


### PR DESCRIPTION
Update `nodejs` version that should be used by Travis from `6` to `8`.
Error:
```
$ yarn global add typings webpack karma typescript
yarn global v1.3.2
[1/4] Resolving packages...
warning typings@2.1.1: Typings is deprecated in favor of NPM @types -- see README for more information
warning karma > log4js > circular-json@0.5.9: CircularJSON is in maintenance only, flatted is its successor.
[2/4] Fetching packages...
info fsevents@1.2.7: The platform "linux" is incompatible with this module.
info "fsevents@1.2.7" is an optional dependency and failed compatibility check. Excluding it from installation.
error karma@4.0.0: The engine "node" is incompatible with this module. Expected version ">= 8".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
The command "yarn global add typings webpack karma typescript" failed and exited with 1 during .
```

@miq-bot add_label hammer/no, gaprindashvili/no, build

@himdel please review, thanks :)

Note to self: 
If backport is needed try something like this:
```diff
diff --git a/.travis.yml b/.travis.yml
index 08b04a6..92ad57d 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - node_modules
 
 before_install:
-  - 'yarn global add typings webpack karma typescript'
+  - 'yarn global add typings webpack karma@3.1.1 typescript'
```