### PR TITLE
DialogUser dropdowns - support integer keys

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -61,13 +61,10 @@
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
               class="form-control"
               data-container="body"
-              id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
-      </select>
+              id="{{ vm.dialogField.name }}"
+              ng-options="value[0] as value[1] for value in vm.dialogField.values"
+              miq-options="{ 'data-tokens': value[0] + ' ' + value[1] }"
+      ></select>
 
       <select miq-select multiple
               data-live-search="true"
@@ -78,13 +75,10 @@
               ng-change="vm.changesHappened(item)"
               ng-blur="vm.validateField()"
               ng-disabled="vm.dialogField.read_only || vm.inputDisabled"
-              input-id="{{ vm.dialogField.name }}">
-        <option ng-repeat="value in vm.dialogField.values track by $index"
-                data-tokens="{{value[0]}} {{value[1]}}"
-                value="{{value[0]}}">
-          {{value[1]}}
-        </option>
-      </select>
+              input-id="{{ vm.dialogField.name }}"
+              ng-options="value[0] as value[1] for value in vm.dialogField.values"
+              miq-options="{ 'data-tokens': value[0] + ' ' + value[1] }"
+      ></select>
     </div>
 
     <div class="col-sm-6" ng-switch-when="DialogFieldTagControl">

--- a/src/miq-select/index.ts
+++ b/src/miq-select/index.ts
@@ -1,7 +1,9 @@
 import MiqSelect from './miqSelect';
+import MiqOptions from './miqOptions';
 import * as angular from 'angular';
 
 module miqSelect {
   export const app = angular.module('miqStaticAssets.miqSelect', []);
   app.directive('miqSelect', MiqSelect);
+  app.directive('miqOptions', MiqOptions);
 }

--- a/src/miq-select/miqOptions.js
+++ b/src/miq-select/miqOptions.js
@@ -1,0 +1,79 @@
+// use together with ng-options to set extra attributes on the option elements
+// use miq-options="{ attr1: 'static', attr2: expression, attr3: vm.function }"
+// expression gets evaluated in each option's scope separately,
+// function gets run with (scope, element)
+
+/* @ngInject */
+var miqOptions = function ($parse) {
+  'use strict';
+
+  return {
+    priority: 0,
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+      var match = attrs.ngOptions.match(/for\s+(.+)\s+in\s+(.+)\s*/);
+      if (!match) {
+        console.warn('miqOptions: couldn\'t parse ngOptions', attrs.ngOptions);
+        return;
+      }
+      var attrName = match[1];
+      var attrToWatch = match[2];
+
+      var parsedOptions = $parse(attrs.miqOptions);
+
+      var updateOptions = function (newValue) {
+        if (!newValue) {
+          return;
+        }
+
+        var values = [];
+        if (_.isArray(newValue)) {
+          values = newValue;
+        } else if (_.isObject(newValue)) {
+          values = Object.values(newValue);
+        } else {
+          console.warn('miqOptions: Unknown ngOptions source', newValue);
+          return;
+        }
+
+        var optionCount = angular.element('option', element).length;
+
+        var ignoredOptions = 0;
+        if (values.length === optionCount) {
+          ignoredOptions = 0;
+        } else if (values.length === optionCount - 1) {
+          ignoredOptions = 1;
+        } else {
+          console.warn('miqOptions: mismatch between number of items and options', values.length, optionCount);
+          return;
+        }
+
+        angular.element('option', element).each(function (i, optionElement) {
+          var idx = i - ignoredOptions;
+          if (idx < 0) {
+            return; // skip empty option
+          }
+
+          var optionScope = scope.$new();
+          optionScope.$index = idx;
+          optionScope[attrName] = values[idx];
+
+          var miqOptions = parsedOptions(optionScope);
+          Object.keys(miqOptions).forEach(function(key) {
+            var value = miqOptions[key];
+            if (_.isFunction(value)) {
+              value = value(optionScope, optionElement);
+            }
+
+            angular.element(optionElement).attr(key, value);
+          });
+        });
+      };
+
+      scope.$watch(attrToWatch, updateOptions);
+      scope.$watchCollection(attrToWatch, updateOptions);
+    },
+  };
+};
+
+export default miqOptions;


### PR DESCRIPTION
(extracted from https://github.com/ManageIQ/ui-components/pull/379)

This adds a `miq-options` directive to allow using `ng-options` and setting additional attributes (`data-tokens`) on the generated `<option>` elements.

And it changes dialog-user dropdowns to use these => numeric values should be supported in dropdowns now.