### PR TITLE
Correctly set null as default value for null and empty strings

### DIFF
--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -117,7 +117,7 @@ export default class DialogDataService {
           // single-select - convert value to the chosen default_type, API always returns string
           defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
         }
-      } else if (!data.default_value) {
+      } else if (data.default_value === null || data.default_value === '') {
         defaultValue = null;
       }
     }


### PR DESCRIPTION
1. create a service dialog with integer-type values, make sure `0` is among them
2. make sure the data type is set to integer and that `0` is set as default value
3. create a catalog item with the above service dialog
4. order the catalog item and observe the form

before
![Screenshot from 2020-09-11 14-58-16](https://user-images.githubusercontent.com/6648365/92928418-54bcd580-f43f-11ea-8d2d-396d278ae197.png)


after
![Screenshot from 2020-09-11 14-56-34](https://user-images.githubusercontent.com/6648365/92928427-57b7c600-f43f-11ea-8100-2553f17f8e6c.png)

Previously, `0` as default value would be incorrectly interpreted as no default value.

https://bugzilla.redhat.com/show_bug.cgi?id=1878103