### PR TITLE
Fix for dynamic dialog fields not being updated 

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -13,7 +13,7 @@
 
   <div ng-switch on="vm.dialogField.type">
     <div class="col-sm-4" ng-switch-when="DialogFieldTextBox">
-      <input ng-model="vm.dialogField.default_value"
+      <input ng-model="vm.dialogField.values"
              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
              ng-change="vm.changesHappened()"
              ng-blur="vm.validateField()"
@@ -21,7 +21,7 @@
              class="form-control"
              type="{{ vm.dialogField.options.protected ? 'password' : 'text' }}"
              uib-tooltip="{{ ::inputTitle }}"
-             value="{{ vm.dialogField.default_value }}"
+             value="{{ vm.dialogField.values }}"
              id="{{ vm.dialogField.name }}">
       <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
     </div>

--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -26,7 +26,7 @@
       <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
     </div>
     <div class="col-sm-8" ng-switch-when="DialogFieldTextAreaBox">
-      <textarea ng-model="vm.dialogField.default_value"
+      <textarea ng-model="vm.dialogField.values"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 ng-change="vm.changesHappened()"
                 ng-model-options="{debounce: {'default': 500}}"
@@ -38,7 +38,7 @@
       </textarea>
     </div>
     <div class="col-sm-1" ng-switch-when="DialogFieldCheckBox">
-      <input  ng-model="vm.dialogField.default_value"
+      <input  ng-model="vm.dialogField.values"
               ng-true-value="'t'"
               ng-false-value="'f'"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
@@ -138,7 +138,7 @@
         <input uib-datepicker-popup
                type="text"
                class="form-control"
-               ng-model="vm.dialogField.default_value"
+               ng-model="vm.dialogField.values"
                ng-change="vm.changesHappened()"
                is-open="open"
                min-date="vm.minDate"

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -68,10 +68,12 @@ export class DialogFieldController extends DialogFieldClass {
   public changesHappened(value) {
     const selectedValue = 0;
     this.validation = this.validateField();
-    let fieldValue = (value ? value[selectedValue] : this.dialogField.default_value);
+    let fieldValue = (value ? value[selectedValue] : this.dialogField.values);
     if ((this.dialogField.type === 'DialogFieldTagControl' ||
-         this.dialogField.type === 'DialogFieldDropDownList') &&
+         this.dialogField.type === 'DialogFieldDropDownList' ||
+         this.dialogField.type === 'DialogFieldRadioButton') &&
         this.dialogField.default_value instanceof Array) {
+        // using `default_value` if field.type is a subclass of DialogFieldSortedItem
         fieldValue = this.dialogField.default_value.join();
       }
     this.onUpdate({ dialogFieldName: this.field.name, value: fieldValue });


### PR DESCRIPTION
Using dialogField.value for fields that are not a subclass of `DialogFieldSortedItem`.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1696474