### PR TITLE
Fix travis - restrict bootstrap-select to ~1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "awesome-typescript-loader": "~4.0.1",
     "bootstrap-combobox": "^1.0.2",
     "bootstrap-datepicker": "^1.6.4",
-    "bootstrap-select": "^1.12.1",
+    "bootstrap-select": "~1.12.1",
     "bootstrap-switch": "^3.3.4",
     "browser-sync": "^2.18.2",
     "browser-sync-spa": "^1.0.3",

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -51,7 +51,7 @@ export class DialogFieldController extends DialogFieldClass {
   public $doCheck() {
     if (!_.isEqual(this.field, this.clonedDialogField)) {
       this.clonedDialogField = _.cloneDeep(this.field);
-      if (_.isObject(this.validation)) {
+      if (this.validation) {
         this.field.fieldValidation = this.validation.isValid;
         this.field.errorMessage = this.validation.message;
       }


### PR DESCRIPTION
Fixes `undefined is not an object (evaluating 'this.$newElement[0].parentNode.classList.contains')` by making sure we don't use too new a version of bootstrap-select. (ui-classic is using `@pf3/select` which is a fork of the 1.12 branch of bootstrap-select)

And just because it still fails with that, this also removes a useless `_.isObject` which narrows the type of `this.validation` from `any` to `object`, causing errors.