### PR TITLE
Honor sorting parameters in dialog editor

### DIFF
--- a/src/dialog-editor/components/field/field.html
+++ b/src/dialog-editor/components/field/field.html
@@ -65,23 +65,26 @@
     <!-- drop down list -->
     <div ng-switch-when="DialogFieldDropDownList">
       <div ng-if="!vm.fieldData.options.force_multi_value">
-        <select class="form-control" miq-select
+        <select class="form-control"
+                miq-select
+                ng-options="item[0] as item[1] for item in vm.sortedField"
                 ng-model="vm.fieldData.default_value">
           <option value="" translate>None</option>
-          <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
         </select>
       </div>
       <div ng-if="vm.fieldData.options.force_multi_value">
-        <select class="form-control" multiple miq-select
+        <select class="form-control"
+                multiple
+                miq-select
+                ng-options="item[0] as item[1] for item in vm.sortedField"
                 ng-model="vm.fieldData.default_value">
-          <option ng-repeat="value in vm.fieldData.values" value="{{value[0]}}">{{value[1]}}</option>
         </select>
       </div>
     </div>
 
     <!-- radio button -->
     <span ng-switch-when="DialogFieldRadioButton">
-      <label ng-repeat="option in vm.fieldData.values"
+      <label ng-repeat="option in vm.sortedField"
              class="radio-inline">
         <input type="radio"
                name="{{vm.fieldData.name}}"

--- a/src/dialog-editor/components/field/fieldComponent.ts
+++ b/src/dialog-editor/components/field/fieldComponent.ts
@@ -9,11 +9,12 @@ import * as angular from 'angular';
  */
 class FieldController {
   public service: any;
+  public sortedField: any;
   public fieldData: any;
   public boxPosition: any;
 
   /*@ngInject*/
-  constructor(private DialogEditor: any) {
+  constructor(private DialogEditor: any, private DialogData: any) {
   }
 
   /**
@@ -23,6 +24,18 @@ class FieldController {
    */
   public $onInit() {
     this.service = this.DialogEditor;
+    this.sortedField = this.DialogData.setupSortableValues(this.fieldData);
+  }
+
+  /**
+   * Update sortedField
+   * @memberof FieldController
+   * @function $onChanges
+   */
+  public $onChanges(changesObj: any) {
+    if (changesObj.fieldData) {
+      this.sortedField = this.DialogData.setupSortableValues(this.fieldData);
+    }
   }
 
   /**


### PR DESCRIPTION
This change is for dialog editor to honor sorting options of dropdown & radio button fields:
* sort either by key or by value
* sort values either as strings or as integers

Needs to go in with https://github.com/ManageIQ/manageiq-ui-classic/pull/7202

https://bugzilla.redhat.com/show_bug.cgi?id=1740878