### PR TITLE
Downgrade karma version that should be used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - node_modules
 
 before_install:
-  - 'yarn global add typings webpack karma typescript'
+  - 'yarn global add typings webpack karma@3.1.1 typescript'
 
 script: ./scripts/.build.sh
 


### PR DESCRIPTION
Downgrade karma version that should be used by Travis from 4.0.0 to 3.1.1 to resolve karma@4.0.0 failing because it needs nodejs 8.0.0 or higher

Error:
```
14.08s$ yarn global add typings webpack karma typescript
yarn global v1.3.2
[1/4] Resolving packages...
warning typings@2.1.1: Typings is deprecated in favor of NPM @types -- see README for more information
warning karma > log4js > circular-json@0.5.9: CircularJSON is in maintenance only, flatted is its successor.
[2/4] Fetching packages...
info fsevents@1.2.7: The platform "linux" is incompatible with this module.
info "fsevents@1.2.7" is an optional dependency and failed compatibility check. Excluding it from installation.
error karma@4.0.0: The engine "node" is incompatible with this module. Expected version ">= 8".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
The command "yarn global add typings webpack karma typescript" failed and exited with 1 during .
```

@miq-bot add_label build