### PR TITLE
Replaces 'group' with 'section' for consistency

### DIFF
--- a/src/dialog-editor/services/dialogValidationService.spec.ts
+++ b/src/dialog-editor/services/dialogValidationService.spec.ts
@@ -64,7 +64,7 @@ describe('DialogValidation test', () => {
           }]
         }];
         expect(dialogValidation.dialogIsValid(dialogData)).toEqual(false);
-        expect(dialogValidation.invalid.message).toEqual('Dialog tab needs to have at least one group');
+        expect(dialogValidation.invalid.message).toEqual('Dialog tab needs to have at least one section');
       });
     });
   });
@@ -84,7 +84,7 @@ describe('DialogValidation test', () => {
           }]
         }];
         expect(dialogValidation.dialogIsValid(dialogData)).toEqual(false);
-        expect(dialogValidation.invalid.message).toEqual('Dialog group needs to have a label');
+        expect(dialogValidation.invalid.message).toEqual('Dialog section needs to have a label');
       });
     });
     describe('when a group has no fields', () => {
@@ -101,7 +101,7 @@ describe('DialogValidation test', () => {
           }]
         }];
         expect(dialogValidation.dialogIsValid(dialogData)).toEqual(false);
-        expect(dialogValidation.invalid.message).toEqual('Dialog group needs to have at least one field');
+        expect(dialogValidation.invalid.message).toEqual('Dialog section needs to have at least one field');
       });
     });
   });

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -17,13 +17,13 @@ export default class DialogValidationService {
         tab => ({ status: ! _.isEmpty(tab.label),
                   errorMessage: __('Dialog tab needs to have a label') }),
         tab => ({ status: tab.dialog_groups.length > 0,
-                  errorMessage: __('Dialog tab needs to have at least one group') })
+                  errorMessage: __('Dialog tab needs to have at least one section') })
       ],
       groups: [
         group => ({ status: ! _.isEmpty(group.label),
-                    errorMessage: __('Dialog group needs to have a label') }),
+                    errorMessage: __('Dialog section needs to have a label') }),
         group => ({ status: group.dialog_fields.length > 0,
-                    errorMessage: __('Dialog group needs to have at least one field') })
+                    errorMessage: __('Dialog section needs to have at least one field') })
       ],
       fields: [
         field => ({ status: ! _.isEmpty(field.name),


### PR DESCRIPTION
in UI of the dialog editor we're hinting users to "add a section", but the error messages used a term "group".