### PR TITLE
Dialog editor - validate tag category

### DIFF
--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -1,4 +1,5 @@
 import {__} from '../../common/translateFunction';
+import {sprintf} from 'sprintf-js';
 import * as _ from 'lodash';
 
 const tagHasCategory = (field) => field.options && field.options.category_id;
@@ -59,22 +60,36 @@ export default class DialogValidationService {
   public dialogIsValid(dialogData: any) {
     this.invalid.message = null;
 
-    let validate = (f, item) => {
-      let validation = f(item);
+    const validate = (item, description) => ((fn) => {
+      let validation = fn(item);
       if (! validation.status) {
-        this.invalid = { element: item, message: validation.errorMessage };
+        Object.assign(this.invalid, {
+          item,
+          description,
+          message: validation.errorMessage,
+        });
       }
       return validation.status;
-    };
+    });
+
+    const describeDialog = (dialog) => dialog.label ? sprintf(__('Dialog %s'), dialog.label) : __('Unnamed Dialog');
+    const describeTab = (tab) => tab.label ? sprintf(__('Tab %s'), tab.label) : __('Unnamed Tab');
+    const describeGroup = (group) => group.label ? sprintf(__('Section %s'), group.label) : __('Unnamed Section');
+    const describeField = (field) => field.label ? sprintf(__('Field %s'), field.label) : __('Unnamed Field');
+
+    const validateDialog = (dialog) => _.every(this.validators.dialog, validate(dialog, describeDialog(dialog)));
+    const validateTab = (tab) => _.every(this.validators.tabs, validate(tab, describeTab(tab)));
+    const validateGroup = (group) => _.every(this.validators.groups, validate(group, describeGroup(group)));
+    const validateField = (field) => _.every(this.validators.fields, validate(field, describeField(field)));
 
     return _.every(dialogData, dialog =>
-      _.every(this.validators.dialog, f => validate(f, dialog)) &&
+      validateDialog(dialog) &&
       _.every((<any>dialog).dialog_tabs, tab =>
-        _.every(this.validators.tabs, f => validate(f, tab)) &&
+        validateTab(tab) &&
         _.every((<any>tab).dialog_groups, group =>
-          _.every(this.validators.groups, f => validate(f, group)) &&
+          validateGroup(group) &&
           _.every((<any>group).dialog_fields, field =>
-            _.every(this.validators.fields, f => validate(f, field))
+            validateField(field)
           )
         )
       )

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -1,6 +1,8 @@
 import {__} from '../../common/translateFunction';
 import * as _ from 'lodash';
 
+const tagHasCategory = (field) => field.options && field.options.category_id;
+
 export default class DialogValidationService {
   public invalid: any = {};
   private validators: any = {};
@@ -34,8 +36,7 @@ export default class DialogValidationService {
                                 field.type === 'DialogFieldRadioButton')
                                && (!field.dynamic && _.isEmpty(field.values))),
                     errorMessage: __('Dropdown needs to have entries') }),
-        field => ({ status: ! (field.type === 'DialogFieldTagControl'
-                               && field.category_id === ''),
+        field => ({ status: (field.type !== 'DialogFieldTagControl') || tagHasCategory(field),
                     errorMessage: __('Category needs to be set for TagControl field') }),
         field => ({ status: ! (field.dynamic && _.isEmpty(field.resource_action.ae_class)),
                     errorMessage: __('Entry Point needs to be set for Dynamic elements') }),

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -57,11 +57,12 @@ export default class DialogValidationService {
    * @function dialogIsValid
    */
   public dialogIsValid(dialogData: any) {
-    const self = this;
+    this.invalid.message = null;
+
     let validate = (f, item) => {
       let validation = f(item);
       if (! validation.status) {
-        self.invalid = { element: item, message: validation.errorMessage };
+        this.invalid = { element: item, message: validation.errorMessage };
       }
       return validation.status;
     };


### PR DESCRIPTION
Adding a Tag control without chosing a category should fail dialog editor validation.

Previously, this didn't work because it's set to `""` not `null` when unset, and it's `field.options.category_id`, not `field.category_id`.

Now, the validation will fail with "'Category needs to be set for TagControl field".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1729265

---

The problem with that ^ is that we never actually show the validation message anywhere.
We're trying to show it on the submit button in ui-classic, but the button is disabled (and thus not rendering title) when validation fails.

=> Moving validation to the top of the dialog, together with https://github.com/ManageIQ/manageiq-ui-classic/pull/5938 (or https://github.com/ManageIQ/manageiq-ui-classic/pull/5922 for the future)

(merge ui-components first)