### PR TITLE
Modified CSS to Prevent Truncation Issue in Certain Locales

### DIFF
--- a/src/styles/dialog-editor-toolbox.scss
+++ b/src/styles/dialog-editor-toolbox.scss
@@ -12,7 +12,7 @@
 
   .static-field-list {
     list-style: none;
-    width: 107px;
+    width: 115px;
     overflow-y: auto;
     margin-bottom: 0px;
     padding-left: 0;
@@ -23,7 +23,7 @@
     border-bottom: 1px solid $color-gray-1;
     border-radius: 1px;
     cursor: pointer;
-    height: 70px;
+    min-height: 70px;
     width: 100%;
     position: relative;
     text-align: center;

--- a/src/styles/dialog-editor.scss
+++ b/src/styles/dialog-editor.scss
@@ -10,7 +10,7 @@
 
     .editable-fields-container {
       padding-top: 10px;
-      padding-left: 120px;
+      padding-left: 128px;
       width: 80%;
     }
 


### PR DESCRIPTION
Found in: Automation -> Automate -> Customization -> Service Dialogs

Fixes: https://github.com/ManageIQ/ui-components/issues/453

Preview:
<img src="https://user-images.githubusercontent.com/64800041/101544041-10c06a80-3973-11eb-82cc-0998d4cf9da9.png" width="300">
![image](https://user-images.githubusercontent.com/64800041/101544055-1453f180-3973-11eb-993f-9d4cf96e5fac.png)