### PR TITLE
[WIP] DialogUser - support integer keys in dropdowns, refreshing multidropdowns

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -62,6 +62,7 @@
               class="form-control"
               data-container="body"
               id="{{ vm.dialogField.name }}"
+              miq-options="{ 'data-tokens': vm.fieldTokens }"
               ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
 
@@ -75,6 +76,7 @@
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               input-id="{{ vm.dialogField.name }}"
+              miq-options="{ 'data-tokens': vm.fieldTokens }"
               ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
     </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -62,7 +62,7 @@
               class="form-control"
               data-container="body"
               id="{{ vm.dialogField.name }}"
-              miq-options="{ 'data-tokens': vm.fieldTokens }"
+              miq-options="{ 'data-tokens': value[0] + ' ' + value[1] }"
               ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
 
@@ -76,7 +76,7 @@
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               input-id="{{ vm.dialogField.name }}"
-              miq-options="{ 'data-tokens': vm.fieldTokens }"
+              miq-options="{ 'data-tokens': value[0] + ' ' + value[1] }"
               ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
     </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -71,7 +71,7 @@
               ng-if="vm.dialogField.options.force_multi_value"
               ng-model="vm.dialogField.default_value"
               watch-model="vm.dialogField.values"
-              ng-change="vm.changesHappened(item)"
+              ng-change="vm.changesHappened()"
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               input-id="{{ vm.dialogField.name }}"

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -61,12 +61,8 @@
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               class="form-control"
               data-container="body"
-              id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
+              id="{{ vm.dialogField.name }}"
+              ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
 
       <select miq-select multiple
@@ -78,12 +74,8 @@
               ng-change="vm.changesHappened(item)"
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-              input-id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
+              input-id="{{ vm.dialogField.name }}"
+              ng-options="value[0] as value[1] for value in vm.dialogField.values">
       </select>
     </div>
 

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -121,6 +121,10 @@ export class DialogFieldController extends DialogFieldClass {
   public refreshSingleField() {
     this.singleRefresh({ field: this.field.name });
   }
+
+  public fieldTokens(element) {
+    return element.innerText + ' ' + element.value.split(/:/)[1];
+  }
 }
 
 export default class DialogField {

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -121,10 +121,6 @@ export class DialogFieldController extends DialogFieldClass {
   public refreshSingleField() {
     this.singleRefresh({ field: this.field.name });
   }
-
-  public fieldTokens(element) {
-    return element.innerText + ' ' + element.value.split(/:/)[1];
-  }
 }
 
 export default class DialogField {

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -66,14 +66,8 @@ export class DialogFieldController extends DialogFieldClass {
    * @function changesHappened
    */
   public changesHappened(value) {
-    const selectedValue = 0;
     this.validation = this.validateField();
-    let fieldValue = (value ? value[selectedValue] : this.dialogField.default_value);
-    if ((this.dialogField.type === 'DialogFieldTagControl' ||
-         this.dialogField.type === 'DialogFieldDropDownList') &&
-        this.dialogField.default_value instanceof Array) {
-        fieldValue = this.dialogField.default_value.join();
-      }
+    let fieldValue = value || this.dialogField.default_value;
     this.onUpdate({ dialogFieldName: this.field.name, value: fieldValue });
   }
 
@@ -97,7 +91,7 @@ export class DialogFieldController extends DialogFieldClass {
     let minutes = this.dialogField.timeField.getMinutes();
 
     let fullDate = new Date(fullYear, month, date, hours, minutes);
-    this.changesHappened([fullDate]);
+    this.changesHappened(fullDate);
   }
 
   /**

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -18,7 +18,7 @@ export class DialogUserController extends DialogClass implements IDialogs {
   public service: any;
   public refreshRequestCount: number;
   public areFieldsBeingRefreshed: boolean;
-  public hasFieldsToUpdate: boolean;
+
   /**
    * constructor
    ** DialogData - This is the data service that handles manipulating and organizing field data
@@ -37,33 +37,37 @@ export class DialogUserController extends DialogClass implements IDialogs {
    * @function $onInit
    */
   public $onInit() {
-    const vm = this;
-    vm.dialogFields = {};
-    vm.refreshableFields = [];
-    vm.fieldAssociations = {};
-    vm.dialogValues = {};
-    vm.refreshRequestCount = 0;
-    vm.areFieldsBeingRefreshed = false;
-    vm.inputDisabled = vm.inputDisabled || false;
+    this.dialogFields = {};
+    this.refreshableFields = [];
+    this.fieldAssociations = {};
+    this.dialogValues = {};
+    this.refreshRequestCount = 0;
+    this.areFieldsBeingRefreshed = false;
+    this.inputDisabled = this.inputDisabled || false;
+
     this.service = this.DialogData;
     for (const dialogTabs of this.dialog.dialog_tabs) {
       for (const dialogGroup of dialogTabs.dialog_groups) {
         for (const dialogField of dialogGroup.dialog_fields) {
-          vm.dialogFields[dialogField.name] = this.service.setupField(dialogField);
-          // at this point all dialog fields are stored in a object keyed by field name
-          vm.dialogValues[dialogField.name] = vm.dialogFields[dialogField.name].default_value;
-          if (dialogField.dialog_field_responders !== undefined) {
-            vm.fieldAssociations[dialogField.name] = dialogField.dialog_field_responders;
-          } else {
-            if (dialogField.auto_refresh === true || dialogField.trigger_auto_refresh === true) {
-              vm.refreshableFields.push(dialogField.name);
-            }
-          }
+          this.initField(dialogField);
         }
       }
     }
-    vm.saveDialogData();
+
+    this.saveDialogData();
   }
+
+  private initField(dialogField) {
+    this.dialogFields[dialogField.name] = this.service.setupField(dialogField);
+    this.dialogValues[dialogField.name] = this.dialogFields[dialogField.name].default_value;
+
+    if (dialogField.dialog_field_responders !== undefined) {
+      this.fieldAssociations[dialogField.name] = dialogField.dialog_field_responders;
+    } else if (dialogField.auto_refresh === true || dialogField.trigger_auto_refresh === true) {
+      this.refreshableFields.push(dialogField.name);
+    }
+  }
+
   /**
   * This reports all values from the dialog up to the parent component
   * The onUpdate method signature from the parent component should be updateFunctionName(data)
@@ -100,6 +104,7 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
     return validations;
   }
+
   /**
    * This method handles refreshing of a dialog field as well
    * as determining which other fields might need to be updated
@@ -109,17 +114,22 @@ export class DialogUserController extends DialogClass implements IDialogs {
    * @param value {any} This is the updated value based on the selection the user made on a particular dialog field
    */
   public updateDialogField(dialogFieldName, value) {
-    this.hasFieldsToUpdate = false;
-    if (!_.isEmpty(this.fieldAssociations) && this.fieldAssociations[dialogFieldName].length > 0) {
-      this.hasFieldsToUpdate = true;
-    }
+    let hasFieldsToUpdate = this.fieldAssociations && this.fieldAssociations[dialogFieldName].length;
+
+    console.log('updateDialogField', {
+      name: dialogFieldName,
+      from: this.dialogValues[dialogFieldName],
+      to: value,
+    });
     this.dialogValues[dialogFieldName] = value;
-    if (this.hasFieldsToUpdate) {
+    if (hasFieldsToUpdate) {
       this.determineRefreshRequestCount(dialogFieldName);
       this.areFieldsBeingRefreshed = true;
     }
+
     this.saveDialogData();
-    if (this.hasFieldsToUpdate) {
+
+    if (hasFieldsToUpdate) {
       this.updateTargetedFieldsFrom(dialogFieldName);
     } else {
       const refreshable = _.indexOf(this.refreshableFields, dialogFieldName);
@@ -219,6 +229,8 @@ export class DialogUserController extends DialogClass implements IDialogs {
    */
 
   private refreshFieldCallback(field, data) {
+    this.initField(data);
+
     this.dialogFields[field] = this.updateDialogFieldData(field, data);
     if (this.isASortedItemDialogField(data.type)) {
       this.dialogValues[field] = data.default_value;

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -88,11 +88,10 @@ export default class DialogDataService {
    **/
   private setDefaultValue(data): any {
     let defaultValue: any = '';
-    const firstOption = 0; // these are meant to help make code more readable
-    const fieldValue = 0;
 
     if (_.isObject(data.values)) {
-      defaultValue = data.values[firstOption][fieldValue];
+      // default to the value of the first option
+      defaultValue = data.values[0][0];
     }
 
     if (data.type === 'DialogFieldDateControl' || data.type === 'DialogFieldDateTimeControl') {
@@ -103,7 +102,9 @@ export default class DialogDataService {
       defaultValue = data.default_value;
     }
 
-    if (data.type === 'DialogFieldDropDownList' && data.options.force_multi_value && data.default_value) {
+    // FIXME maybe better make sure it's never not string (must come from double call)
+    if (data.type === 'DialogFieldDropDownList' && data.options.force_multi_value &&
+        data.default_value && _.isString(data.default_value)) {
       defaultValue = JSON.parse(data.default_value);
     }
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -13,14 +13,17 @@ export default class DialogDataService {
    **/
   public setupField(data: any) {
     let field = _.cloneDeep(data);
-    const dropDownValues = [];
-    field.fieldBeingRefreshed = (angular.isDefined(field.fieldBeingRefreshed) ? field.fieldBeingRefreshed : false);
+
+    field.fieldBeingRefreshed = field.fieldBeingRefreshed || false;
+
     if (angular.isUndefined(field.fieldValidation)) {
       field.fieldValidation = '';
       field.errorMessage = '';
     }
+
     const sortableFieldTypes = ['DialogFieldDropDownList', 'DialogFieldRadioButton'];
-    if (_.includes(sortableFieldTypes,field.type)) {
+    if (_.includes(sortableFieldTypes, field.type)) {
+      const dropDownValues = [];
       for (let option of field.values) {
         if (option[0] === String(field.default_value)) {
           field.selected = option;

--- a/src/miq-select/index.ts
+++ b/src/miq-select/index.ts
@@ -1,7 +1,9 @@
 import MiqSelect from './miqSelect';
+import MiqOptions from './miqOptions';
 import * as angular from 'angular';
 
 module miqSelect {
   export const app = angular.module('miqStaticAssets.miqSelect', []);
   app.directive('miqSelect', MiqSelect);
+  app.directive('miqOptions', MiqOptions);
 }

--- a/src/miq-select/miqOptions.js
+++ b/src/miq-select/miqOptions.js
@@ -1,0 +1,40 @@
+// use together with ng-options to set extra attributes on the option elements
+// use miq-options="{ attr1: 'static', attr2: vm.function }", where function gets run for each such element
+var miqOptions = function ($parse) {
+  'use strict';
+
+  return {
+    priority: 0,
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+      var miqOptions = $parse(attrs.miqOptions)(scope);
+
+      var match = attrs.ngOptions.match(/for\s+.+\s+in\s+(.+)\s*/);
+      if (!match) {
+        return;
+      }
+      var attrToWatch = match[1];
+
+      scope.$watch(attrToWatch, function (newValue) {
+        if (!newValue) {
+          return;
+        }
+
+        angular.element('option', element).each(function (_i, e) {
+          Object.keys(miqOptions).forEach(function(k) {
+            var v = miqOptions[k];
+            if (_.isFunction(v)) {
+              v = v(e);
+            }
+
+            angular.element(e).attr(k, v);
+          });
+        });
+      });
+    },
+  };
+};
+
+miqOptions.$inject = ['$parse'];
+
+export default miqOptions;

--- a/src/miq-select/miqOptions.js
+++ b/src/miq-select/miqOptions.js
@@ -1,5 +1,9 @@
 // use together with ng-options to set extra attributes on the option elements
-// use miq-options="{ attr1: 'static', attr2: vm.function }", where function gets run for each such element
+// use miq-options="{ attr1: 'static', attr2: expression, attr3: vm.function }"
+// expression gets evaluated in each option's scope separately,
+// function gets run with (scope, element)
+
+/* @ngInject */
 var miqOptions = function ($parse) {
   'use strict';
 
@@ -7,34 +11,69 @@ var miqOptions = function ($parse) {
     priority: 0,
     restrict: 'A',
     link: function (scope, element, attrs) {
-      var miqOptions = $parse(attrs.miqOptions)(scope);
-
-      var match = attrs.ngOptions.match(/for\s+.+\s+in\s+(.+)\s*/);
+      var match = attrs.ngOptions.match(/for\s+(.+)\s+in\s+(.+)\s*/);
       if (!match) {
+        console.warn('miqOptions: couldn\'t parse ngOptions', attrs.ngOptions);
         return;
       }
-      var attrToWatch = match[1];
+      var attrName = match[1];
+      var attrToWatch = match[2];
 
-      scope.$watch(attrToWatch, function (newValue) {
+      var parsedOptions = $parse(attrs.miqOptions);
+
+      var updateOptions = function (newValue) {
         if (!newValue) {
           return;
         }
 
-        angular.element('option', element).each(function (_i, e) {
-          Object.keys(miqOptions).forEach(function(k) {
-            var v = miqOptions[k];
-            if (_.isFunction(v)) {
-              v = v(e);
+        var values = [];
+        if (_.isArray(newValue)) {
+          values = newValue;
+        } else if (_.isObject(newValue)) {
+          values = Object.values(newValue);
+        } else {
+          console.warn('miqOptions: Unknown ngOptions source', newValue);
+          return;
+        }
+
+        var optionCount = angular.element('option', element).length;
+
+        var ignoredOptions = 0;
+        if (values.length === optionCount) {
+          ignoredOptions = 0;
+        } else if (values.length === optionCount - 1) {
+          ignoredOptions = 1;
+        } else {
+          console.warn('miqOptions: mismatch between number of items and options', values.length, optionCount);
+          return;
+        }
+
+        angular.element('option', element).each(function (i, optionElement) {
+          var idx = i - ignoredOptions;
+          if (idx < 0) {
+            return; // skip empty option
+          }
+
+          var optionScope = scope.$new();
+          optionScope.$index = idx;
+          optionScope[attrName] = values[idx];
+
+          var miqOptions = parsedOptions(optionScope);
+          Object.keys(miqOptions).forEach(function(key) {
+            var value = miqOptions[key];
+            if (_.isFunction(value)) {
+              value = value(optionScope, optionElement);
             }
 
-            angular.element(e).attr(k, v);
+            angular.element(optionElement).attr(key, value);
           });
         });
-      });
+      };
+
+      scope.$watch(attrToWatch, updateOptions);
+      scope.$watchCollection(attrToWatch, updateOptions);
     },
   };
 };
-
-miqOptions.$inject = ['$parse'];
 
 export default miqOptions;


### PR DESCRIPTION
The dialog player component can't currently deal with integer keys, because `<option ng-repeat` will always create strings.
=> switched to `ng-options`

Also, the code path for the refresh button and fields to refresh does not go through the `setupField` logic that converts dropdown default values from json.
=> unifying (TODO) 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1693294

@miq-bot add_label wip