### PR TITLE
Remove ui-select that is no longer used

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "tslint-loader": "3.2.0",
     "typescript": "~2.8.3",
     "ui-router": "^1.0.0-alpha0",
-    "ui-select": "0.19.8",
     "url-loader": "^0.5.7",
     "webpack": "2.2.0"
   },

--- a/src/dialog-user/index.ts
+++ b/src/dialog-user/index.ts
@@ -3,7 +3,7 @@ import components from './components';
 import * as angular from 'angular';
 
 module dialogUser {
-  export const app = angular.module('miqStaticAssets.dialogUser',['ui.select']);
+  export const app = angular.module('miqStaticAssets.dialogUser',[]);
   services(app);
   components(app);
 }

--- a/src/styles/vendor.scss
+++ b/src/styles/vendor.scss
@@ -5,4 +5,3 @@ $ff-font-path: '~@manageiq/font-fabulous/assets/fonts/font-fabulous';
 @import '~google-code-prettify/bin/prettify.min.css';
 @import '~eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker';
 @import '~angular-patternfly/dist/styles/angular-patternfly.css';
-@import '~ui-select/dist/select.css';

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -13,5 +13,4 @@ import 'angular-ui-sortable';
 import 'angular-dragdrop';
 import 'angular-bootstrap-switch';
 import 'bootstrap-select';
-import 'ui-select';
 import 'patternfly-bootstrap-treeview';


### PR DESCRIPTION
Removing `ui-select` as mentioned in https://github.com/ManageIQ/manageiq-ui-classic/pull/5607#issuecomment-497364608
> LGTM, except it seems this is dead.
>
>ui-select was added in ui-classic in 8fd8d7b, "to match ui-components". (ui-classic has never used ui-select directly it seems)
>
>ui-componens did use ui-select in dialog-user, until ManageIQ/ui-components@5fcb88d (ManageIQ/ui-components#249), where it was replaced by pf-select (and later miq-select).
>
>Can you change this to remove ui-select please? :) (also from ui-components)

@miq-bot add_label dependencies, hammer/no, changelog/no