### PR TITLE
Don't set default value for non-applicable fields

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -96,13 +96,6 @@ export default class DialogDataService {
   private setDefaultValue(data): any {
     let defaultValue: any = '';
 
-    if (_.isObject(data.values)) {
-      const firstOption = 0; // these are meant to help make code more readable
-      const fieldValue = 0;
-
-      defaultValue = data.values[firstOption][fieldValue];
-    }
-
     // FIXME: don't convert twice, but now "0" -> 0 -> 1 happens otherwise for numeric dropdowns
     let validZero = (data.default_value === 0) && data.data_type === 'integer';
 


### PR DESCRIPTION
1. create a service dialog with two radio buttons: one of the doesn't have default value set, the other one does
2. create a catalog item that uses the above service dialog
3. try to order the service

Without this fix, the field with no default value would always default to the first choice.
![Screenshot from 2020-06-17 13-41-18](https://user-images.githubusercontent.com/6648365/84893986-6b51cb80-b0a0-11ea-9371-4a28411f81af.png)

With this fix in place, the no default value is being honored.
![Screenshot from 2020-06-17 13-12-46](https://user-images.githubusercontent.com/6648365/84894018-7ad11480-b0a0-11ea-9c95-0964d93256ee.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1713212