### PR TITLE
Webpack.config - clean up formatting, support vim

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,5 +136,8 @@ module.exports = (env) => {
       'numeral': 'numeral',
       '__': '__',
     },
+    watchOptions: {
+      ignored: ['**/.*.sw[po]'],
+    },
   };
 };


### PR DESCRIPTION
The first commit literally just cleans up formatting, whitespace, etc. and moves all the code inside the exported function, instead of ignoring environment in the first parts.

The second adds `watchOptions.ignore` to ignore vim swapfiles when running `webpack --watch`.

