### PR TITLE
Move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "angular-patternfly": "^3.15.0",
     "angular-sanitize": "~1.5.9",
     "awesome-typescript-loader": "~4.0.1",
+    "babel-eslint": "^7.2.3",
     "bootstrap-combobox": "^1.0.2",
     "bootstrap-datepicker": "^1.6.4",
     "bootstrap-select": "~1.12.1",
@@ -54,6 +55,7 @@
     "css-loader": "^0.26.0",
     "d3": "^4.4.1",
     "eonasdan-bootstrap-datetimepicker": "^4.17.43",
+    "eslint": "~3.9.1",
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^2.0.0-beta.5",
     "file-loader": "^0.9.0",
@@ -91,10 +93,8 @@
     "angular-bootstrap-switch": "^0.5.1",
     "angular-dragdrop": "^1.0.13",
     "angular-ui-sortable": "^0.16.1",
-    "babel-eslint": "^7.2.3",
     "es6-shim": "^0.35.3",
     "es7-shim": "^6.0.0",
-    "eslint": "~3.9.1",
     "sprintf-js": "^1.1.1"
   }
 }


### PR DESCRIPTION
eslint is not a dependency, and brings in an old js-yaml, which has a security warning.
