### PR TITLE
Squash tooltips from child elements in toolbar dropdown if disabled

### DIFF
--- a/src/toolbar/components/toolbar-menu/toolbar-list.html
+++ b/src/toolbar/components/toolbar-menu/toolbar-list.html
@@ -1,6 +1,6 @@
 <div class="btn-group" ng-class="vm.dropdownClass" uib-dropdown ng-if="vm.isEmpty">
   <button type="button" uib-dropdown-toggle class="btn uib-dropdown-toggle btn-default"
-          ng-class="{disabled: !vm.isToolbarEnabled()}" title="{{vm.toolbarList.title}}">
+          ng-class="{disabled: !vm.isToolbarEnabled()}" title="{{vm.toolbarTitle()}}">
     <i class="{{vm.toolbarList.icon}}"
        ng-if="vm.toolbarList.icon"
        ng-style="{color: vm.toolbarList.color}"></i>

--- a/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
+++ b/src/toolbar/components/toolbar-menu/toolbarListComponent.ts
@@ -59,6 +59,21 @@ export class ToolbarListController implements IToolbarListBindings {
       this.toolbarList.items &&
       this.toolbarList.items.some((item: IToolbarItem) => item.enabled);
   }
+
+  private toolbarTitle(): string {
+    let squashedTitle = [this.toolbarList.title];
+
+    // If the toolbar item has child elements and all of them are disabled
+    if (this.toolbarList &&
+        this.toolbarList.items &&
+        this.toolbarList.items.every((item: IToolbarItem) => !item.enabled)) {
+      // Collect the titles (reasons why they are disabled) of all the disabled children
+      let items = this.toolbarList.items.filter((item : IToolbarItem) => item.title !== undefined);
+      squashedTitle.push(...items.map((item: IToolbarItem) => `⚬ ${item.text} - ${item.title}`));
+    }
+
+    return squashedTitle.join('\n');
+  }
 }
 
 /**


### PR DESCRIPTION
When there's a toolbar dropdown with all child items disabled, it is not possible to open it. Each disabled toolbar button contains a hint about why it is disabled if you hover on it. These two things don't really fit together as you are not able to hover onto a disabled child element in a dropdown if all the other child elements are disabled.

![Screenshot from 2019-03-14 13-41-42](https://user-images.githubusercontent.com/649130/54357932-70cf9300-465f-11e9-80fc-4b4450ab170f.png)

My solution is to, if it is necessary, collect all the tooltips from the child items and display them inside the tooltip of the parent element.

![list-bullets](https://user-images.githubusercontent.com/649130/54423505-1c84eb80-4711-11e9-8ef6-9061459418c1.png) 

@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_label toolbars, hammer/no, ux/review

Fixes https://github.com/ManageIQ/manageiq/issues/18460