### PR TITLE
Add a section with creating a new tab

### DIFF
--- a/src/dialog-editor/components/tab-list/tabListComponent.ts
+++ b/src/dialog-editor/components/tab-list/tabListComponent.ts
@@ -65,7 +65,11 @@ class TabListController {
         label: __('New tab ') + nextIndex,
         position: nextIndex,
         active: true,
-        dialog_groups: [],
+        dialog_groups: [{
+          'label': __('New section'),
+          'position': 0,
+          'dialog_fields': [],
+        }],
       }
     );
     this.DialogEditor.activeTab = nextIndex;


### PR DESCRIPTION
It does not make sense to create a new tab without a content, with adding a new section, user can drag&drop new Dialog Fields right after creating a new tab.