### PR TITLE
Update node-sass to a version that support node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "karma-webpack": "1.8.0",
     "lodash": "^4.17.2",
     "ng-annotate-webpack-plugin": "0.1.3",
-    "node-sass": "^3.13.0",
+    "node-sass": "^4.12.0",
     "numeral": "^2.0.6",
     "patternfly": "^3.15.0",
     "patternfly-bootstrap-treeview": "^2.1.5",


### PR DESCRIPTION
Fixes #411

Now, `yarn` works even with v12.8.0 :).

Cc @romanblanco 
