### PR TITLE
[WIP] Dialog Editor - reset default_value when changing dropdown type, values, or between single and multiselect

### DIFF
--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -73,7 +73,6 @@
       </div>
       <div ng-if="vm.fieldData.options.force_multi_value">
         <select class="form-control" multiple miq-select
-                ng-init="vm.convertValuesToArray()"
                 ng-model="vm.fieldData.default_value">
           <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
         </select>

--- a/src/dialog-editor/components/field/fieldComponent.ts
+++ b/src/dialog-editor/components/field/fieldComponent.ts
@@ -39,15 +39,6 @@ class FieldController {
   }
 
   /**
-   * Convert default value for multiple select fields to an array
-   * @memberof FieldController
-   * @function convertValuesToArray
-   */
-  public convertValuesToArray() {
-    this.fieldData.default_value = angular.fromJson(this.fieldData.default_value);
-  }
-
-  /**
    * Find fields at tabId and boxId.
    * @memberof FieldController
    * @function getFields

--- a/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
+++ b/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
@@ -28,19 +28,34 @@ class ModalFieldController {
     };
   }
 
-  public resetDefaultValue() {
-    // TODO replace with shared impl
+  public emptyDefaultValue(field) {
+    // FIXME replace with DialogData shared impl?
+    const byDataType = field.data_type === 'integer' ? 0 : '';
 
-    if ('force_multi_value' in this.modalData.options && this.modalData.options.force_multi_value) {
-      this.modalData.default_value = [];
-    } else if ('force_single_value' in this.modalData.options && ! this.modalData.options.force_single_value) {
-      this.modalData.default_value = [];
-    } else if (this.modalData.data_type === 'integer') {
-      this.modalData.default_value = 0;
-    } else {
-      this.modalData.default_value = '';
+    switch (field.type) {
+      case 'DialogFieldTagControl':
+        return field.options.force_single_value ? byDataType : [];
+      case 'DialogFieldDropDownList':
+        return field.options.force_multi_value ? [] : byDataType;
+      default:
+        return byDataType;
     }
+  }
 
+  public convertDefaultValue(field) {
+    switch (field.type) {
+      case 'DialogFieldTagControl':
+        return field.options.force_single_value ? byDataType : [];
+      case 'DialogFieldDropDownList':
+        return field.options.force_multi_value ? [] : byDataType;
+      default:
+        return byDataType;
+    }
+  }
+
+  public resetDefaultValue() {
+    // TODO first use the real value if possible
+    this.modalData.default_value = this.emptyDefaultValue(this.modalData);
     console.log('resetDefaultValue', this.modalData.default_value);
   }
 

--- a/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
+++ b/src/dialog-editor/components/modal-field-template/modalFieldTemplateComponent.ts
@@ -28,14 +28,42 @@ class ModalFieldController {
     };
   }
 
-  public $onChanges(changesObj) {
-    if (changesObj.modalData && changesObj.modalData.default_value === []) {
+  public resetDefaultValue() {
+    // TODO replace with shared impl
+
+    if ('force_multi_value' in this.modalData.options && this.modalData.options.force_multi_value) {
+      this.modalData.default_value = [];
+    } else if ('force_single_value' in this.modalData.options && ! this.modalData.options.force_single_value) {
+      this.modalData.default_value = [];
+    } else if (this.modalData.data_type === 'integer') {
+      this.modalData.default_value = 0;
+    } else {
       this.modalData.default_value = '';
     }
+
+    console.log('resetDefaultValue', this.modalData.default_value);
   }
 
+  // reset default_value on data_type change and single/multi change
+  public $onInit() {
+    const watch = (path, fn) => {
+      this.$scope.$watch(path, (current, old) => {
+        if (current !== old) {
+          return fn();
+        }
+      });
+    };
+
+    watch('vm.modalData.options.force_multi_value', () => this.resetDefaultValue());
+    watch('vm.modalData.options.force_single_value', () => this.resetDefaultValue());
+    watch('vm.modalData.data_type', () => this.resetDefaultValue());
+    // vm.modalData.values - handled by entriesChange
+  }
+
+  // reset default_value on entries list change
   public entriesChange() {
     setTimeout(() => this.$element.find('select').selectpicker('refresh'));
+    this.resetDefaultValue();
   }
 }
 


### PR DESCRIPTION
When editing dropdown or tag control properties, changing the value type, single/multi, or the list of tags would not update the chosen defualt_value.

That leads to problems like integer multiselects having a default value of `1` (integer), causing the backend code to blow up trying to iterate over the chosen options.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1746211

---

wip - fixes the bug, but the reset method should be shared, and should pick the first value sometimes, (and maybe even preserve the original value if it still exists)
and move the watch part of entries change to oninit too
and check out the intent behind the relevant changes from https://github.com/ManageIQ/ui-components/pull/223
and convertValuesToArray should be merged into this code too