### PR TITLE
dialogData#validateField - fail validation when regex is not supported by browser

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "forin": true,
     "indent": [true, "spaces"],
     "label-position": true,
-    "max-line-length": [true, 120],
+    "max-line-length": false,
     "member-access": true,
     "no-arg": true,
     "no-bitwise": true,


### PR DESCRIPTION
Regex validation in the browser depends on the browser supporting the regex,

when using negative lookbehind, which is not supported in Firefox <78,
it just logs an error in the console:

![bad](https://user-images.githubusercontent.com/289743/84683050-1ee28080-af26-11ea-94f0-0989ce7be2d5.png)


now, it also shows a message

![good-firefox](https://user-images.githubusercontent.com/289743/84683066-273abb80-af26-11ea-8a03-fc7a063339a4.png)


(when the feautre is supported, no effect)

![good-chrome](https://user-images.githubusercontent.com/289743/84683084-302b8d00-af26-11ea-950b-bf33d4caa001.png)


Related: https://github.com/ManageIQ/manageiq-ui-classic/issues/7050