### PR TITLE
Fixed table header shift after icon column was removed from list view

### DIFF
--- a/src/gtl/components/data-table/data-table.html
+++ b/src/gtl/components/data-table/data-table.html
@@ -14,10 +14,8 @@
          ng-if="tableCtrl.rows && tableCtrl.rows.length !== 0">
     <thead>
     <tr>
-      <th class="narrow">
-
-      </th>
-      <th ng-if="$index !== 0"
+      <th ng-if="tableCtrl.countCheckboxes() > 0" class="narrow"></th>
+      <th ng-if="($index !== 0 && tableCtrl.countCheckboxes() > 0) || tableCtrl.countCheckboxes() <= 0"
           ng-repeat="column in tableCtrl.columns track by $index"
           ng-click="tableCtrl.onSortClick($index, !!tableCtrl.settings.sortBy && !tableCtrl.settings.sortBy.isAscending)"
           ng-class="tableCtrl.getColumnClass(column)">


### PR DESCRIPTION
This issue was introduced in https://github.com/ManageIQ/manageiq-ui-classic/pull/7189 Issue existed on the lists with no checkboxes/icons. Table headers were shifted on such screens.

before
![Screenshot from 2020-09-03 17-24-34](https://user-images.githubusercontent.com/3450808/92175146-6fbd9300-ee0a-11ea-9fce-79c202686f16.png)
![Screenshot from 2020-09-03 17-23-36](https://user-images.githubusercontent.com/3450808/92175151-70562980-ee0a-11ea-95f0-462d12db0af9.png)

after
![Screenshot from 2020-09-03 17-14-02](https://user-images.githubusercontent.com/3450808/92175268-777d3780-ee0a-11ea-87e3-0bae68a01c62.png)

![Screenshot from 2020-09-03 19-43-29](https://user-images.githubusercontent.com/3450808/92183941-c7b1c500-ee1d-11ea-9f63-056ee21df23d.png)

