### PR TITLE
dialog-user: Move tagging fix from #412 to setDefaultValue

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogField.ts
+++ b/src/dialog-user/components/dialog-user/dialogField.ts
@@ -50,13 +50,6 @@ export class DialogFieldController {
     this.clonedDialogField = _.cloneDeep(this.field);
     this.dialogField = this.service.setupField(this.field);
 
-    if (this.dialogField.type === 'DialogFieldTagControl') {
-      // if not set already, setting the default_value on <None>
-      if (typeof this.dialogField.default_value === 'undefined') {
-        this.dialogField.default_value = 0;
-      }
-    }
-
     if ((this.dialogField.type === 'DialogFieldDateTimeControl') ||
         (this.dialogField.type === 'DialogFieldDateControl')) {
       this.setMinDate();

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -128,6 +128,11 @@ export default class DialogDataService {
         defaultOption.id = 0;
         defaultValue = defaultOption.id;
       }
+
+      // if not set already, setting the default_value on <None>
+      if (defaultValue === undefined) {
+        defaultValue = 0;
+      }
     }
 
     return defaultValue;


### PR DESCRIPTION
(follow-up to #412)

The dialogField component should not be changing default_value,
the dialogData service is the place where default_value gets set.

Otherwise, validations from dialog-user and from dialog-field will work with different values, which can cause invalid validations or validation loops.

(docs - https://github.com/ManageIQ/manageiq-ui-classic/wiki/Dialogs#dialog-user-tidbits)

https://bugzilla.redhat.com/show_bug.cgi?id=1729379

Cc @romanblanco @h-kataria 