### PR TITLE
Bump lodash to v4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-jasmine": "1.0.2",
     "karma-jsdom-launcher": "~7.1.0",
     "karma-webpack": "~1.8.1",
-    "lodash": "~4.17.20",
+    "lodash": "~4.18.0",
     "ng-annotate-webpack-plugin": "0.1.3",
     "numeral": "^2.0.6",
     "patternfly": "^3.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,7 +124,7 @@ __metadata:
     karma-jasmine: "npm:1.0.2"
     karma-jsdom-launcher: "npm:~7.1.0"
     karma-webpack: "npm:~1.8.1"
-    lodash: "npm:~4.17.20"
+    lodash: "npm:~4.18.0"
     ng-annotate-webpack-plugin: "npm:0.1.3"
     numeral: "npm:^2.0.6"
     patternfly: "npm:^3.15.0"
@@ -7608,10 +7608,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4, lodash@npm:^4.0.0, lodash@npm:^4.17.0, lodash@npm:^4.17.10, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:~4.17.20":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10/82504c88250f58da7a5a4289f57a4f759c44946c005dd232821c7688b5fcfbf4a6268f6a6cdde4b792c91edd2f3b5398c1d2a0998274432cff76def48735e233
+"lodash@npm:^4, lodash@npm:^4.0.0, lodash@npm:^4.17.0, lodash@npm:^4.17.10, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.3, lodash@npm:^4.17.4, lodash@npm:^4.17.5, lodash@npm:^4.3.0, lodash@npm:^4.5.0, lodash@npm:~4.18.0":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces: https://github.com/ManageIQ/ui-components/pull/568
PR to bump `lodash` to `4.18`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
