### PR TITLE
Fix failing spec - missing mock data

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -111,6 +111,7 @@ describe('Dialog field test', () => {
       'type': 'DialogFieldDateTimeControl',
       'dateField': testDate,
       'timeField': testDate,
+      'options': {},
     };
 
     it('calls onUpdate with the correct full date', () => {


### PR DESCRIPTION
Fixes..

```
Dialog field test #dateTimeFieldChanged calls onUpdate with the correct full date FAILED
	TypeError: undefined is not an object (evaluating 'this.dialogField.options.show_past_dates') (line 9)
	setMinDate@dist/js/ui-components.js:9:120490
	$onInit@dist/js/ui-components.js:9:116953
	src/dialog-user/components/dialog-user/dialogField.spec.ts:189:35
	WorkFn@node_modules/angular-mocks/angular-mocks.js:3130:26
	src/dialog-user/components/dialog-user/dialogField.spec.ts:187:32
	inject@node_modules/angular-mocks/angular-mocks.js:3093:34
	src/dialog-user/components/dialog-user/dialogField.spec.ts:187:32
```

the spec comes from https://github.com/ManageIQ/ui-components/pull/317,
`setMinDate` logic comes from https://github.com/ManageIQ/ui-components/pull/355