### PR TITLE
Dialog user - only run regex validation when validator_type is set to regex

### DIFF
--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -275,6 +275,26 @@ describe('DialogDataService test', () => {
             expect(validation.message).toEqual('Entered text should match the format: ^1234');
           });
         });
+
+        describe('when the validator rule is present but the type is not regex', () => {
+          let testField;
+
+          beforeEach(() => {
+            testField = {
+              'type': 'DialogFieldTextBox',
+              'default_value': '123',
+              'required': true,
+              'validator_type': 'f',
+              'validator_rule': '^1234'
+            }
+          });
+
+          it('passes validation', () => {
+            let validation = dialogData.validateField(testField);
+            expect(validation.isValid).toEqual(true);
+            expect(validation.message).toEqual('');
+          });
+        });
       });
     });
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -151,8 +151,9 @@ export default class DialogDataService {
         validation.message = __('This field is required');
       }
     }
+
     // Run check if someone has specified a regex.  Make sure if its required it is not blank
-    if (field.validator_rule && validation.isValid === true) {
+    if (field.validator_rule && field.validator_type === 'regex' && validation.isValid === true) {
       if (angular.isDefined(fieldValue) && !_.isEmpty(fieldValue)) {
         // This use case ensures that an optional field doesnt check a regex if field is blank
         const regexPattern = field.validator_rule.replace(/\\A/i, '^').replace(/\\Z/i,'$');


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1721814

The dialog-user component is only looking at `validator_rule`, not `validator_type`.
Thus, it attempts to run regex validation even when validation is disabled.

This is a follow-up to https://github.com/ManageIQ/ui-components/pull/388 which changed `validator_type` from `undefined` to `false` when disabled. `false` gets saved by automate as `"f"`, which is not falsy.