### PR TITLE
DialogUser - update validator_type during field refresh

### DIFF
--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -229,11 +229,13 @@ describe('Dialog test', () =>  {
     describe('when the dialog data field type is not a sorted item type', () => {
       const newDialogData = {
         data_type: 'new data_type',
+        default_value: 'new default_value',
         options: 'new options',
         read_only: 'new read_only',
         required: true,
+        validator_rule: 'new validator_rule',
+        validator_type: 'new validator_type',
         visible: false,
-        default_value: 'new default_value'
       };
 
       beforeEach(() => {
@@ -259,11 +261,13 @@ describe('Dialog test', () =>  {
 
       it('updates properties of the field', () => {
         expect(dialogCtrl.dialogFields['service_name'].data_type).toBe('new data_type');
+        expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
         expect(dialogCtrl.dialogFields['service_name'].options).toBe('new options');
         expect(dialogCtrl.dialogFields['service_name'].read_only).toBe('new read_only');
         expect(dialogCtrl.dialogFields['service_name'].required).toBe(true);
+        expect(dialogCtrl.dialogFields['service_name'].validator_rule).toBe('new validator_rule');
+        expect(dialogCtrl.dialogFields['service_name'].validator_type).toBe('new validator_type');
         expect(dialogCtrl.dialogFields['service_name'].visible).toBe(false);
-        expect(dialogCtrl.dialogFields['service_name'].default_value).toBe('new default_value');
       });
     });
   });

--- a/src/dialog-user/components/dialog-user/dialogUser.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.ts
@@ -255,6 +255,7 @@ export class DialogUserController extends DialogClass implements IDialogs {
     dialogField.values = data.values;
     dialogField.default_value = data.default_value;
     dialogField.validator_rule = data.validator_rule;
+    dialogField.validator_type = data.validator_type;
 
     return dialogField;
   }


### PR DESCRIPTION
when validator_type is set to 'regex' on load, the field will use the current validator_rule to validate,
but if validator_type is changed only later in a method, the field never starts to validate.

Making sure both validator_rule and validator_type are respected during field refresh.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1769960