### PR TITLE
[WIP] DialogEditor - angular-ui-bootstrap 2.x compatibility

### DIFF
--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -1,36 +1,39 @@
 <div ng-switch on="vm.fieldData.type" class="form-group">
   <label class="control-label col-sm-2">{{ vm.fieldData.label }}</label>
-  <div class="col-sm-5">
 
-    <!-- text box -->
-    <input ng-switch-when="DialogFieldTextBox"
-           ng-model="vm.fieldData.default_value"
+  <!-- text box -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldTextBox">
+    <input ng-model="vm.fieldData.default_value"
            class="form-control"
            type="{{ vm.fieldData.options.protected ? 'password' : 'text' }}"
-           placeholder="{{'Default value'|translate}}">
+           placeholder="{{'Default value'|translate}}" />
+  </div>
 
-    <!-- text area -->
-    <textarea ng-switch-when="DialogFieldTextAreaBox"
-              ng-model="vm.fieldData.default_value"
+  <!-- text area -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldTextAreaBox">
+    <textarea ng-model="vm.fieldData.default_value"
               class="form-control"
               rows="4">
       {{ vm.fieldData.default_value }}
     </textarea>
+  </div>
 
-    <!-- check box -->
-    <input ng-switch-when="DialogFieldCheckBox"
-           ng-model="vm.fieldData.default_value"
+  <!-- check box -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldCheckBox">
+    <input ng-model="vm.fieldData.default_value"
            ng-true-value="'t'"
-           type="checkbox">
+           type="checkbox" />
+  </div>
 
-    <!-- date control -->
-    <p class="input-group" ng-switch-when="DialogFieldDateControl">
+  <!-- date control -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldDateControl">
+    <p class="input-group">
       <input uib-datepicker-popup="MM/dd/yyyy"
              type="text"
              class="form-control"
              ng-model="vm.fieldData.default_value"
              is-open="open"
-             close-text="{{'Close'|translate}}"/>
+             close-text="{{'Close'|translate}}" />
       <span class="input-group-btn">
         <button type="button"
                 class="btn btn-default"
@@ -39,8 +42,11 @@
         </button>
       </span>
     </p>
-    <!-- date time control -->
-    <div ng-switch-when="DialogFieldDateTimeControl">
+  </div>
+
+  <!-- date time control -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldDateTimeControl">
+    <div>
       <div class="col-sm-6 dateTimePadding">
         <p class="input-group">
           <input uib-datepicker-popup="MM/dd/yyyy"
@@ -48,7 +54,7 @@
                  class="form-control"
                  ng-model="vm.fieldData.default_value"
                  is-open="open"
-                 close-text="{{'Close'|translate}}"/>
+                 close-text="{{'Close'|translate}}" />
           <span class="input-group-btn">
             <button type="button"
                     class="btn btn-default"
@@ -61,48 +67,49 @@
         <uib-timepicker ng-model="vm.fieldData.default_value"></uib-timepicker>
       </div>
     </div>
+  </div>
 
-    <!-- drop down list -->
-    <div ng-switch-when="DialogFieldDropDownList">
-      <div ng-if="!vm.fieldData.options.force_multi_value">
-        <select class="form-control" miq-select
-                ng-model="vm.fieldData.default_value">
-          <option value="" translate>None</option>
-          <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
-        </select>
-      </div>
-      <div ng-if="vm.fieldData.options.force_multi_value">
-        <select class="form-control" multiple miq-select
-                ng-init="vm.convertValuesToArray()"
-                ng-model="vm.fieldData.default_value">
-          <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
-        </select>
-      </div>
+  <!-- drop down list -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldDropDownList">
+    <div ng-if="!vm.fieldData.options.force_multi_value">
+      <select class="form-control" miq-select
+              ng-model="vm.fieldData.default_value">
+        <option value="" translate>None</option>
+        <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
+      </select>
     </div>
+    <div ng-if="vm.fieldData.options.force_multi_value">
+      <select class="form-control" multiple miq-select
+              ng-init="vm.convertValuesToArray()"
+              ng-model="vm.fieldData.default_value">
+        <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
+      </select>
+    </div>
+  </div>
 
-    <!-- radio button -->
-    <span ng-switch-when="DialogFieldRadioButton">
-      <label ng-repeat="option in vm.fieldData.values"
-             class="radio-inline">
-        <input type="radio"
-               name="{{vm.fieldData.name}}"
-               ng-model="vm.fieldData.default_value"
-               ng-value="option[0]">
-        {{ option[1] }}
-      </label>
-    </span>
+  <!-- radio button -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldRadioButton">
+    <label ng-repeat="option in vm.fieldData.values"
+           class="radio-inline">
+      <input type="radio"
+             name="{{vm.fieldData.name}}"
+             ng-model="vm.fieldData.default_value"
+             ng-value="option[0]" />
+      {{ option[1] }}
+    </label>
+  </div>
 
-    <!-- tag control -->
-    <select ng-switch-when="DialogFieldTagControl"
-            miq-select
+  <!-- tag control -->
+  <div class="col-sm-5" ng-switch-when="DialogFieldTagControl">
+    <select miq-select
             class="form-control">
       <option ng-repeat="option in vm.fieldData.values"
               value="{{ option[0] }}">
         {{ option[1] }}
       </option>
     </select>
-
   </div>
+
   <div class="col-sm-5 editor-field-actions">
     <button type="button" class="close hide"
             ng-click="vm.removeField(

--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -101,13 +101,20 @@
 
   <!-- tag control -->
   <div class="col-sm-5" ng-switch-when="DialogFieldTagControl">
-    <select miq-select
-            class="form-control">
-      <option ng-repeat="option in vm.fieldData.values"
-              value="{{ option[0] }}">
-        {{ option[1] }}
-      </option>
-    </select>
+    <div ng-if="!vm.fieldData.options.force_multi_value">
+      <select class="form-control" miq-select
+              ng-model="vm.fieldData.default_value">
+        <option value="" translate>None</option>
+        <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
+      </select>
+    </div>
+    <div ng-if="vm.fieldData.options.force_multi_value">
+      <select class="form-control" multiple miq-select
+              ng-init="vm.convertValuesToArray()"
+              ng-model="vm.fieldData.default_value">
+        <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
+      </select>
+    </div>
   </div>
 
   <div class="col-sm-5 editor-field-actions">

--- a/src/dialog-editor/components/field/fieldComponent.ts
+++ b/src/dialog-editor/components/field/fieldComponent.ts
@@ -44,6 +44,10 @@ class FieldController {
    * @function convertValuesToArray
    */
   public convertValuesToArray() {
+    if (! this.fieldData.default_value || ! _.isString(this.fieldData.default_value)) {
+      return;
+    }
+
     this.fieldData.default_value = angular.fromJson(this.fieldData.default_value);
   }
 

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -292,16 +292,21 @@ class ModalController {
    * @function showModal
    */
   public showModal(options: any) {
-    options.controller = ['parent', function(parent) { this.parent = parent; }];
-    options.resolve = {
-      parent: () => this
-    };
-    options.controllerAs = 'modalCtrl';
-    options.template = ModalController.buildTemplate(options.component);
     this.modalTab = 'element_information';
     this.loadModalData(this.elementInfo);
-    this.uibModalInstance = this.$uibModal.open(options);
-    return this.uibModalInstance.result.catch(() => undefined);
+    this.uibModalInstance = this.$uibModal.open({
+      controller: ['parent', function(parent) {
+        this.parent = parent;
+      }],
+      controllerAs: 'modalCtrl',
+      resolve: {
+        parent: () => this,
+      },
+      size: options.size,
+      template: ModalController.buildTemplate(options.component),
+    });
+
+    return this.uibModalInstance.result.catch((e) => console.error('showModal', e));
   }
 
   /**


### PR DESCRIPTION
Needed by https://github.com/ManageIQ/manageiq-ui-classic/pull/6449, but can go in standalone.

Since 2.x, angular-ui-bootstrap supports `.component` in addition to `.controller` + `.template` in modals, but that acts very differently (ignores controller and template, and renders the component with a fixed set of args).

The old behaviour still works, but we can't just pass an options object with `.component` to `open`.
Replacing with an object created with just the relevant options. (So, this is pretty much `delete options.component`.)

Also changing a "catch any error and ignore it" to at least `console.error` it,
and because of changes in how ng-switch-when interacts with other directives on the same element, transforming the dialog editor template from (simplified):

```haml
  .col-sm-5
    %input{ng-switch-when...., ng-model...}
    %select{ng-switch-when..., miq-select...}
```

to:

```haml
  .col-sm-5{ng-switch-when....}
    %input{ng-model...}
  .col-sm-5{ng-switch-when....}
    %select{miq-select...}
```

And finally fixing the tag control preview to also support multiselect, and the function used to transform values from JSON in the editor to deal with the values already having been transformed (happened when switching a new dropdown to multiselect).