### PR TITLE
DialogUser - convert single-select default_value to the right data_type

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.spec.ts
@@ -86,6 +86,7 @@ describe('Dialog field test', () => {
           ...dialogField.options,
           force_multi_value: true,
         },
+        data_type: 'string',
       };
       dialogCtrl.$doCheck();
       expect(dialogCtrl.dialogField.default_value).toEqual(['one', 'two']);

--- a/src/dialog-user/services/dialogData.spec.ts
+++ b/src/dialog-user/services/dialogData.spec.ts
@@ -411,38 +411,38 @@ describe('DialogDataService test', () => {
   it('should allow a select list to be sorted', () => {
     const testDropDown = {
       values: [
-        [0, 'Test'],
+        [1, 'Test'],
         [5, 'Test2'],
         [2, 'Test5']
       ],
       options: { sort_by: 'value', sort_order: 'descending', data_type: 'integer' }
     };
     const testSorted = dialogData.updateFieldSortOrder(testDropDown);
-    const expectedResult = [[5, 'Test2'], [2, 'Test5'], [0, 'Test']];
+    const expectedResult = [[5, 'Test2'], [2, 'Test5'], [1, 'Test']];
     expect(testSorted).toEqual(expectedResult);
     const testDropDownDescription = {
       values: [
-        [0, 'B'],
+        [1, 'B'],
         [5, 'C'],
         [2, 'A']
       ],
       options: { sort_by: 'description', sort_order: 'descending' }
     };
     const testSortedDescription = dialogData.updateFieldSortOrder(testDropDownDescription);
-    const expectedSortedResult = [[5, 'C'], [0, 'B'], [2, 'A']];
+    const expectedSortedResult = [[5, 'C'], [1, 'B'], [2, 'A']];
     expect(testSortedDescription).toEqual(expectedSortedResult);
   });
   it('should allow a numeric Description field to be sorted in a dropdown', () => {
     const testDropDownDescription = {
       values: [
-        ['zero', '0'],
+        ['zero', '1'],
         ['five', '5'],
         ['two', '2']
       ],
       options: { sort_by: 'description', sort_order: 'descending' }
     };
     const testSortedDescription = dialogData.updateFieldSortOrder(testDropDownDescription);
-    const expectedSortedResult = [['five', '5'], ['two', '2'], ['zero', '0']];
+    const expectedSortedResult = [['five', '5'], ['two', '2'], ['zero', '1']];
     expect(testSortedDescription).toEqual(expectedSortedResult);
   });
 });

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -19,9 +19,6 @@ export default class DialogDataService {
     if (_.includes(sortableFieldTypes, field.type)) {
       const dropDownValues = [];
       for (let option of field.values) {
-        if (option[0] === String(field.default_value)) {
-          field.selected = option;
-        }
         const value = ((field.data_type === 'integer' && option[0] !== null) ? parseInt(option[0], 10) : option[0]);
         const description = (!Number.isInteger(option[1]) ? option[1] : parseInt(option[1], 10));
         dropDownValues.push([value, description]);

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -113,7 +113,7 @@ export default class DialogDataService {
     if (data.type === 'DialogFieldDropDownList' && data.default_value && _.isString(data.default_value)) {
       if (data.options.force_multi_value) {
         // multi-select - convert value from JSON, assume right type
-        defaultValue = JSON.parse(data.default_value);
+        defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
       } else if (data.data_type === 'integer') {
         // single-select - convert value to the chosen default_type, API always returns string
         defaultValue = this.convertDropdownValue(data.default_value, data.data_type);

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -93,10 +93,15 @@ export default class DialogDataService {
       defaultValue = data.default_value ? new Date(data.default_value) : new Date();
     }
 
-    // FIXME maybe better make sure it's never not string (must come from double call)
-    if (data.type === 'DialogFieldDropDownList' && data.options.force_multi_value
-      && data.default_value && _.isString(data.default_value)) {
-      defaultValue = JSON.parse(data.default_value);
+    // don't convert twice, FIXME: later refactor so that this doesn't get called twice for the same data
+    if (data.type === 'DialogFieldDropDownList' && data.default_value && _.isString(data.default_value)) {
+      if (data.options.force_multi_value) {
+        // multi-select - convert value from JSON, assume right type
+        defaultValue = JSON.parse(data.default_value);
+      } else if (data.data_type === 'integer') {
+        // single-select - convert value to the chosen default_type, API always returns string
+        defaultValue = parseInt(data.default_value, 10) || 0;
+      }
     }
 
     if (data.type === 'DialogFieldTagControl') {


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/ui-components/pull/394,
we now require `default_value`'s type to match the types of keys in `values`.

But:

* the API never returns a non-string `default_value` - we have to do the conversion to the right type.
  For multiselects, the value is JSON-encoded and preserves types,
  but for single select, even integer values get passed as strings.
* we want to explicitly support converting the keys in `values` to the right type

So now, all of these get converted (on load) to the type in `data_type`:

* `default_value` for single-selects
* each value in `default_value` for multi-selects
* each `value[0]` from `values` for all selects

The conversion rules are as follow:

* if `data_type` is `string`:
  * `null` or `undefined` (actual nil values, not strings) get treated special and stay as `null`
  * any other value gets naively stringified by a simple `toString()`
* if `data_type` is `integer`:
  * `null` or `undefined` (actual nil values, not strings) get treated special and stay as `null`
  * integers stay integers
  * other numbers (floats), or integers over 9007199254740991 may or may not match each other or other such numbers
  * string representations of integers get converted to integers, **including** representations with leading/trailing whitespace (`  1 `), or trailing non-numeric parts (`23 kg`), but **excluding** base-specific notations (`0x123`) or scientific notation (`2e3`)
  * any other value gets converted to 0

A side effect of this change is that `0` gets treated as a valid default dropdown option, so a first option with 0 value will now always get sorted first, whereas previously, this treatment would only apply to non-numeric or null.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1729046