### PR TITLE
Split build and publish and add build to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
       run: bin/ci
     - name: Run security tests
       run: yarn test:security
+    - name: Run build
+      run: bin/build
     - name: Report code coverage
       if: "${{ github.ref == 'refs/heads/master' }}"
       continue-on-error: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . /ui-components
 
 RUN git clean -fdx
 RUN yarn install
-RUN yarn pack
+RUN yarn pack --out pkg/%s-%v.tgz

--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ docker build . -t $image --no-cache
 
 # Extract the package from the image
 container_id=$(docker create $image)
-package=$(docker run --rm -it --entrypoint /bin/bash $image -c "cd pkg && ls -1 *.tgz" | tr -d '\r')
+package=$(docker run --rm --entrypoint /bin/bash $image -c "cd pkg && ls -1 *.tgz" | tr -d '\r')
 docker cp "$container_id:/ui-components/pkg/$package" pkg
 docker rm "$container_id"
 

--- a/bin/build
+++ b/bin/build
@@ -16,19 +16,5 @@ docker rm "$container_id"
 echo
 echo "Package '$package' has been built."
 echo
-
-# Optionally publish the image
-read -r -p "Publish the package now? (y/N) " -n 1
+echo "You can publish the package with bin/publish"
 echo
-echo
-if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-    pushd pkg >/dev/null
-    npm login
-    npm publish --access public $package
-    popd >/dev/null
-else
-    echo "You can manually publish the package with:"
-    echo "    cd pkg"
-    echo "    npm login"
-    echo "    npm publish --access public $package"
-fi

--- a/bin/build
+++ b/bin/build
@@ -9,12 +9,12 @@ docker build . -t $image --no-cache
 
 # Extract the package from the image
 container_id=$(docker create $image)
-package=$(docker run --rm -it --entrypoint /bin/bash $image -c "ls -1 manageiq-ui-components-*.tgz" | tr -d '\r')
-docker cp "$container_id:/ui-components/$package" pkg
+package=$(docker run --rm -it --entrypoint /bin/bash $image -c "cd pkg && ls -1 *.tgz" | tr -d '\r')
+docker cp "$container_id:/ui-components/pkg/$package" pkg
 docker rm "$container_id"
 
 echo
-echo "Package 'pkg/$package' has been built."
+echo "Package '$package' has been built."
 echo
 
 # Optionally publish the image

--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "ERROR: Must specify a package to publish"
+    exit 1
+fi
+package=$1
+
+pushd pkg >/dev/null
+npm login
+npm publish --access public $package
+popd >/dev/null
+
+echo
+echo "Package '$package' has been published."
+echo


### PR DESCRIPTION
Built on #571 .  This adds the build to the test suite. This way renovate package PRs and things like #569 are also verifying that the build works.

@agrare @GilbertCherrie Please review.