### PR TITLE
Dialog editor - fix Validate switch undecided value

### DIFF
--- a/src/dialog-editor/components/index.ts
+++ b/src/dialog-editor/components/index.ts
@@ -1,25 +1,27 @@
-import tabList from './tab-list';
 import box from './box';
+import dialogEditor from './dialog-editor';
 import field from './field';
-import toolbox from './toolbox';
 import modal from './modal';
-import modalTab from './modal-tab';
 import modalBox from './modal-box';
 import modalField from './modal-field';
 import modalFieldTemplate from './modal-field-template';
-import dialogEditor from './dialog-editor';
+import modalTab from './modal-tab';
+import tabList from './tab-list';
+import toolbox from './toolbox';
 import treeSelector from './tree-selector';
+import validation from './validation';
 
 export default (module: ng.IModule) => {
-  tabList(module);
   box(module);
+  dialogEditor(module);
   field(module);
-  toolbox(module);
   modal(module);
-  modalTab(module);
   modalBox(module);
   modalField(module);
   modalFieldTemplate(module);
-  dialogEditor(module);
+  modalTab(module);
+  tabList(module);
+  toolbox(module);
   treeSelector(module);
+  validation(module);
 };

--- a/src/dialog-editor/components/modal-field-template/text-area-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-area-box.html
@@ -27,25 +27,7 @@
              switch-on-text="{{'Yes'|translate}}"
              switch-off-text="{{'No'|translate}}">
     </div>
-    <div pf-form-group pf-label="{{'Validation'|translate}}">
-      <input bs-switch
-             ng-model="vm.modalData.validator_type"
-             type="checkbox"
-             ng-true-value="'regex'"
-             ng-false-value="undefined"
-             switch-on-text="{{'Yes'|translate}}"
-             switch-off-text="{{'No'|translate}}">
-    </div>
-    <div ng-if="vm.modalData.validator_type === 'regex'"
-         pf-form-group pf-label="{{'Validator'|translate}}">
-      <i class="fa fa-info-circle primary help-icon"
-           tooltip-append-to-body="true"
-           uib-tooltip="{{ 'Regular Expression' }}"
-           tooltip-placement="auto">
-      </i>
-      <input id="validator_rule" name="validator_rule"
-             ng-model="vm.modalData.validator_rule"/>
-    </div>
+    <dialog-editor-validation modal-data="vm.modalData"></dialog-editor-validation>
     <dialog-editor-modal-field-template template="fields-to-refresh.html"
                                         modal-data="vm.modalData">
     </dialog-editor-modal-field-template>
@@ -72,25 +54,7 @@
                switch-on-text="{{'Yes'|translate}}"
                switch-off-text="{{'No'|translate}}">
       </div>
-      <div pf-form-group pf-label="{{'Validation'|translate}}">
-        <input bs-switch
-               ng-model="vm.modalData.validator_type"
-               type="checkbox"
-               ng-true-value="'regex'"
-               ng-false-value="undefined"
-               switch-on-text="{{'Yes'|translate}}"
-               switch-off-text="{{'No'|translate}}">
-      </div>
-      <div ng-if="vm.modalData.validator_type === 'regex'"
-           pf-form-group pf-label="{{'Validator'|translate}}">
-        <i class="fa fa-info-circle primary help-icon"
-             tooltip-append-to-body="true"
-             uib-tooltip="{{ 'Regular Expression' }}"
-             tooltip-placement="auto">
-        </i>
-        <input id="validator_rule" name="validator_rule"
-               ng-model="vm.modalData.validator_rule"/>
-      </div>
+      <dialog-editor-validation modal-data="vm.modalData"></dialog-editor-validation>
       <dialog-editor-modal-field-template template="fields-to-refresh.html"
                                           modal-data="vm.modalData">
       </dialog-editor-modal-field-template>

--- a/src/dialog-editor/components/modal-field-template/text-box.html
+++ b/src/dialog-editor/components/modal-field-template/text-box.html
@@ -39,25 +39,7 @@
         <option selected="selected" value="string" translate>String</option>
       </select>
     </div>
-    <div pf-form-group pf-label="{{'Validation'|translate}}">
-      <input bs-switch
-             ng-model="vm.modalData.validator_type"
-             type="checkbox"
-             ng-true-value="'regex'"
-             ng-false-value="undefined"
-             switch-on-text="{{'Yes'|translate}}"
-             switch-off-text="{{'No'|translate}}">
-    </div>
-    <div ng-if="vm.modalData.validator_type === 'regex'"
-         pf-form-group pf-label="{{'Validator'|translate}}">
-      <i class="fa fa-info-circle primary help-icon"
-           tooltip-append-to-body="true"
-           uib-tooltip="{{ 'Regular Expression' }}"
-           tooltip-placement="auto">
-      </i>
-      <input id="validator_rule" name="validator_rule"
-             ng-model="vm.modalData.validator_rule"/>
-    </div>
+    <dialog-editor-validation modal-data="vm.modalData"></dialog-editor-validation>
     <dialog-editor-modal-field-template template="fields-to-refresh.html"
                                         modal-data="vm.modalData">
     </dialog-editor-modal-field-template>
@@ -97,25 +79,7 @@
           <option selected="selected" value="string" translate>String</option>
         </select>
       </div>
-      <div pf-form-group pf-label="{{'Validation'|translate}}">
-        <input bs-switch
-               ng-model="vm.modalData.validator_type"
-               type="checkbox"
-               ng-true-value="'regex'"
-               ng-false-value="undefined"
-               switch-on-text="{{'Yes'|translate}}"
-               switch-off-text="{{'No'|translate}}">
-      </div>
-      <div ng-if="vm.modalData.validator_type === 'regex'"
-           pf-form-group pf-label="{{'Validator'|translate}}">
-        <i class="fa fa-info-circle primary help-icon"
-             tooltip-append-to-body="true"
-             uib-tooltip="{{ 'Regular Expression' }}"
-             tooltip-placement="auto">
-        </i>
-        <input id="validator_rule" name="validator_rule"
-               ng-model="vm.modalData.validator_rule"/>
-      </div>
+      <dialog-editor-validation modal-data="vm.modalData"></dialog-editor-validation>
       <dialog-editor-modal-field-template template="fields-to-refresh.html"
                                           modal-data="vm.modalData">
       </dialog-editor-modal-field-template>

--- a/src/dialog-editor/components/validation/index.ts
+++ b/src/dialog-editor/components/validation/index.ts
@@ -1,0 +1,5 @@
+import Validation from './validation';
+
+export default (module: ng.IModule) => {
+  module.component('dialogEditorValidation', Validation);
+};

--- a/src/dialog-editor/components/validation/validation.html
+++ b/src/dialog-editor/components/validation/validation.html
@@ -3,7 +3,7 @@
          ng-model="$ctrl.modalData.validator_type"
          type="checkbox"
          ng-true-value="'regex'"
-         ng-false-value="undefined"
+         ng-false-value="false"
          switch-on-text="{{'Yes'|translate}}"
          switch-off-text="{{'No'|translate}}">
 </div>

--- a/src/dialog-editor/components/validation/validation.html
+++ b/src/dialog-editor/components/validation/validation.html
@@ -1,0 +1,19 @@
+<div pf-form-group pf-label="{{'Validation'|translate}}">
+  <input bs-switch
+         ng-model="$ctrl.modalData.validator_type"
+         type="checkbox"
+         ng-true-value="'regex'"
+         ng-false-value="undefined"
+         switch-on-text="{{'Yes'|translate}}"
+         switch-off-text="{{'No'|translate}}">
+</div>
+<div ng-if="$ctrl.modalData.validator_type === 'regex'"
+     pf-form-group pf-label="{{'Validator'|translate}}">
+  <i class="fa fa-info-circle primary help-icon"
+     tooltip-append-to-body="true"
+     uib-tooltip="{{ 'Regular Expression' }}"
+     tooltip-placement="auto">
+  </i>
+  <input id="validator_rule" name="validator_rule"
+         ng-model="$ctrl.modalData.validator_rule" />
+</div>

--- a/src/dialog-editor/components/validation/validation.ts
+++ b/src/dialog-editor/components/validation/validation.ts
@@ -3,4 +3,12 @@ export default {
   bindings: {
     modalData: '<',
   },
+  controller: function() {
+    this.$onChanges = () => {
+      if (this.modalData && ! this.modalData.validator_type) {
+        // prevent null or undefined being interpreted wrong by the switch
+        this.modalData.validator_type = false;
+      }
+    };
+  },
 };

--- a/src/dialog-editor/components/validation/validation.ts
+++ b/src/dialog-editor/components/validation/validation.ts
@@ -1,0 +1,6 @@
+export default {
+  template: require('./validation.html'),
+  bindings: {
+    modalData: '<',
+  },
+};

--- a/src/dialog-editor/index.ts
+++ b/src/dialog-editor/index.ts
@@ -7,8 +7,9 @@ module dialogEditor {
     'ui.sortable',
     'ngDragDrop',
     'frapontillo.bootstrap-switch',
-    'miqStaticAssets.miqSelect'
+    'miqStaticAssets.miqSelect',
   ]);
+
   services(app);
   components(app);
 }


### PR DESCRIPTION
1. Create a Dialog with text box validation button
2. Give a validation Regex expression
3. Move the button 'No'

Actual results:
it will be again halfway between Yes and No when the user opens the dialog editor next time.

Expected results:
It should be either Yes/No as per previously saved data

--- 

This is caused by the switch using `ng-true-value="'regex'" ng-false-value="undefined"`, together with angular-bootstrap-switch assuming that `null` and `undefined` always mean "not sure" (https://github.com/frapontillo/angular-bootstrap-switch/issues/138)

Changing to use "false" for no validator type. (And to automatically convert null/undefined to false when editing.)

---

Also moved the 4 copies of the switch + regex input to a separate component, and sorted the requires,

https://bugzilla.redhat.com/show_bug.cgi?id=1705013