### PR TITLE
Fix for duplicate field names and render validation messages for server

### DIFF
--- a/src/dialog-editor/components/abstractModal.ts
+++ b/src/dialog-editor/components/abstractModal.ts
@@ -36,6 +36,7 @@ export class AbstractModal {
     uibModalInstance: '<',
     treeOptions: '<',
     modalUnchanged: '<',
+    fieldDuplicates: '<',
     validation: '<',
   };
 }

--- a/src/dialog-editor/components/modal-field/field.html
+++ b/src/dialog-editor/components/modal-field/field.html
@@ -6,6 +6,10 @@
 </div>
 
 <div class="modal-body">
+  <div class="dialog-editor-tab-notification" ng-if="vm.modalNotification().error">
+    <i class="pficon pficon-error-circle-o"></i>
+    {{vm.modalNotification().message}}
+  </div>
   <ul class="nav nav-tabs dialog-editor-tab-list">
     <li ng-class="{active:vm.modalTabIsSet('element_information')}">
       <a ng-click="vm.modalTabSet('element_information')" translate>Field Information</a>
@@ -141,7 +145,7 @@
   <button type="button"
           class="btn btn-primary"
           ng-click="vm.closeModal(true)"
-          ng-disabled="vm.modalUnchanged() || !vm.modalFieldIsValid()"
+          ng-disabled="vm.modalUnchanged() || vm.fieldDuplicates() || !vm.modalFieldIsValid()"
           ng-attr-title="{{vm.modalFieldIsValid() ? '' : vm.validation.invalid.message}}" translate>Save
   </button>
 </div>

--- a/src/dialog-editor/components/modal-field/modalFieldComponent.ts
+++ b/src/dialog-editor/components/modal-field/modalFieldComponent.ts
@@ -149,6 +149,21 @@ class ModalFieldController extends ModalController {
     this.treeOptions.show = false;
   }
 
+  /** Function to get notification messages for options modal box if any. */
+  public modalNotification() {
+    const notice = { error: false, message: undefined };
+
+    if (!this.modalFieldIsValid() && this.validation.invalid && this.validation.invalid.message) {
+      notice.message = this.validation.invalid.message;
+      notice.error = true;
+    } else if (this.modalData.validationMessage) {
+      notice.message = this.modalData.validationMessage;
+      notice.error = true;
+    }
+
+    return notice;
+  }
+
   public modalFieldIsValid() {
     return this.validation.validateField(this.modalData);
   }

--- a/src/dialog-editor/services/dialogValidationService.ts
+++ b/src/dialog-editor/services/dialogValidationService.ts
@@ -6,6 +6,7 @@ const tagHasCategory = (field) => field.options && field.options.category_id;
 
 export default class DialogValidationService {
   public invalid: any = {};
+  public dialogFields: any = [];
   private validators: any = {};
 
   constructor() {
@@ -100,11 +101,30 @@ export default class DialogValidationService {
   }
 
   /**
+   * Run validations across each dialog field elements and check for duplicate field names.
+   * @memberof DialogValidationService
+   * @function validateDialogFields
+   */
+  public validateDialogFields(field: any) {
+    if (!this.validateField(field)) {
+      return false;
+    }
+    const isDuplicate = this.dialogFields.includes(field.name);
+    if (isDuplicate) {
+      this.invalid.message = sprintf(__('Duplicate field name found: %s'), field.name);
+      return false;
+    }
+    this.dialogFields.push(field.name);
+    return true;
+  }
+
+  /**
    * Run validations across each dialog elements.
    * @memberof DialogValidationService
    * @function dialogIsValid
    */
   public dialogIsValid(dialogData: any) {
+    this.dialogFields = [];
     this.invalid.message = null;
 
     return _.every(dialogData, dialog =>
@@ -113,9 +133,7 @@ export default class DialogValidationService {
         this.validateTab(tab) &&
         _.every((<any>tab).dialog_groups, group =>
           this.validateGroup(group) &&
-          _.every((<any>group).dialog_fields, field =>
-            this.validateField(field)
-          )
+          group.dialog_fields.every((field) => this.validateDialogFields(field))
         )
       )
     );

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -5,6 +5,22 @@
 
 /* Begin Patternfly Tab overrides used in the Dialog Editor */
 
+.dialog-editor-tab-notification {
+  color: #363636;
+  font-weight: bold;
+  background: #ffe6e7;
+  border: 1px solid #cd0000;
+  padding: 10px;
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  i {
+    font-size: 16px;
+  }
+}
+
 .dialog-editor-tab-list {
   margin-bottom: 20px !important;
 }


### PR DESCRIPTION
Before -

https://github.com/ManageIQ/ui-components/assets/87487049/f9b88090-1e73-45d6-94b2-b31f8a2a7ad8


<img width="931" alt="image" src="https://github.com/ManageIQ/ui-components/assets/87487049/411134a9-61ff-46df-a1d8-ede481bd6ee6">
<img width="1528" alt="image" src="https://github.com/ManageIQ/ui-components/assets/87487049/18b51195-949f-4f61-bdec-36ad9c0f09f6">
<img width="1524" alt="image" src="https://github.com/ManageIQ/ui-components/assets/87487049/3be51a7b-b3d7-4ca3-87a0-17b5eb5f4f23">

- Edit a service dialog, 
- Click edit field to open the options modal box
- Change a field name to an already used name (duplicate name)
- Click save at the options modal box
- Click save at the service dialog form
- We will get a warning that the field name cannot be used.
- cancel the form.
- select the service dialog again and edit it
- check the field name of the field where you tried to put a duplicate name.
- See that the field name got updated and now we have a duplicate field.


After

https://github.com/ManageIQ/ui-components/assets/87487049/f3b8c739-6b52-45b3-92f2-8278d54fc7d2


<img width="922" alt="image" src="https://github.com/ManageIQ/ui-components/assets/87487049/560e4cbf-97f1-48cd-8e14-fef67d25ea11">

- The options modal box will check for duplicate field names
- If there are duplicate field names, the save button of the options modal will be disabled.
- Introduced Validation messages in the options modal box. Earlier it was displayed as a title (on mouse hover) of the save button
- For existing records, the service dialog save button will be disabled if there are duplicate field names.
- The options modal's save button will also be disabled unless you change the field name to avoid duplicate.