### PR TITLE
Revert ng-model changes from #381

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -13,7 +13,7 @@
 
   <div ng-switch on="vm.dialogField.type">
     <div class="col-sm-4" ng-switch-when="DialogFieldTextBox">
-      <input ng-model="vm.dialogField.values"
+      <input ng-model="vm.dialogField.default_value"
              ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
              ng-change="vm.changesHappened()"
              ng-blur="vm.validateField()"
@@ -26,7 +26,7 @@
       <div ng-if="vm.dialogField.fieldValidation===false">{{ vm.dialogField.errorMessage }}</div>
     </div>
     <div class="col-sm-8" ng-switch-when="DialogFieldTextAreaBox">
-      <textarea ng-model="vm.dialogField.values"
+      <textarea ng-model="vm.dialogField.default_value"
                 ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
                 ng-change="vm.changesHappened()"
                 ng-model-options="{debounce: {'default': 500}}"
@@ -38,7 +38,7 @@
       </textarea>
     </div>
     <div class="col-sm-1" ng-switch-when="DialogFieldCheckBox">
-      <input  ng-model="vm.dialogField.values"
+      <input  ng-model="vm.dialogField.default_value"
               ng-true-value="'t'"
               ng-false-value="'f'"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
@@ -138,7 +138,7 @@
         <input uib-datepicker-popup
                type="text"
                class="form-control"
-               ng-model="vm.dialogField.values"
+               ng-model="vm.dialogField.default_value"
                ng-change="vm.changesHappened()"
                is-open="open"
                min-date="vm.minDate"

--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -68,7 +68,7 @@ export class DialogFieldController extends DialogFieldClass {
   public changesHappened(value) {
     const selectedValue = 0;
     this.validation = this.validateField();
-    let fieldValue = (value ? value[selectedValue] : this.dialogField.values);
+    let fieldValue = (value ? value[selectedValue] : this.dialogField.default_value);
     if ((this.dialogField.type === 'DialogFieldTagControl' ||
          this.dialogField.type === 'DialogFieldDropDownList' ||
          this.dialogField.type === 'DialogFieldRadioButton') &&


### PR DESCRIPTION
After some deliberation, we decided it doesn't really make sense to change the `ng-model` designation since "values" doesn't make sense for a non sorted field that doesn't actually have a list of multiple values. Instead, the `ng-model` changes will be reverted and we will ensure the back end passes through the `"default_value"` properly for dynamic non sorted fields. That PR can be [found here](https://github.com/ManageIQ/manageiq/pull/18650)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1698586

/cc @himdel 