### PR TITLE
Dialog User - set default value for tag controls

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -126,7 +126,11 @@ export default class DialogDataService {
     }
 
     if (data.type === 'DialogFieldTagControl') {
-      defaultValue = 0;
+      if (data.options.force_single_value) {
+        defaultValue = '';
+      } else {
+        defaultValue = [];
+      }
     }
 
     return defaultValue;


### PR DESCRIPTION
right now, field.default_value gets initialized to 0 for every DialogFieldTagControl.

What should be happening:

- single selects:
  `<Choose>`/`<None>` gets shown as default
- multiselects:
  `Nothing selected`

same as the other dropdowns and multidropdowns.

Thus changing the initialization to set either "" or [] as default_value.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6392
May depend on https://github.com/ManageIQ/manageiq/pull/19696 ~~and https://github.com/ManageIQ/manageiq/pull/19697~~