### PR TITLE
miq-select: default liveSearchFocus to false

### DIFF
--- a/src/miq-select/miqSelect.js
+++ b/src/miq-select/miqSelect.js
@@ -20,7 +20,9 @@ var miqSelect = function () {
         element.selectpicker('destroy');
       };
 
-      element.selectpicker(scope.selectPickerOptions);
+      element.selectpicker(scope.selectPickerOptions || {
+        liveSearchFocus: false,
+      });
 
       ngModel.$render = function () {
         $render.apply(this, arguments);


### PR DESCRIPTION
Prevent the select from focusing the search input on actions like selecting an option.

This makes it possible to unselect multiple items in a row, even when scolled down.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7010