### PR TITLE
Fix sporadic "AggregateError" issue in CI

### DIFF
--- a/demo/styles/demo-app.scss
+++ b/demo/styles/demo-app.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 ul.nav.nav-list.well {
   padding: 0;
 
@@ -72,14 +74,14 @@ table .narrow {
 
   @for $i from 0 through 10 {
     &.fill-#{$i}::before {
-      transform: rotate(#{$i / 20}turn);
+      transform: rotate(#{math.div($i, 20)}turn);
     }
   }
 
   @for $i from 11 through 20 {
     &.fill-#{$i}::before {
       background: $chart-fill;
-      transform: rotate(#{($i - 10) / 20}turn);
+      transform: rotate(#{math.div($i - 10, 20)}turn);
     }
   }
 }

--- a/src/styles/dialog-editor-boxes.scss
+++ b/src/styles/dialog-editor-boxes.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 .dialog-editor-container {
   background-color: #fff;
   padding: 20px;

--- a/src/styles/dialog-editor-toolbox.scss
+++ b/src/styles/dialog-editor-toolbox.scss
@@ -1,3 +1,5 @@
+@use 'colors' as *;
+
 .static-field-container {
   background-color: $color-white-94;
   border: 1.5px solid $color-light-gray-approx;

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'colors';
 @import 'dialog-editor';
 @import 'dialog-editor-toolbox';
@@ -222,7 +223,7 @@ miq-quadicon {
   $quad-w: 78px;
   $quad-h: 78px;
   $radius: 6px;
-  $font-size: $quad-w /3;
+  $font-size: math.div($quad-w, 3);
   $quad-bg: linear-gradient(180deg, rgb(144, 142, 143) 0%, rgb(87, 87, 87) 62%, rgb(64, 64, 65) 100%);
   $piechart-small: 30px;
   $piechart-large: 60px;
@@ -260,7 +261,7 @@ miq-quadicon {
       justify-content: center;
 
       position: relative;
-      height: $quad-h / 2;
+      height: math.div($quad-h, 2);
 
       .piechart {
         width: $piechart-small;
@@ -268,20 +269,20 @@ miq-quadicon {
       }
 
       .fileicon img{
-        height: $quad-h / 3 + ($quad-h / 14);
-        width: $quad-w / 3 + ($quad-h / 14);
+        height: math.div($quad-h, 3) + math.div($quad-h, 14);
+        width: math.div($quad-w, 3) + math.div($quad-h, 14);
       }
 
       .fonticon, .text {
-        font-size: $font-size / 2 + ($font-size / 3);
+        font-size: math.div($font-size, 2) + math.div($font-size, 3);
       }
 
       .text.font-small {
-        font-size: $font-size / 3 + ($font-size / 3);
+        font-size: math.div($font-size, 3) + math.div($font-size, 3);
       }
 
       .text.font-tiny {
-        font-size: $font-size * 1/2;
+        font-size: math.div($font-size, 2);
       }
 
       &.top-left {
@@ -304,14 +305,14 @@ miq-quadicon {
 
       &.middle {
         flex: 0 0 100%;
-        margin-top: - $quad-h + ($quad-h / 4);
+        margin-top: - $quad-h + math.div($quad-h, 4);
 
         .fileicon img {
-          height: $quad-h / 3 + ($quad-h / 14);
-          width: $quad-w / 3 + ($quad-h / 14);
+          height: math.div($quad-h, 3) + math.div($quad-h, 14);
+          width: math.div($quad-w, 3) + math.div($quad-h, 14);
         }
         .fonticon {
-          font-size: $font-size + ($font-size / 5);
+          font-size: $font-size + math.div($font-size, 5);
         }
       }
     }
@@ -329,8 +330,8 @@ miq-quadicon {
       & > miq-quaditem {
 
         .fileicon img {
-          height: $quad-h / 2 + ($quad-h / 4);
-          width: $quad-w / 2 + ($quad-w / 4);
+          height: math.div($quad-h, 2) + math.div($quad-h, 4);
+          width: math.div($quad-w, 2) + math.div($quad-w, 4);
         }
 
         .piechart {
@@ -343,11 +344,11 @@ miq-quadicon {
         }
 
         .text.font-small {
-          font-size: $font-size * 3/3;
+          font-size: math.div($font-size * 3, 3);
         }
 
         .text.font-tiny {
-          font-size: $font-size * 2/3;
+          font-size: math.div($font-size * 2, 3);
         }
       }
   }

--- a/src/styles/ui-components.scss
+++ b/src/styles/ui-components.scss
@@ -1,8 +1,7 @@
 @use 'sass:math';
-@import 'colors';
-@import 'dialog-editor';
-@import 'dialog-editor-toolbox';
-@import 'dialog-editor-boxes';
+@use 'dialog-editor';
+@use 'dialog-editor-toolbox';
+@use 'dialog-editor-boxes';
 
 /* Begin Patternfly Tab overrides used in the Dialog Editor */
 


### PR DESCRIPTION
PR to fix SCSS warnings:

 - ### Caused by deprecated division(`/`), replaced with `math.div`

```
Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($i, 20) or calc($i / 20)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
75 │       transform: rotate(#{$i / 20}turn);
   │                           ^^^^^^^
   ╵
    stdin 75:27  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($i - 10, 20) or calc(($i - 10) / 20)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
82 │       transform: rotate(#{($i - 10) / 20}turn);
   │                           ^^^^^^^^^^^^^^
   ╵
    stdin 82:27  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($quad-w, 3) or calc($quad-w / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
225 │   $font-size: $quad-w /3;
    │               ^^^^^^^^^^
    ╵
    stdin 225:15  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($quad-h, 2) or calc($quad-h / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
263 │       height: $quad-h / 2;
    │               ^^^^^^^^^^^
    ╵
    stdin 263:15  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($quad-h, 3) or calc($quad-h / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
271 │         height: $quad-h / 3 + ($quad-h / 14);
    │                 ^^^^^^^^^^^
    ╵
    stdin 271:17  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($quad-h, 14) or calc($quad-h / 14)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
271 │         height: $quad-h / 3 + ($quad-h / 14);
    │                                ^^^^^^^^^^^^
    ╵
    stdin 271:32  root stylesheet

Deprecation Warning [slash-div]: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($quad-w, 3) or calc($quad-w / 3)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
272 │         width: $quad-w / 3 + ($quad-h / 14);
    │                ^^^^^^^^^^^
    ╵
    stdin 272:16  root stylesheet

Warning: 18 repetitive deprecation warnings omitted.
```

 - ### Caused by deprecated `@import` rules, replaced with `@use`
```
Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
2 │ @import 'colors';
  │         ^^^^^^^^
  ╵
    stdin 2:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
3 │ @import 'dialog-editor';
  │         ^^^^^^^^^^^^^^^
  ╵
    stdin 3:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
4 │ @import 'dialog-editor-toolbox';
  │         ^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    stdin 4:9  root stylesheet

Deprecation Warning [import]: Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

  ╷
5 │ @import 'dialog-editor-boxes';
  │         ^^^^^^^^^^^^^^^^^^^^^
  ╵
    stdin 5:9  root stylesheet
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
