### PR TITLE
Remove conflicting toolbar styling

### DIFF
--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -4,39 +4,6 @@
 @import 'dialog-editor-boxes';
 @import 'toolbar';
 
-
-/* Begin Patternfly Toolbar overrides */
-
-
-/* overrides _toolbar.scss to account for intermediate Angular markup and adjusted the margins to properly style wrapped form-groups */
-
-.miq-toolbar-actions {
-  margin-top: -10px;
-  .form-group:first-of-type {
-    padding-left: 0;
-  }
-  .form-group {
-    margin-top: 10px;
-    padding-left: 20px;
-    padding-right: 15px; /* adjusted to account for button margin */
-    white-space: nowrap;
-    .btn { /* margin for buttons (not part of Patternfly) */
-      margin-right: 5px;
-      i {
-        margin-right: 5px;
-      }
-    }
-  }
-}
-
-.miq-custom-html {
-  .form-group.text, .form-group.has-clear {
-    padding-right: 20px;
-  }
-}
-
-/* End Patternfly Toolbar overrides */
-
 /* Begin Patternfly Tab overrides used in the Dialog Editor */
 
 .dialog-editor-tab-list {


### PR DESCRIPTION
This PR removes the original PF3 toolbar styling overrides that have been duplicated in the React repo (https://github.com/ManageIQ/react-ui-components/blob/master/src/toolbar/styles.scss#L21), preventing styling updates.

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6317