### PR TITLE
Allow validator_rule to be updated in case of dynamic text boxes

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -62,7 +62,7 @@ describe('Dialog field test', () => {
       const expectedValue = {
         isValid: false,
         field: 'Service Name',
-        message: 'Entered text does not match required format.'
+        message: 'Entered text should match the format: [0-9]'
       };
 
       expect(fieldValid).toEqual(expectedValue);

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -35,15 +35,17 @@ describe('Dialog test', () =>  {
         expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('service_default');
     });
     it('should allow properties on a dialog field to be updated', () => {
-        const testChanges = {
-            data_type: 'string',
-            read_only: true,
-            required: true,
-            visible: true
-        };
-        const dialogName = 'service_name';
-        dialogCtrl.updateDialogFieldData(dialogName, testChanges);
-        expect(dialogCtrl.dialogFields[dialogName].read_only).toBe(true);
+      const testChanges = {
+        data_type: 'string',
+        read_only: true,
+        required: true,
+        visible: true,
+        validator_rule: '^1234',
+      };
+      const dialogName = 'service_name';
+      dialogCtrl.updateDialogFieldData(dialogName, testChanges);
+      expect(dialogCtrl.dialogFields[dialogName].read_only).toBe(true);
+      expect(dialogCtrl.dialogFields[dialogName].validator_rule).toBe('^1234');
     });
   });
   describe('controller with refreshable fields', () => {

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -267,6 +267,7 @@ export class DialogUserController extends DialogClass implements IDialogs {
     dialogField.visible = data.visible;
     dialogField.values = data.values;
     dialogField.default_value = data.default_value;
+    dialogField.validator_rule = data.validator_rule;
 
     return dialogField;
   }

--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -254,6 +254,28 @@ describe('DialogDataService test', () => {
           });
         });
       });
+
+      describe('when the field is a text box', () => {
+        describe('when the validator rule does not match the text', () => {
+          let testField;
+
+          beforeEach(() => {
+            testField = {
+              'type': 'DialogFieldTextBox',
+              'default_value': '123',
+              'required': true,
+              'validator_type': 'regex',
+              'validator_rule': '^1234'
+            }
+          });
+
+          it('fails validation', () => {
+            let validation = dialogData.validateField(testField);
+            expect(validation.isValid).toEqual(false);
+            expect(validation.message).toEqual('Entered text should match the format: ^1234');
+          });
+        });
+      });
     });
 
     describe('when the field is not required', () => {

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -167,7 +167,7 @@ export default class DialogDataService {
         const regex = new RegExp(regexPattern);
         const regexValidates = regex.test(fieldValue);
         validation.isValid = regexValidates;
-        validation.message = __('Entered text does not match required format.');
+        validation.message = __('Entered text should match the format:') + ' ' + regexPattern;
       }
     }
 


### PR DESCRIPTION
The UI wasn't changing the validation rule for text boxes when a new rule would come through via automate. This should fix that.

I also updated the message to actually include the regex that the user should match against, otherwise the user is simply guessing at what their "invalid format" is. I'm guessing maybe we had a reason to obscure the regex before, so if that is the case, it can easily be left out of this PR.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1694737

@miq-bot add_label bug, hammer/yes

/cc @tinaafitz Can you comment on the validation message change?

@miq-bot assign @himdel 