### PR TITLE
Correct dropdown choices for tag control in Dialog User

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -50,6 +50,13 @@ export class DialogFieldController {
     this.clonedDialogField = _.cloneDeep(this.field);
     this.dialogField = this.service.setupField(this.field);
 
+    if (this.dialogField.type === 'DialogFieldTagControl') {
+      // if not set already, setting the default_value on <None>
+      if (typeof this.dialogField.default_value === 'undefined') {
+        this.dialogField.default_value = 0;
+      }
+    }
+
     if ((this.dialogField.type === 'DialogFieldDateTimeControl') ||
         (this.dialogField.type === 'DialogFieldDateControl')) {
       this.setMinDate();


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1729379

setting the default_value on `<None>` in case no default_value has been set to avoid getting an empty field that breaks the dropdown functionality