### PR TITLE
Use sessionStorage to avoid loss of unsaved dialog

### DIFF
--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -187,6 +187,9 @@ class ModalController {
       default:
         break;
     }
+    this.DialogEditor.backupSessionStorage(
+      this.DialogEditor.getDialogId(),
+      this.DialogEditor.data);
   }
 
   /**
@@ -203,6 +206,9 @@ class ModalController {
       ].dialog_fields,
       (field: any) => field.position === this.elementInfo.fieldId
     );
+    this.DialogEditor.backupSessionStorage(
+      this.DialogEditor.getDialogId(),
+      this.DialogEditor.data);
   }
 
   /**

--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -95,6 +95,9 @@ class TabListController {
     }
     // remove tab with matching id
     _.remove(this.tabList, (tab: any) => tab.position === id);
+    this.DialogEditor.backupSessionStorage(
+      this.DialogEditor.getDialogId(),
+      this.DialogEditor.data);
     // update indexes of other tabs after removing
     if (this.tabList.length !== 0) {
       this.DialogEditor.updatePositions(this.tabList);

--- a/src/dialog-editor/services/dialogEditorService.spec.ts
+++ b/src/dialog-editor/services/dialogEditorService.spec.ts
@@ -116,7 +116,32 @@ describe('DialogEditor test', () => {
     });
 
     it('returns the id of the dialog', () => {
-      expect(dialogEditor.getDialogId()).toEqual(123);
+      expect(dialogEditor.getDialogId()).toEqual('123');
+    });
+
+  });
+
+  describe('#getDialogId', () => {
+    let dialogData = {
+      'content': [{
+        'dialog_tabs': [{
+          'label': 'New tab',
+          'position': 0,
+          'dialog_groups': [{
+            'label': 'New section',
+            'position': 0,
+            'dialog_fields': [],
+          }],
+        }],
+      }],
+    };
+
+    beforeEach(() => {
+      dialogEditor.setData(dialogData);
+    });
+
+    it('returns the "new" as an id of the dialog', () => {
+      expect(dialogEditor.getDialogId()).toEqual('new');
     });
   });
 

--- a/src/dialog-editor/services/dialogEditorService.ts
+++ b/src/dialog-editor/services/dialogEditorService.ts
@@ -27,7 +27,7 @@ export default class DialogEditorService {
    * @function getDialogId
    */
   public getDialogId() {
-    return this.data.content[0].id;
+    return String(this.data.content[0].id || 'new');
   }
 
   /**
@@ -79,6 +79,7 @@ export default class DialogEditorService {
    */
   public updatePositions(elements: any[]) {
     elements.forEach((value, key) => value.position = key);
+    this.backupSessionStorage(this.getDialogId(), this.data);
   }
 
   /**
@@ -97,6 +98,18 @@ export default class DialogEditorService {
       newOrdinalNumber++;
     }
     return fieldType + '_' + newOrdinalNumber;
+  }
+
+  public clearSessionStorage(id: string) {
+    sessionStorage.removeItem(this.sessionStorageKey(id));
+  }
+
+  public backupSessionStorage(id: string, dialog: any) {
+    sessionStorage.setItem(this.sessionStorageKey(id), JSON.stringify(dialog));
+  }
+
+  public restoreSessionStorage(id: string) {
+    return JSON.parse(sessionStorage.getItem(this.sessionStorageKey(id)));
   }
 
   /**
@@ -166,5 +179,9 @@ export default class DialogEditorService {
         });
       }
     });
+  }
+
+  private sessionStorageKey(id: string) {
+    return 'service_dialog-' + id;
   }
 }


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1707961

The dialog's content is saved into `sessionStorage` while the editor is getting initialized.
Every change should update the content of the saved dialog.
In the `sessionStorage` the dialog is stored under key `service_dialog-new` or `service_dialog-{id}`.
The dialog is removed from the `sessionStorage` if the dialog is submitted, of user confirms he want's to abandon the changes.
In case the user gets unintentionally redirected, an option to restore the changes will be offered.

This PR contains mostly the calls to update the dialog after the change is done.

Links
----------------

* https://github.com/ManageIQ/manageiq-ui-classic/pull/5612
* https://bugzilla.redhat.com/show_bug.cgi?id=1707961

Steps for Testing/QA
-------------------------------

1. Automate - Automation - Customization
2. Edit or create a new dialog
3. Go to any other page in the menu
4. Get back to the dialog editation