### PR TITLE
Cleanup useless regular-expression character escape

### DIFF
--- a/src/fonticon-picker/services/fonticonService.ts
+++ b/src/fonticon-picker/services/fonticonService.ts
@@ -24,7 +24,7 @@ export default class FonticonService {
   }
 
   private static clearRule(rule: string, family: string): string {
-    let re = new RegExp(`.*(${family}\-[a-z0-9\-\_]+).*`);
+    let re = new RegExp(`.*(${family}-[a-z0-9_-]+).*`);
     return rule.replace(re, '$1');
   }
 


### PR DESCRIPTION
@asirvadAbrahamVarghese These are triggering some low sev CodeQL issues because they are unnecessary.