### PR TITLE
Validate content for non-required fields

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -204,6 +204,14 @@ export default class DialogDataService {
             }
           }
       }
+    } else {
+      if (field.type === 'DialogFieldDateControl' ||
+          field.type === 'DialogFieldDateTimeControl') {
+        if (!(_.isDate(value) || value === null)) {
+          // if value === undefined, a sting has been entered
+          fail(__('Select a valid date'));
+        }
+      }
     }
 
     // Run check if someone has specified a regex.  Make sure if its required it is not blank


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1670051

In case the `DateControl` or `DateTimeControl` field are not set as `required`, the added code tests if the entered value is a date or an empty field and therefore valid.