### PR TITLE
[JANSA] tslint: remove line lenght limit

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,7 @@
     "forin": true,
     "indent": [true, "spaces"],
     "label-position": true,
-    "max-line-length": [true, 120],
+    "max-line-length": false,
     "member-access": true,
     "no-arg": true,
     "no-bitwise": true,


### PR DESCRIPTION
On master, this was part of https://github.com/ManageIQ/ui-components/pull/441,
now backporting https://github.com/ManageIQ/ui-components/pull/447 to jansa caused travis to [go red](https://travis-ci.com/github/ManageIQ/ui-components/builds/178817018),

Removing the line lenght limit for previous releases (both, 447 is ivanchuk/yes).
Fixes travis.

(This is an alternative to backporting the whole PR, https://github.com/ManageIQ/ui-components/pull/441#issuecomment-670531704)
