### PR TITLE
Allow the selection of a node in DialogEditor + TreeSelector

### DIFF
--- a/src/dialog-editor/components/modal-field/modalFieldComponent.ts
+++ b/src/dialog-editor/components/modal-field/modalFieldComponent.ts
@@ -35,6 +35,7 @@ class ModalFieldController extends ModalController {
 
           this.treeOptions.load(fqname).then((data) => {
             this.treeOptions.data = data;
+            this.treeOptions.selected = {fqname: '/' + fqname};
           });
         }
       },

--- a/src/dialog-editor/components/tree-selector/tree-selector.html
+++ b/src/dialog-editor/components/tree-selector/tree-selector.html
@@ -12,6 +12,7 @@
     selectable="{key: '^aei-'}"
     on-select="$ctrl.treeOptions.onSelect(node)"
     lazy-load="$ctrl.treeOptions.lazyLoad(node)"
+    selected="$ctrl.treeOptions.selected"
   ></miq-tree-selector>
 </div>
 


### PR DESCRIPTION
If the domain prefix is included in the automate entry point for a dialog element, it is possible to select the right node in the tree selector. 

@miq-bot add_reviewer @himdel 
cc@pkomanek
@miq-bot add_label bug, hammer/no

https://bugzilla.redhat.com/show_bug.cgi?id=1553846