### PR TITLE
Correctly set 'null' default value for TagControl & Dropdown

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -108,19 +108,23 @@ export default class DialogDataService {
     }
 
     // don't convert twice, FIXME: later refactor so that this doesn't get called twice for the same data
-    if (data.type === 'DialogFieldDropDownList' && data.default_value && _.isString(data.default_value)) {
-      if (data.options.force_multi_value) {
-        // multi-select - convert value from JSON, assume right type
-        defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
-      } else if (data.data_type === 'integer') {
-        // single-select - convert value to the chosen default_type, API always returns string
-        defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
+    if (data.type === 'DialogFieldDropDownList') {
+      if (data.default_value && _.isString(data.default_value)) {
+        if (data.options.force_multi_value) {
+          // multi-select - convert value from JSON, assume right type
+          defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
+        } else if (data.data_type === 'integer') {
+          // single-select - convert value to the chosen default_type, API always returns string
+          defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
+        }
+      } else if (!data.default_value) {
+        defaultValue = null;
       }
     }
 
     if (data.type === 'DialogFieldTagControl') {
       if (data.options.force_single_value) {
-        defaultValue = '';
+        defaultValue = null;
       } else {
         defaultValue = [];
       }


### PR DESCRIPTION
This is what `data.values` for single-value `DialogFieldDropDownList` looks like:
```
Array(4)
0: (2) [null, "<None>"]
1: (2) ["1", "One"]
2: (2) ["3", "Three"]
3: (2) ["2", "Two"]
length: 4
__proto__: Array(0)
```

This is what `data.values` for single-value `DialogFieldTagControl` looks like:
```
Array(5)
0: {id: null, name: "<None>", description: "<None>"}
1: {id: "3", name: "chicago", description: "Chicago"}
2: {id: "4", name: "london", description: "London"}
3: {id: "2", name: "ny", description: "New York"}
4: {id: "5", name: "paris", description: "Paris"}
length: 5
__proto__: Array(0)
```

Setting the `null` default value for these cases will make the `Nothing Selected` thing go away.

Before:
![Screenshot from 2020-08-03 17-14-29](https://user-images.githubusercontent.com/6648365/89197999-d0a84000-d5ac-11ea-9719-53291c5aa736.png)


After:
![Screenshot from 2020-08-03 17-06-41](https://user-images.githubusercontent.com/6648365/89197878-ad7d9080-d5ac-11ea-84f4-3a741a92b144.png)



https://bugzilla.redhat.com/show_bug.cgi?id=1861252