### PR TITLE
Dialog editor: Make "Load Values on Init" independent of "Show Refresh Button" 

### DIFF
--- a/src/dialog-editor/components/modal-field-template/dynamic-values.html
+++ b/src/dialog-editor/components/modal-field-template/dynamic-values.html
@@ -5,7 +5,7 @@
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate }}"/>
 </div>
-<div ng-if="vm.modalData.show_refresh_button" pf-form-group pf-label="{{'Load values on init'|translate}}">
+<div pf-form-group pf-label="{{'Load values on init'|translate}}">
   <input bs-switch
          ng-model="vm.modalData.load_values_on_init"
          type="checkbox"

--- a/src/dialog-editor/components/toolbox/toolboxComponent.ts
+++ b/src/dialog-editor/components/toolbox/toolboxComponent.ts
@@ -27,7 +27,7 @@ class DialogField {
       position: 0,
       dynamic: false,
       show_refresh_button: false,
-      load_values_on_init: false,
+      load_values_on_init: true,
       auto_refresh: false,
       trigger_auto_refresh: false,
       reconfigurable: false,


### PR DESCRIPTION
Depends on:
  * schema: https://github.com/ManageIQ/manageiq-schema/pull/357 (merged)
  * core: https://github.com/ManageIQ/manageiq/pull/18600 (merged)

Dynamic dialog fields can load on init (once), by manually triggering a refresh button, or from "fields to refresh".

Before, when there was no refresh button, load on init was hardcoded to true on the model side and the switch was hidden.

This makes the "Load Values on Init" switch always visible, independent of "Show Refresh Button".

![good](https://user-images.githubusercontent.com/289743/55242747-c4cca100-5235-11e9-9a38-a5a5fb9769d2.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1684575