### PR TITLE
Fix drop down default value

### DIFF
--- a/demo/data/dialog-data.json
+++ b/demo/data/dialog-data.json
@@ -317,25 +317,25 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 1,
-                      "name": "1",
+                      "name": "string_dropdown_1",
                       "data_type": "string",
                       "display": "edit",
                       "display_method_options": {},
                       "required": true,
                       "required_method_options": {},
-                      "default_value": "2",
+                      "default_value": "two",
                       "values": [
                         [
-                          "1",
-                          "1"
+                          "one",
+                          "First"
                         ],
                         [
-                          "2",
-                          "2"
+                          "two",
+                          "Second"
                         ],
                         [
-                          "4",
-                          "4"
+                          "three",
+                          "Third"
                         ],
                         [
                           null,
@@ -365,25 +365,25 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 2,
-                      "name": "2",
+                      "name": "string_dropdown_2",
                       "data_type": "string",
                       "display": "edit",
                       "display_method_options": {},
                       "required": true,
                       "required_method_options": {},
-                      "default_value": ["1", "2"],
+                      "default_value": ["first", "2"],
                       "values": [
                         [
-                          "1",
-                          "1"
+                          "first",
+                          "First"
                         ],
                         [
                           "2",
-                          "2"
+                          "Second"
                         ],
                         [
-                          "4",
-                          "4"
+                          "3",
+                          "Third"
                         ],
                         [
                           null,
@@ -413,7 +413,7 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 3,
-                      "name": "3",
+                      "name": "integer_dropdown_3",
                       "data_type": "integer",
                       "display": "edit",
                       "display_method_options": {},
@@ -423,15 +423,15 @@
                       "values": [
                         [
                           "1",
-                          1
+                          "First"
                         ],
                         [
                           "2",
-                          2
+                          "Second"
                         ],
                         [
-                          "4",
-                          4
+                          "3",
+                          "Third"
                         ],
                         [
                           null,
@@ -461,25 +461,25 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 4,
-                      "name": "4",
+                      "name": "integer_dropdown_4",
                       "data_type": "integer",
                       "display": "edit",
                       "display_method_options": {},
                       "required": true,
                       "required_method_options": {},
-                      "default_value": ["1", "2"],
+                      "default_value": [1, 2],
                       "values": [
                         [
                           "1",
-                          1
+                          "New York"
                         ],
                         [
                           "2",
-                          2
+                          "Chicago"
                         ],
                         [
-                          "4",
-                          4
+                          "3",
+                          "Seattle"
                         ],
                         [
                           null,
@@ -505,6 +505,218 @@
                         "resource_type": "DialogField",
                         "ae_attributes": {}
                       }
+                    },
+                    {
+                      "name": "tag_control_1",
+                      "description": "",
+                      "type": "DialogFieldTagControl",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "read_only": false,
+                      "required": false,
+                      "required_method_options": {},
+                      "default_value": "2",
+                      "values_method_options": {},
+                      "label": "Tag String Single Select",
+                      "position": 0,
+                      "dynamic": false,
+                      "show_refresh_button": false,
+                      "load_values_on_init": true,
+                      "auto_refresh": false,
+                      "trigger_auto_refresh": false,
+                      "reconfigurable": false,
+                      "visible": true,
+                      "options": {
+                        "category_id": "",
+                        "force_single_value": true,
+                        "sort_by": "description",
+                        "sort_order": "ascending"
+                      },
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      },
+                      "data_type": "string",
+                      "values": [
+                        {
+                          "description": "Automotive",
+                          "href": "http://localhost:3000/api/service_dialogs/1",
+                          "id": "1",
+                          "name": "automotive"
+                        },
+                        {
+                          "description": "Engineering",
+                          "href": "http://localhost:3000/api/service_dialogs/2",
+                          "id": "2",
+                          "name": "engineering"
+                        },
+                        {
+                          "description": "Test",
+                          "href": "http://localhost:3000/api/service_dialogs/3",
+                          "id": "3",
+                          "name": "test"
+                        }
+                      ],
+                      "automation_type": "embedded_automate"
+                    },
+                    {
+                      "name": "tag_control_2",
+                      "description": "",
+                      "type": "DialogFieldTagControl",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "read_only": false,
+                      "required": false,
+                      "required_method_options": {},
+                      "default_value": ["1", "2"],
+                      "values_method_options": {},
+                      "label": "Tag String Multi Select",
+                      "position": 0,
+                      "dynamic": false,
+                      "show_refresh_button": false,
+                      "load_values_on_init": true,
+                      "auto_refresh": false,
+                      "trigger_auto_refresh": false,
+                      "reconfigurable": false,
+                      "visible": true,
+                      "options": {
+                        "category_id": "",
+                        "force_single_value": false,
+                        "sort_by": "description",
+                        "sort_order": "ascending"
+                      },
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      },
+                      "data_type": "string",
+                      "values": [
+                        {
+                          "description": "Automotive",
+                          "href": "http://localhost:3000/api/service_dialogs/1",
+                          "id": "1",
+                          "name": "automotive"
+                        },
+                        {
+                          "description": "Engineering",
+                          "href": "http://localhost:3000/api/service_dialogs/2",
+                          "id": "2",
+                          "name": "engineering"
+                        },
+                        {
+                          "description": "Test",
+                          "href": "http://localhost:3000/api/service_dialogs/3",
+                          "id": "3",
+                          "name": "test"
+                        }
+                      ],
+                      "automation_type": "embedded_automate"
+                    },
+                    {
+                      "name": "tag_control_3",
+                      "description": "",
+                      "type": "DialogFieldTagControl",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "read_only": false,
+                      "required": false,
+                      "required_method_options": {},
+                      "default_value": 2,
+                      "values_method_options": {},
+                      "label": "Tag Integer Single Select",
+                      "position": 0,
+                      "dynamic": false,
+                      "show_refresh_button": false,
+                      "load_values_on_init": true,
+                      "auto_refresh": false,
+                      "trigger_auto_refresh": false,
+                      "reconfigurable": false,
+                      "visible": true,
+                      "options": {
+                        "category_id": "",
+                        "force_single_value": true,
+                        "sort_by": "description",
+                        "sort_order": "ascending"
+                      },
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      },
+                      "data_type": "integer",
+                      "values": [
+                        {
+                          "description": "Automotive",
+                          "href": "http://localhost:3000/api/service_dialogs/1",
+                          "id": "1",
+                          "name": "automotive"
+                        },
+                        {
+                          "description": "Engineering",
+                          "href": "http://localhost:3000/api/service_dialogs/2",
+                          "id": "2",
+                          "name": "engineering"
+                        },
+                        {
+                          "description": "Test",
+                          "href": "http://localhost:3000/api/service_dialogs/3",
+                          "id": "3",
+                          "name": "test"
+                        }
+                      ],
+                      "automation_type": "embedded_automate"
+                    },
+                    {
+                      "name": "tag_control_4",
+                      "description": "",
+                      "type": "DialogFieldTagControl",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "read_only": false,
+                      "required": false,
+                      "required_method_options": {},
+                      "default_value": [1, 2],
+                      "values_method_options": {},
+                      "label": "Tag Integer Multi Select",
+                      "position": 0,
+                      "dynamic": false,
+                      "show_refresh_button": false,
+                      "load_values_on_init": true,
+                      "auto_refresh": false,
+                      "trigger_auto_refresh": false,
+                      "reconfigurable": false,
+                      "visible": true,
+                      "options": {
+                        "category_id": "",
+                        "force_single_value": false,
+                        "sort_by": "description",
+                        "sort_order": "ascending"
+                      },
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      },
+                      "data_type": "integer",
+                      "values": [
+                        {
+                          "description": "Automotive",
+                          "href": "http://localhost:3000/api/service_dialogs/1",
+                          "id": "1",
+                          "name": "automotive"
+                        },
+                        {
+                          "description": "Engineering",
+                          "href": "http://localhost:3000/api/service_dialogs/2",
+                          "id": "2",
+                          "name": "engineering"
+                        },
+                        {
+                          "description": "Test",
+                          "href": "http://localhost:3000/api/service_dialogs/3",
+                          "id": "3",
+                          "name": "test"
+                        }
+                      ],
+                      "automation_type": "embedded_automate"
                     }
                   ]
                 }

--- a/demo/data/dialog-data.json
+++ b/demo/data/dialog-data.json
@@ -413,7 +413,7 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 3,
-                      "name": "integer_dropdown_3",
+                      "name": "integer_dropdown_1",
                       "data_type": "integer",
                       "display": "edit",
                       "display_method_options": {},
@@ -461,7 +461,7 @@
                     {
                       "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
                       "id": 4,
-                      "name": "integer_dropdown_4",
+                      "name": "integer_dropdown_2",
                       "data_type": "integer",
                       "display": "edit",
                       "display_method_options": {},

--- a/demo/data/dialog-data.json
+++ b/demo/data/dialog-data.json
@@ -302,6 +302,211 @@
                       }
                     }
                   ]
+                },
+                {
+                  "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000002379",
+                  "id": 10000000002379,
+                  "description": "Test Drop downs",
+                  "display": "edit",
+                  "created_at": "2017-06-16T19:29:28Z",
+                  "updated_at": "2017-06-16T19:29:28Z",
+                  "label": "Test drop downs",
+                  "dialog_tab_id": 10000000000987,
+                  "position": 1,
+                  "dialog_fields": [
+                    {
+                      "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
+                      "id": 1,
+                      "name": "1",
+                      "data_type": "string",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "required": true,
+                      "required_method_options": {},
+                      "default_value": "2",
+                      "values": [
+                        [
+                          "1",
+                          "1"
+                        ],
+                        [
+                          "2",
+                          "2"
+                        ],
+                        [
+                          "4",
+                          "4"
+                        ],
+                        [
+                          null,
+                          "<Choose>"
+                        ]
+                      ],
+                      "values_method_options": {},
+                      "options": {
+                        "sort_by": "description",
+                        "sort_order": "ascending",
+                        "force_multi_value": false
+                      },
+                      "created_at": "2017-06-16T19:29:28Z",
+                      "updated_at": "2017-06-16T19:29:28Z",
+                      "label": "String Single Select",
+                      "dialog_group_id": 10000000002379,
+                      "position": 1,
+                      "dynamic": false,
+                      "read_only": false,
+                      "visible": true,
+                      "type": "DialogFieldDropDownList",
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      }
+                    },
+                    {
+                      "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
+                      "id": 2,
+                      "name": "2",
+                      "data_type": "string",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "required": true,
+                      "required_method_options": {},
+                      "default_value": ["1", "2"],
+                      "values": [
+                        [
+                          "1",
+                          "1"
+                        ],
+                        [
+                          "2",
+                          "2"
+                        ],
+                        [
+                          "4",
+                          "4"
+                        ],
+                        [
+                          null,
+                          "<Choose>"
+                        ]
+                      ],
+                      "values_method_options": {},
+                      "options": {
+                        "sort_by": "description",
+                        "sort_order": "ascending",
+                        "force_multi_value": true
+                      },
+                      "created_at": "2017-06-16T19:29:28Z",
+                      "updated_at": "2017-06-16T19:29:28Z",
+                      "label": "String Multi Select",
+                      "dialog_group_id": 10000000002379,
+                      "position": 1,
+                      "dynamic": false,
+                      "read_only": false,
+                      "visible": true,
+                      "type": "DialogFieldDropDownList",
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      }
+                    },
+                    {
+                      "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
+                      "id": 3,
+                      "name": "3",
+                      "data_type": "integer",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "required": true,
+                      "required_method_options": {},
+                      "default_value": 2,
+                      "values": [
+                        [
+                          "1",
+                          1
+                        ],
+                        [
+                          "2",
+                          2
+                        ],
+                        [
+                          "4",
+                          4
+                        ],
+                        [
+                          null,
+                          "<Choose>"
+                        ]
+                      ],
+                      "values_method_options": {},
+                      "options": {
+                        "sort_by": "description",
+                        "sort_order": "ascending",
+                        "force_multi_value": false
+                      },
+                      "created_at": "2017-06-16T19:29:28Z",
+                      "updated_at": "2017-06-16T19:29:28Z",
+                      "label": "Integer Single Select",
+                      "dialog_group_id": 10000000002379,
+                      "position": 1,
+                      "dynamic": false,
+                      "read_only": false,
+                      "visible": true,
+                      "type": "DialogFieldDropDownList",
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      }
+                    },
+                    {
+                      "href": "http://localhost:3001/api/service_templates/10000000000015/service_dialogs/10000000007063",
+                      "id": 4,
+                      "name": "4",
+                      "data_type": "integer",
+                      "display": "edit",
+                      "display_method_options": {},
+                      "required": true,
+                      "required_method_options": {},
+                      "default_value": ["1", "2"],
+                      "values": [
+                        [
+                          "1",
+                          1
+                        ],
+                        [
+                          "2",
+                          2
+                        ],
+                        [
+                          "4",
+                          4
+                        ],
+                        [
+                          null,
+                          "<Choose>"
+                        ]
+                      ],
+                      "values_method_options": {},
+                      "options": {
+                        "sort_by": "description",
+                        "sort_order": "ascending",
+                        "force_multi_value": true
+                      },
+                      "created_at": "2017-06-16T19:29:28Z",
+                      "updated_at": "2017-06-16T19:29:28Z",
+                      "label": "Integer Multi Select",
+                      "dialog_group_id": 10000000002379,
+                      "position": 1,
+                      "dynamic": false,
+                      "read_only": false,
+                      "visible": true,
+                      "type": "DialogFieldDropDownList",
+                      "resource_action": {
+                        "resource_type": "DialogField",
+                        "ae_attributes": {}
+                      }
+                    }
+                  ]
                 }
               ]
             }

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -20,8 +20,9 @@ describe('Dialog test', () =>  {
       });
     });
     it('should have some values set', () => {
-        const expectedDialogs = ['option_1_cores_per_socket', 'option_1_vm_memory',
-                                 'option_1_vm_name', 'service_name', 'tag_0_environment', 'tag_1_function', '1', '2', '3', '4'];
+        const expectedDialogs = ['option_1_cores_per_socket', 'option_1_vm_memory', 'option_1_vm_name', 'service_name',
+                                 'tag_0_environment', 'tag_1_function', 'string_dropdown_1', 'string_dropdown_2', 
+                                 'integer_dropdown_1', 'integer_dropdown_2', 'tag_control_1', 'tag_control_2','tag_control_3', 'tag_control_4'].sort();
         const actualDialogs = Object.keys(dialogCtrl.dialogFields).sort();
         expect(expectedDialogs).toEqual(actualDialogs);
     });

--- a/src/dialog-user/components/dialog-user/dialogUser.spec.ts
+++ b/src/dialog-user/components/dialog-user/dialogUser.spec.ts
@@ -21,7 +21,7 @@ describe('Dialog test', () =>  {
     });
     it('should have some values set', () => {
         const expectedDialogs = ['option_1_cores_per_socket', 'option_1_vm_memory',
-                                 'option_1_vm_name', 'service_name', 'tag_0_environment', 'tag_1_function'];
+                                 'option_1_vm_name', 'service_name', 'tag_0_environment', 'tag_1_function', '1', '2', '3', '4'];
         const actualDialogs = Object.keys(dialogCtrl.dialogFields).sort();
         expect(expectedDialogs).toEqual(actualDialogs);
     });

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -109,13 +109,19 @@ export default class DialogDataService {
 
     // don't convert twice, FIXME: later refactor so that this doesn't get called twice for the same data
     if (data.type === 'DialogFieldDropDownList') {
-      if (data.default_value && _.isString(data.default_value)) {
-        if (data.options.force_multi_value) {
-          // multi-select - convert value from JSON, assume right type
-          defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
-        } else if (data.data_type === 'integer') {
-          // single-select - convert value to the chosen default_type, API always returns string
-          defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
+      if (data.default_value) {
+        if (_.isString(data.default_value)) {
+          if (data.options.force_multi_value) { // String data with array default_value
+            defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
+          } else { // String data with string default_value
+            defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
+          }
+        } else {
+          if (data.options.force_multi_value) { // Non-string data with array default_value
+            defaultValue = data.default_value.map((value) => this.convertDropdownValue(value, data.data_type));
+          } else { // Non-string data with string/integer default_value
+            defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
+          }
         }
       } else if (data.default_value === null || data.default_value === '') {
         defaultValue = null;
@@ -123,10 +129,12 @@ export default class DialogDataService {
     }
 
     if (data.type === 'DialogFieldTagControl') {
-      if (data.options.force_single_value) {
+      if (data.default_value === null || data.default_value === '') {
         defaultValue = null;
+      } else if (data.options.force_single_value) {
+        defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
       } else {
-        defaultValue = [];
+        defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
       }
     }
 

--- a/src/dialog-user/services/dialogData.ts
+++ b/src/dialog-user/services/dialogData.ts
@@ -131,10 +131,12 @@ export default class DialogDataService {
     if (data.type === 'DialogFieldTagControl') {
       if (data.default_value === null || data.default_value === '') {
         defaultValue = null;
-      } else if (data.options.force_single_value) {
-        defaultValue = this.convertDropdownValue(data.default_value, data.data_type);
-      } else {
-        defaultValue = JSON.parse(data.default_value).map((value) => this.convertDropdownValue(value, data.data_type));
+      } else if (data.options.force_single_value) { // string/integer default value
+        // For tag control, always convert to string
+        defaultValue = this.convertDropdownValue(data.default_value, 'string');
+      } else { // array default value
+        // For tag control, always convert to string
+        defaultValue = data.default_value.map((value) => value.toString());
       }
     }
 


### PR DESCRIPTION
This is a follow up to this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9482 to fix the tag control field default values.

These are test fields showing the default values working for the single and multi select dropdown and tag fields.
<img width="1073" height="440" alt="Screenshot 2025-09-03 at 1 50 23 PM" src="https://github.com/user-attachments/assets/b9ca76b5-f4e1-4790-8dbe-bbd3c8d59c4d" />
