### PR TITLE
Replace 'values' key with 'default_value' when updating value for field

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -224,7 +224,6 @@ describe('Dialog test', () =>  {
         read_only: 'new read_only',
         required: true,
         visible: false,
-        values: 'new values',
         default_value: 'new default_value'
       };
 
@@ -246,7 +245,7 @@ describe('Dialog test', () =>  {
       });
 
       it('updates the field value', () => {
-        expect(dialogCtrl.dialogValues['service_name']).toBe('new values');
+        expect(dialogCtrl.dialogValues['service_name']).toBe('new default_value');
       });
 
       it('updates properties of the field', () => {
@@ -255,7 +254,6 @@ describe('Dialog test', () =>  {
         expect(dialogCtrl.dialogFields['service_name'].read_only).toBe('new read_only');
         expect(dialogCtrl.dialogFields['service_name'].required).toBe(true);
         expect(dialogCtrl.dialogFields['service_name'].visible).toBe(false);
-        expect(dialogCtrl.dialogFields['service_name'].values).toBe('new values');
         expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
       });
     });

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -220,11 +220,8 @@ export class DialogUserController extends DialogClass implements IDialogs {
 
   private refreshFieldCallback(field, data) {
     this.dialogFields[field] = this.updateDialogFieldData(field, data);
-    if (this.isASortedItemDialogField(data.type)) {
-      this.dialogValues[field] = data.default_value;
-    } else {
-      this.dialogValues[field] = data.values;
-    }
+
+    this.dialogValues[field] = data.default_value;
     this.dialogFields[field].fieldBeingRefreshed = false;
 
     this.saveDialogData();
@@ -236,18 +233,6 @@ export class DialogUserController extends DialogClass implements IDialogs {
       this.areFieldsBeingRefreshed = false;
       this.saveDialogData();
     }
-  }
-
-  /**
-   * Determines if the given field type is a subclass of DialogFieldSortedItem
-   * @memberof DialogUserController
-   * @function isASortedItemDialogField
-   * @param fieldType {string} This is the field type that should be used for comparison
-   */
-  private isASortedItemDialogField(fieldType) {
-    return fieldType === 'DialogFieldDropDownList' ||
-           fieldType === 'DialogFieldRadioButton' ||
-           fieldType === 'DialogFieldTagControl';
   }
 
   /**


### PR DESCRIPTION
This should fix https://bugzilla.redhat.com/show_bug.cgi?id=1706693.

Basically, we made [this change](https://github.com/ManageIQ/manageiq/pull/18650) but neglected to change the ui-components side on refresh callback, so it was still using the old `values` but that key no longer was being returned.

@himdel Please Review

@miq-bot add_label bug
@miq-bot assign @himdel 