### PR TITLE
Add support for local validation of box, tab and field

### DIFF
--- a/src/dialog-editor/components/abstractModal.ts
+++ b/src/dialog-editor/components/abstractModal.ts
@@ -35,5 +35,7 @@ export class AbstractModal {
     saveModal: '<',
     uibModalInstance: '<',
     treeOptions: '<',
+    modalUnchanged: '<',
+    validation: '<',
   };
 }

--- a/src/dialog-editor/components/modal-box/box.html
+++ b/src/dialog-editor/components/modal-box/box.html
@@ -32,7 +32,8 @@
   <button type="button"
           class="btn btn-primary"
           ng-click="vm.closeModal(true)"
-          ng-disabled="vm.modalUnchanged()" translate>Save
+          ng-disabled="vm.modalUnchanged() || !vm.modalBoxIsValid()"
+          ng-attr-title="{{vm.modalBoxIsValid() ? '' : vm.validation.invalid.message}}" translate>Save
   </button>
 </div>
 

--- a/src/dialog-editor/components/modal-box/modalBoxComponent.ts
+++ b/src/dialog-editor/components/modal-box/modalBoxComponent.ts
@@ -1,4 +1,4 @@
-import { AbstractModal } from '../abstractModal';
+import { AbstractModal, ModalController } from '../abstractModal';
 
 /**
  * @memberof miqStaticAssets
@@ -12,4 +12,14 @@ import { AbstractModal } from '../abstractModal';
  */
 export default class ModalBoxTemplate extends AbstractModal {
   public template = require('./box.html');
+  public controller = ModalBoxController;
+}
+
+class ModalBoxController extends ModalController {
+  public modalData: any;
+  public validation: any;
+
+  public modalBoxIsValid() {
+    return this.validation.validateGroup(this.modalData, true);
+  }
 }

--- a/src/dialog-editor/components/modal-field/field.html
+++ b/src/dialog-editor/components/modal-field/field.html
@@ -141,6 +141,7 @@
   <button type="button"
           class="btn btn-primary"
           ng-click="vm.closeModal(true)"
-          ng-disabled="vm.modalUnchanged()" translate>Save
+          ng-disabled="vm.modalUnchanged() || !vm.modalFieldIsValid()"
+          ng-attr-title="{{vm.modalFieldIsValid() ? '' : vm.validation.invalid.message}}" translate>Save
   </button>
 </div>

--- a/src/dialog-editor/components/modal-field/modalFieldComponent.ts
+++ b/src/dialog-editor/components/modal-field/modalFieldComponent.ts
@@ -18,6 +18,7 @@ export default class ModalField extends AbstractModal {
 class ModalFieldController extends ModalController {
   public treeOptions: any;
   public modalData: any;
+  public validation: any;
 
   public $onInit() {
     this.treeOptions = {
@@ -69,5 +70,9 @@ class ModalFieldController extends ModalController {
     };
 
     this.treeOptions.show = false;
+  }
+
+  public modalFieldIsValid() {
+    return this.validation.validateField(this.modalData);
   }
 }

--- a/src/dialog-editor/components/modal-tab/modalTabComponent.ts
+++ b/src/dialog-editor/components/modal-tab/modalTabComponent.ts
@@ -1,4 +1,4 @@
-import { AbstractModal } from '../abstractModal';
+import { AbstractModal, ModalController } from '../abstractModal';
 
 /**
  * @memberof miqStaticAssets
@@ -12,4 +12,14 @@ import { AbstractModal } from '../abstractModal';
  */
 export default class ModalTabTemplate extends AbstractModal {
   public template = require('./tab.html');
+  public controller = ModalTabController;
+}
+
+class ModalTabController extends ModalController {
+  public modalData: any;
+  public validation: any;
+
+  public modalTabIsValid() {
+    return this.validation.validateTab(this.modalData, true);
+  }
 }

--- a/src/dialog-editor/components/modal-tab/tab.html
+++ b/src/dialog-editor/components/modal-tab/tab.html
@@ -32,6 +32,7 @@
   <button type="button"
           class="btn btn-primary"
           ng-click="vm.closeModal(true)"
-          ng-disabled="vm.modalUnchanged()" translate>Save
+          ng-disabled="vm.modalUnchanged() || !vm.modalTabIsValid()"
+          ng-attr-title="{{vm.modalTabIsValid() ? '' : vm.validation.invalid.message}}" translate>Save
   </button>
 </div>

--- a/src/dialog-editor/components/modal/modalComponent.ts
+++ b/src/dialog-editor/components/modal/modalComponent.ts
@@ -145,10 +145,9 @@ class ModalController {
       box: this.DialogEditor.getDialogTabs()[
         this.DialogEditor.activeTab].dialog_groups[
           this.elementInfo.boxId],
-      field: this.DialogEditor.getDialogTabs()[
+      field: _.get(this.DialogEditor.getDialogTabs()[
         this.DialogEditor.activeTab].dialog_groups[
-          this.elementInfo.boxId].dialog_fields[
-            this.elementInfo.fieldId]
+          this.elementInfo.boxId], 'dialog_fields[' + this.elementInfo.fieldId + ']')
     };
     return this.elementInfo.type in elements &&
       _.isMatch(elements[this.elementInfo.type], this.modalData);
@@ -292,7 +291,10 @@ class ModalController {
    * @function showModal
    */
   public showModal(options: any) {
-    options.controller = ['parent', function(parent) { this.parent = parent; }];
+    options.controller = ['parent', 'DialogValidation', function(parent, DialogValidation) {
+      this.parent = parent;
+      this.validation = DialogValidation;
+    }];
     options.resolve = {
       parent: () => this
     };
@@ -328,6 +330,8 @@ class ModalController {
       tree-options="modalCtrl.parent.treeOptions"
       update-dialog-field-responders="modalCtrl.parent.updateDialogFieldResponders"
       setup-category-options="modalCtrl.parent.setupCategoryOptions"
+      modal-unchanged="modalCtrl.parent.modalUnchanged"
+      validation="modalCtrl.validation"
       ></${component}>`;
   }
 }

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -12,44 +12,91 @@ export default class DialogValidationService {
     this.validators = {
       dialog: [
         dialog => ({ status: ! _.isEmpty(dialog.label),
-                     errorMessage: __('Dialog needs to have a label') }),
+                     errorMessage: __('Dialog needs to have a label'),
+                     local: true }),
         dialog => ({ status: dialog.dialog_tabs.length > 0,
-                     errorMessage: __('Dialog needs to have at least one tab') })
+                     errorMessage: __('Dialog needs to have at least one tab'),
+                     local: false })
       ],
       tabs: [
         tab => ({ status: ! _.isEmpty(tab.label),
-                  errorMessage: __('Dialog tab needs to have a label') }),
+                  errorMessage: __('Dialog tab needs to have a label'),
+                  local: true }),
         tab => ({ status: tab.dialog_groups.length > 0,
-                  errorMessage: __('Dialog tab needs to have at least one section') })
+                  errorMessage: __('Dialog tab needs to have at least one section'),
+                  local: false })
       ],
       groups: [
         group => ({ status: ! _.isEmpty(group.label),
-                    errorMessage: __('Dialog section needs to have a label') }),
+                    errorMessage: __('Dialog section needs to have a label'),
+                    local: true }),
         group => ({ status: group.dialog_fields.length > 0,
-                    errorMessage: __('Dialog section needs to have at least one field') })
+                    errorMessage: __('Dialog section needs to have at least one field'),
+                    local: false })
       ],
       fields: [
         field => ({ status: ! _.isEmpty(field.name),
-                    errorMessage: __('Dialog field needs to have a name') }),
+                    errorMessage: __('Dialog field needs to have a name'),
+                    local: true }),
         field => ({ status: ! _.isEmpty(field.label),
-                    errorMessage: __('Dialog field needs to have a label') }),
+                    errorMessage: __('Dialog field needs to have a label'),
+                    local: true }),
         field => ({ status: ! ((field.type === 'DialogFieldDropDownList' ||
                                 field.type === 'DialogFieldRadioButton')
                                && (!field.dynamic && _.isEmpty(field.values))),
-                    errorMessage: __('Dropdown needs to have entries') }),
+                    errorMessage: __('Dropdown needs to have entries'),
+                    local: true }),
         field => ({ status: (field.type !== 'DialogFieldTagControl') || tagHasCategory(field),
-                    errorMessage: __('Category needs to be set for TagControl field') }),
+                    errorMessage: __('Category needs to be set for TagControl field'),
+                    local: true }),
         field => ({ status: ! (field.dynamic && _.isEmpty(field.resource_action.ae_class)),
-                    errorMessage: __('Entry Point needs to be set for Dynamic elements') }),
+                    errorMessage: __('Entry Point needs to be set for Dynamic elements'),
+                    local: true }),
         field => ({ status: ! ((field.type === 'DialogFieldDropDownList' ||
                                 field.type === 'DialogFieldRadioButton')
                                && (field.data_type === 'integer')
                                && (!_.chain(field.values)
                                    .map(dialog_entries => _.toNumber(dialog_entries[0]))
                                    .every(value => !_.isNaN(value)).value())),
-                    errorMessage: __('Value type is set as Integer, but the value entered is not a number')}),
+                    errorMessage: __('Value type is set as Integer, but the value entered is not a number'),
+                    local: true }),
       ],
     };
+  }
+
+  private validate = (item, description, local = false) => ((fn) => {
+    let validation = fn(item);
+    if (local && !validation.local) {
+      return true;
+    }
+    if (! validation.status) {
+      Object.assign(this.invalid, {
+        item,
+        description,
+        message: validation.errorMessage,
+      });
+    }
+    return validation.status;
+  })
+
+  public validateDialog(dialog, local = false) {
+    const label = dialog.label ? sprintf(__('Dialog %s'), dialog.label) : __('Unnamed Dialog');
+    return _.every(this.validators.dialog, this.validate(dialog, label, local));
+  }
+
+  public validateTab(tab, local = false) {
+    const label = tab.label ? sprintf(__('Tab %s'), tab.label) : __('Unnamed Tab');
+    return _.every(this.validators.tabs, this.validate(tab, label, local));
+  }
+
+  public validateGroup(group, local = false) {
+    const label = group.label ? sprintf(__('Section %s'), group.label) : __('Unnamed Section');
+    return _.every(this.validators.groups, this.validate(group, label, local));
+  }
+
+  public validateField(field, local = false) {
+    const label = field.label ? sprintf(__('Field %s'), field.label) : __('Unnamed Field');
+    return _.every(this.validators.fields, this.validate(field, label, local));
   }
 
   /**
@@ -60,36 +107,14 @@ export default class DialogValidationService {
   public dialogIsValid(dialogData: any) {
     this.invalid.message = null;
 
-    const validate = (item, description) => ((fn) => {
-      let validation = fn(item);
-      if (! validation.status) {
-        Object.assign(this.invalid, {
-          item,
-          description,
-          message: validation.errorMessage,
-        });
-      }
-      return validation.status;
-    });
-
-    const describeDialog = (dialog) => dialog.label ? sprintf(__('Dialog %s'), dialog.label) : __('Unnamed Dialog');
-    const describeTab = (tab) => tab.label ? sprintf(__('Tab %s'), tab.label) : __('Unnamed Tab');
-    const describeGroup = (group) => group.label ? sprintf(__('Section %s'), group.label) : __('Unnamed Section');
-    const describeField = (field) => field.label ? sprintf(__('Field %s'), field.label) : __('Unnamed Field');
-
-    const validateDialog = (dialog) => _.every(this.validators.dialog, validate(dialog, describeDialog(dialog)));
-    const validateTab = (tab) => _.every(this.validators.tabs, validate(tab, describeTab(tab)));
-    const validateGroup = (group) => _.every(this.validators.groups, validate(group, describeGroup(group)));
-    const validateField = (field) => _.every(this.validators.fields, validate(field, describeField(field)));
-
     return _.every(dialogData, dialog =>
-      validateDialog(dialog) &&
+      this.validateDialog(dialog) &&
       _.every((<any>dialog).dialog_tabs, tab =>
-        validateTab(tab) &&
+        this.validateTab(tab) &&
         _.every((<any>tab).dialog_groups, group =>
-          validateGroup(group) &&
+          this.validateGroup(group) &&
           _.every((<any>group).dialog_fields, field =>
-            validateField(field)
+            this.validateField(field)
           )
         )
       )


### PR DESCRIPTION
This PR implements field, tab & box level validation when creating / editing field, tab & box in current dialog editor. Should a particular validation fail, the `Save` button will be disabled and button title will be set with the validation message. Previously, the validation would take place on the service dialog level, which seemed counter-intuitive.

Field validation example:
![Screenshot from 2020-06-25 16-32-06](https://user-images.githubusercontent.com/6648365/85741303-97092d00-b702-11ea-8749-e7c8c4191a82.png)


Box validation example:
![Screenshot from 2020-06-25 16-32-53](https://user-images.githubusercontent.com/6648365/85741337-9d97a480-b702-11ea-853a-67b24b344b8f.png)


Tab validation example:
![Screenshot from 2020-06-25 16-33-10](https://user-images.githubusercontent.com/6648365/85741355-a25c5880-b702-11ea-85d3-48326efe109b.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1741633