### PR TITLE
Fix build issue where package is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . /ui-components
 
 RUN git clean -fdx
 RUN yarn install
-RUN yarn pack
+RUN yarn pack --out pkg/%s-%v.tgz

--- a/bin/build
+++ b/bin/build
@@ -9,12 +9,12 @@ docker build . -t $image --no-cache
 
 # Extract the package from the image
 container_id=$(docker create $image)
-package=$(docker run --rm -it --entrypoint /bin/bash $image -c "ls -1 manageiq-ui-components-*.tgz" | tr -d '\r')
-docker cp "$container_id:/ui-components/$package" pkg
+package=$(docker run --rm -it --entrypoint /bin/bash $image -c "cd pkg && ls -1 *.tgz" | tr -d '\r')
+docker cp "$container_id:/ui-components/pkg/$package" pkg
 docker rm "$container_id"
 
 echo
-echo "Package 'pkg/$package' has been built."
+echo "Package '$package' has been built."
 echo
 
 # Optionally publish the image


### PR DESCRIPTION
By default the package is built to /package.tgz. This changes enforces writing to the pkg directory with the full name and version in the file name. This is needed to differentiate any other local files from previous builds.

@agrare @GilbertCherrie Please review.