### PR TITLE
Removed methods working with obsolete attribute

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -331,7 +331,6 @@ describe('DialogDataService test', () => {
     describe('when the data type is a check box', () => {
       let testField = {
         default_value: 'f',
-        values: 't',
         name: 'test',
         type: 'DialogFieldCheckBox'
       };
@@ -341,9 +340,9 @@ describe('DialogDataService test', () => {
           testField['dynamic'] = true;
         });
 
-        it('ensures the checkbox uses the values that are set', () => {
+        it('ensures the field\'s default value stays set', () => {
           let testDefault = dialogData.setDefaultValue(testField);
-          expect(testDefault).toBe('t');
+          expect(testDefault).toBe('f');
         });
       });
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -117,15 +117,7 @@ export default class DialogDataService {
       }
     }
 
-    if (this.checkboxNeedsNewDefaultValue(data)) {
-      defaultValue = data.values;
-    }
-
     return defaultValue;
-  }
-
-  private checkboxNeedsNewDefaultValue(data): boolean {
-    return (data.type === 'DialogFieldCheckBox' && data.dynamic && data.values !== data.default_value);
   }
 
   /**


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1713646

As the ng-model does not use attribute 'values' but 'default_value',
the correct value was not getting updated and checkbox had always
received 'undefined'.

After removing the test working with the obsolete attribute,
checkbox gets updated correctly again.