### PR TITLE
Upgrade node version to 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: bionic
 language: node_js
 node_js:
-- '14'
+- '16'
 cache:
   yarn: true
   directories:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For a great overview of using Angular 1.5.x Components please see: [NG-Conf 2016
 
 ## Development Environment
 
-You need to have installed [Node.js >= 14  and npm >= 6](https://docs.npmjs.com/getting-started/installing-node) on your system.
+You need to have installed [Node.js >= 16  and npm >= 8](https://docs.npmjs.com/getting-started/installing-node) on your system.
 It is recommended to use a node version manager such as [n](https://www.npmjs.com/package/n). If you have node installed then it is
 just `yarn global add n` and then `n lts` to use the latest LTS version of node (see the docs for switching versions).
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "authors": [],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0"
+    "node": ">= 16.0.0",
+    "npm": ">= 8.0.0"
   },
   "devDependencies": {
     "@manageiq/font-fabulous": "^1.0.0",


### PR DESCRIPTION
Upgrading package version 
`node` - from `14.0.0` to `16.0.0`
`npm` from `6.0.0 `to` 8.0.0`

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8146


