### PR TITLE
dialogField - move logic for setting default_value to one place

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -73,7 +73,6 @@
               data-live-search="true"
               data-container="body"
               ng-if="vm.dialogField.options.force_multi_value"
-              ng-init="vm.convertValuesToArray()"
               ng-model="vm.dialogField.default_value"
               watch-model="vm.dialogField.values"
               ng-change="vm.changesHappened(item)"

--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -33,12 +33,13 @@ const dialogField = {
 
 describe('Dialog field test', () => {
   let bindings;
+
   describe('controller', () => {
     let dialogCtrl;
 
     beforeEach(() => {
       bindings = {
-        field: dialogField,
+        field: {...dialogField},
         onUpdate: () => true,
         inputDisabled: false
       };
@@ -68,24 +69,33 @@ describe('Dialog field test', () => {
     });
 
     it('should check and update a field when the parent component field has changed', () => {
-      let testDialogUpdate = dialogField;
-      testDialogUpdate.default_value = 'Testing';
-      dialogCtrl.field = testDialogUpdate;
+      dialogCtrl.field.default_value = 'Testing';
       dialogCtrl.$doCheck();
       expect(dialogCtrl.clonedDialogField.default_value).toBe('Testing');
     });
 
-    describe('#convertValuesToArray', () => {
-      it('converts a string of default values to an array', () => {
-        dialogCtrl.dialogField.default_value = '["one", "two"]';
-        dialogCtrl.convertValuesToArray();
-        expect(dialogCtrl.dialogField.default_value).toEqual(['one', 'two']);
-      });
+    it('converts a string of default values to an array', () => {
+      dialogCtrl.field = {
+        ...dialogField,
+        type: 'DialogFieldDropDownList',
+        default_value: '["one", "two"]',
+        values: [
+          ['val', 'label'],
+        ],
+        options: {
+          ...dialogField.options,
+          force_multi_value: true,
+        },
+      };
+      dialogCtrl.$doCheck();
+      expect(dialogCtrl.dialogField.default_value).toEqual(['one', 'two']);
     });
   });
+
   describe('updates should be reported up to function that is passed into component', () => {
     let bindings;
     let dialogCtrl;
+
     it('should report back information when a field gets updated', () => {
       bindings = {
         field: dialogField,

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -32,9 +32,6 @@ export class DialogFieldController extends DialogFieldClass {
     this.clonedDialogField = _.cloneDeep(this.field);
     this.dialogField = this.field;
     this.validation = null;
-    if (this.dialogField.type === 'DialogFieldTagControl') {
-      this.setDefaultValue();
-    }
 
     if ((this.dialogField.type === 'DialogFieldDateTimeControl') ||
         (this.dialogField.type === 'DialogFieldDateControl')) {
@@ -114,16 +111,6 @@ export class DialogFieldController extends DialogFieldClass {
   }
 
   /**
-   * This will convert the values stored in dialogField.default_value to an array
-   * for use with a multiple-select field because by default it comes in as a string
-   * @memberof DialogFieldController
-   * @function convertValuesToArray
-   */
-  public convertValuesToArray() {
-    this.dialogField.default_value = angular.fromJson(this.dialogField.default_value);
-  }
-
-  /**
    * This method validates a dialog field to ensure its current values are valid
    * @memberof DialogFieldController
    * @function validateField
@@ -140,25 +127,9 @@ export class DialogFieldController extends DialogFieldClass {
   public refreshSingleField() {
     this.singleRefresh({ field: this.field.name });
   }
-
-  /**
-   * This method is setting the default_value for a tag control's select box.
-   * In case the default_value is not set for the ng-model of the component,
-   * an empty value option is displayed
-   * @memberof DialogFieldController
-   * @function setDefaultValue
-   */
-  private setDefaultValue() {
-    let defaultOption = _.find(this.dialogField.values, { id: null });
-    if (defaultOption) {
-      defaultOption.id = 0;
-      this.dialogField.default_value = defaultOption.id;
-    }
-  }
 }
 
 export default class DialogField {
-
   public replace: boolean = true;
   public template = require('./dialogField.html');
   public controller: any = DialogFieldController;

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -90,26 +90,31 @@ export default class DialogDataService {
     let defaultValue: any = '';
     const firstOption = 0; // these are meant to help make code more readable
     const fieldValue = 0;
+
     if (_.isObject(data.values)) {
-      if (angular.isDefined(data.default_value) && data.default_value !== null) {
-        defaultValue = data.default_value;
-      } else {
-        defaultValue = data.values[firstOption][fieldValue];
-      }
-    } else {
-      if (data.type === 'DialogFieldDateControl' || data.type === 'DialogFieldDateTimeControl') {
-        if (data.values === undefined) {
-          defaultValue = new Date();
-        } else {
-          defaultValue = new Date(data.values);
-        }
-      } else {
-        defaultValue = data.values;
-      }
+      defaultValue = data.values[firstOption][fieldValue];
+    }
+
+    if (data.type === 'DialogFieldDateControl' || data.type === 'DialogFieldDateTimeControl') {
+      defaultValue = data.values ? new Date(data.values) : new Date();
     }
 
     if (data.default_value) {
       defaultValue = data.default_value;
+    }
+
+    if (data.type === 'DialogFieldDropDownList' && data.options.force_multi_value && data.default_value) {
+      defaultValue = JSON.parse(data.default_value);
+    }
+
+    if (data.type === 'DialogFieldTagControl') {
+      // setting the default_value for a tag control's select box
+      // In case the default_value is not set for the ng-model of the component, an empty value option is displayed
+      let defaultOption = _.find(data.values, { id: null });
+      if (defaultOption) {
+        defaultOption.id = 0;
+        defaultValue = defaultOption.id;
+      }
     }
 
     if (this.checkboxNeedsNewDefaultValue(data)) {


### PR DESCRIPTION
Current state:

* `dialogData.setupField` gets called from `dialogField` on external changes
* `dialogData.setupField` calls `dialogData.setDefaultValue` to set the field's `default_value` field

But in addition to that,

* `dialogField` also calls `dialogField.setDefaultValue` on in `$onInit`, meaning it only happens once - to set an initial value for tags (comes from https://github.com/ManageIQ/ui-components/pull/276)
* and the dropdown template has a `ng-init` on the select element, which calls `convertValuesToArray`, but only once, because `ng-init` (comes from https://github.com/ManageIQ/ui-components/pull/250)


So, this PR moves the second set of bullet points to `dialogData.setDefaultValue`, to make sure every piece of code dealing with default_values gets called in all the circumstances.

This fixes multiselects after refresh, because `convertValuesToArray` is needed after every refresh, not only on load.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1669533