### PR TITLE
Dialog User - use m/d/y for showing dates, instead of iso

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.html
+++ b/src/dialog-user/components/dialog-user/dialogField.html
@@ -133,7 +133,7 @@
 
     <div class="col-sm-4" ng-switch-when="DialogFieldDateControl">
       <p class="input-group">
-        <input uib-datepicker-popup
+        <input uib-datepicker-popup="MM/dd/yyyy"
                type="text"
                class="form-control"
                ng-model="vm.dialogField.default_value"
@@ -157,7 +157,7 @@
     <div class="col-sm-4" ng-switch-when="DialogFieldDateTimeControl">
       <div class="dateTimePadding">
         <p class="input-group">
-          <input uib-datepicker-popup
+          <input uib-datepicker-popup="MM/dd/yyyy"
                  type="text"
                  class="form-control"
                  ng-model="vm.dialogField.dateField"


### PR DESCRIPTION
the model is using a Date object,
but we want the display date to use the US date format for consistency
(instead of the 2019-07-31 default)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1728964

![foo](https://user-images.githubusercontent.com/289743/62206566-a4e2f080-b381-11e9-8bdd-7e497a4555f5.png)
