### PR TITLE
dialog-user: fix integer dropdown 0 default_value handling

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -103,7 +103,10 @@ export default class DialogDataService {
       defaultValue = data.values[firstOption][fieldValue];
     }
 
-    if (data.default_value) {
+    // FIXME: don't convert twice, but now "0" -> 0 -> 1 happens otherwise for numeric dropdowns
+    let validZero = (data.default_value === 0) && data.data_type === 'integer';
+
+    if (data.default_value || validZero) {
       defaultValue = data.default_value;
     }
 


### PR DESCRIPTION
Have a dropdown with integer data_type,
have the values set so that one value is 0,
select that value as default value. (in dialog editor or the dialog field yaml)

Loading the dialog, `default_value: '0'` comes from the server,
`DialogData#setDefaultValue` converts it to numeric `0`, based on the data type,
but when it gets called again, the numeric `0` fails a falsy check, and the first option in the list gets used instead.

Adding a `data_type === 'integer'`, `default_value === 0` exception to the falsy check.

(A better but also much larger fix would be to refactor dialog user so that `setDefaultValue` never gets called twice on the same data.)

Before:

```
numReq old 0 string
       new 0 number
numOpt old 0 string
       new 0 number
strReq old 0 string
       new 0 string
strOpt old 0 string
       new 0 string
numReq old 0 number
       new 1 number
numOpt old 0 number
       new null object
strReq old 0 string
       new 0 string
strOpt old 0 string
       new 0 string
```

Now:

```
numReq old 0 string
       new 0 number
numOpt old 0 string
       new 0 number
strReq old 0 string
       new 0 string
strOpt old 0 string
       new 0 string
numReq old 0 number
       new 0 number
numOpt old 0 number
       new 0 number
strReq old 0 string
       new 0 string
strOpt old 0 string
       new 0 string
```

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1757888