### PR TITLE
Don't print "Nothing Selected" in single value dropdown

### DIFF
--- a/src/dialog-editor/components/modal-field-template/drop-down-list.html
+++ b/src/dialog-editor/components/modal-field-template/drop-down-list.html
@@ -23,7 +23,7 @@
     </div>
     <div pf-form-group pf-label="{{'Default value'|translate}}"
          ng-if="!vm.modalData.options.force_multi_value">
-      <select class="form-control" miq-select ng-attr-title="{{'Nothing Selected'|translate}}"
+      <select class="form-control" miq-select
               ng-model="vm.modalData.default_value">
         <option value="" translate>None</option>
         <option ng-repeat="value in vm.modalData.values" value="{{value[0]}}">{{value[1]}}</option>

--- a/src/dialog-editor/components/modal-field-template/tag-control.html
+++ b/src/dialog-editor/components/modal-field-template/tag-control.html
@@ -22,11 +22,11 @@
              switch-off-text="{{'No'|translate}}">
     </div>
     <div pf-form-group pf-label="{{'Category'|translate}}">
-      <select class="form-control" miq-select ng-attr-title="{{'Nothing Selected'|translate}}"
+      <select class="form-control" miq-select
               ng-change="vm.setupCategoryOptions()"
-              ng-model="vm.modalData.options.category_id"
-              ng-options="category.id.toString() as category.description for category in vm.categories.resources">
+              ng-model="vm.modalData.options.category_id">
         <option selected="selected" value="" translate>None</option>
+        <option ng-repeat="category in vm.categories.resources" value="{{category.id.toString()}}">{{category.description}}</option>
       </select>
     </div>
     <div ng-if="!vm.modalData.options.category_single_value"


### PR DESCRIPTION
1. create a new service dialog, add a single value dropdown
2. select a default value for the dropdown: instead of selected value, the dropdown would render `Nothing Selected`
3. select the same default value again: this time the dropdown will honor and render the selected default value

I think rendering `Nothing Selected` in a single value dropdown is unnecessary and confusing. We already add a `None / "") value to single value dropdowns and it already represents `Nothing Selected`. Removing the `Nothing Selected` label will work-around the weird dropdown behavior described above.

Before:
![Screenshot from 2020-07-01 17-23-07](https://user-images.githubusercontent.com/6648365/86261989-961f4200-bbbf-11ea-98fb-d9614df6f981.png)

After:
![Screenshot from 2020-07-01 17-16-34](https://user-images.githubusercontent.com/6648365/86261982-94ee1500-bbbf-11ea-8766-76f85e0ac82b.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1713205