### PR TITLE
Corrected condition testing emptiness of dialog field

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -161,7 +161,7 @@ export default class DialogDataService {
     }
     // Run check if someone has specified a regex.  Make sure if its required it is not blank
     if (field.validator_rule && validation.isValid === true) {
-      if (angular.isDefined(fieldValue) && fieldValue !== '') {
+      if (angular.isDefined(fieldValue) && !_.isEmpty(fieldValue)) {
         // This use case ensures that an optional field doesnt check a regex if field is blank
         const regexPattern = field.validator_rule.replace(/\\A/i, '^').replace(/\\Z/i,'$');
         const regex = new RegExp(regexPattern);


### PR DESCRIPTION
This change is correcting a test for emptiness of a service dialog field.

The problem now is the button to submit the form is disabled, because the field with validation is treated as not empty (`fieldValue` is of value `null`) and therefore with invalid value.

![Screencast from 2019-03-27 12-47-30](https://user-images.githubusercontent.com/1187051/55077165-f9522880-508e-11e9-925c-ecab38dd00ba.gif)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1692736
