### PR TITLE
tile view styling update

### DIFF
--- a/src/gtl/components/tile-view/tile-view.html
+++ b/src/gtl/components/tile-view/tile-view.html
@@ -11,7 +11,6 @@
                       on-change-per-page="tileCtrl.perPageClick(item)"></miq-pagination>
     </div>
   <div pf-card-view
-       class="miq-sand-paper"
        config="tileCtrl.options"
        items="tileCtrl.rows"
        class="miq-tile-view"

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -4,10 +4,6 @@
 @import 'dialog-editor-boxes';
 @import 'toolbar';
 
-.miq-sand-paper, .miq-sand-paper > div { /* emulates "cards-pf" background color */
-  background: #f5f5f5;
-  overflow: hidden;
-}
 
 /* Begin Patternfly Toolbar overrides */
 
@@ -116,6 +112,10 @@ table.miq-table-with-footer {
       left: 0 !important;
       top: 12px !important;
     }
+  }
+  .card:not(.active) {
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 1px 1px 0px !important;
+    border-top: 1px solid #ededed !important;
   }
 }
 


### PR DESCRIPTION
This PR removes the gray background from the tile view and adjusts the card styling to help it stand out on a white background.

Follow-up PR here: https://github.com/ManageIQ/manageiq-ui-classic/pull/5917

Issue #406

Old
<img width="950" alt="Screen Shot 2019-08-01 at 1 01 09 PM" src="https://user-images.githubusercontent.com/1287144/62312591-89004d00-b45c-11e9-9c29-7c0439121fb5.png">
new
<img width="948" alt="Screen Shot 2019-08-01 at 12 59 23 PM" src="https://user-images.githubusercontent.com/1287144/62312590-8867b680-b45c-11e9-859a-617c2070a43a.png">
