### PR TITLE
Dialog editor endpoint selection - fix badly named fqdn to fqname

### DIFF
--- a/src/dialog-editor/components/modal-field/modalFieldComponent.ts
+++ b/src/dialog-editor/components/modal-field/modalFieldComponent.ts
@@ -31,9 +31,9 @@ class ModalFieldController extends ModalController {
         this.treeOptions.show = ! this.treeOptions.show;
 
         if (this.treeOptions.show) {
-          const fqdn = this.showFullyQualifiedName(this.modalData.resource_action) || null;
+          const fqname = this.showFullyQualifiedName(this.modalData.resource_action) || null;
 
-          this.treeOptions.load(fqdn).then((data) => {
+          this.treeOptions.load(fqname).then((data) => {
             this.treeOptions.data = data;
           });
         }


### PR DESCRIPTION
it's not a fully qualified *domain* name, just a name, the db field is `fqname`.

This just renames a local variable to prevent confusion. No effect whatsoever.

@miq-bot add_label technical debt, hammer/no

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1553846