### PR TITLE
[WIP] Collapse custom buttons in the toolbar if they don't fit on screen

### DIFF
--- a/demo/data/toolbar.json
+++ b/demo/data/toolbar.json
@@ -127,6 +127,38 @@
       "enabled": true,
       "title": "Power",
       "text": "Power"
+    },
+    {
+      "id": "sep_2",
+      "type": "separator"
+    },
+    {
+      "id": "kebab_example",
+      "type": "kebab",
+      "items": [
+        {
+          "child_id": "middleware_server_reload",
+          "id": "middleware_server_power_choice__middleware_server_reload",
+          "type": "button",
+          "img": "middleware_server_reload.png",
+          "imgdis": "middleware_server_reload.png",
+          "icon": "pficon pficon-restart fa-lg",
+          "name": "middleware_server_power_choice__middleware_server_reload",
+          "hidden": false,
+          "pressed": null,
+          "onwhen": "1+",
+          "data": null,
+          "enabled": true,
+          "title": "Reload these Middleware Servers",
+          "text": "Reload Server",
+          "confirm": "Do you want to reload selected servers?",
+          "url_parms": "main_div"
+        }
+      ]
+    },
+    {
+      "id": "sep_2",
+      "type": "separator"
     }
   ],
   [

--- a/src/toolbar/components/toolbar-menu/toolbar-kebab.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-kebab.html
@@ -2,7 +2,7 @@
   <button uib-dropdown-toggle class="btn btn-link" type="button">
     <span class="fa fa-ellipsis-v"></span>
   </button>
-  <ul uib-dropdown-menu aria-labelledby="dropdownKebab">
+  <ul uib-dropdown-menu aria-labelledby="dropdownKebab" class="dropdown-menu-right">
     <li ng-repeat="kebabItem in vm.kebabItem.items"
         role="{{kebabItem.isSeparator ? 'separator' : 'menuitem'}}"
         ng-class="{


### PR DESCRIPTION
When there was more than 3 custom button groups, all custom buttons were collapsed into a kebab menu. I'm changing this behavior to be a little more dynamic: 
* If  the toolbar buttons fit into one row on the screen, all good
* If the kebab menu doesn't exist, create it after the custom button groups
* Move the last custom button group from its original location into the kebab
* Go back to the first step

The whole thing is called on the `$onChange` angular lifecycle hook, i.e. any change in the menu will re-run the hook until there are no further changes. Therefore, after there's enough space in the toolbar or no more buttons to move, the loop will stop. The `$onChange` hook is not called on a screen resize, so this is not a truly responsive solution and I rather don't want to add an `onResize` listener if that's okay.

![screenshot from 2019-03-07 10-52-43](https://user-images.githubusercontent.com/649130/53947982-2d0ce480-40c7-11e9-806f-558e850a6b06.png)

@miq-bot add_reviewer @himdel 
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @karelhala 

https://bugzilla.redhat.com/show_bug.cgi?id=1683703

### TODO:
* I'm open for ideas how to test this :scream: 
* The styling is a little off, the 2nd level dropdown should be expanded to the left, ping @epwinchell 