### PR TITLE
Fix sporadic AggregateError in CI by disabling BrowserSync during tests

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,25 @@ module.exports = (env) => {
       minimize: true,
       drop_console: true,
     }) : undefined,
+    !production && !test ? new BrowserSyncPlugin({
+      host: 'localhost',
+      port: 4000,
+      server: {baseDir: [__dirname + settings.distFolder]},
+      open: true,
+      middleware: [
+        {
+          route: "/data",
+          handle: function (req, res, next) {
+            req.method = 'GET';
+            return next();
+          },
+        },
+      ],
+    }, {
+      use: spa({
+        selector: '[ng-app]',
+      }),
+    }) : undefined,
   ].filter(p => !!p);
 
   return {
@@ -108,28 +127,7 @@ module.exports = (env) => {
         },
       ],
     },
-    plugins: [
-      ...plugins,
-      new BrowserSyncPlugin({
-        host: 'localhost',
-        port: 4000,
-        server: {baseDir: [__dirname + settings.distFolder]},
-        open: !test,
-        middleware: [
-          {
-            route: "/data",
-            handle: function (req, res, next) {
-              req.method = 'GET';
-              return next();
-            },
-          },
-        ],
-      }, {
-        use: spa({
-          selector: '[ng-app]',
-        }),
-      }),
-    ],
+    plugins: plugins,
     externals: {
       'angular': 'angular',
       'lodash': '_',


### PR DESCRIPTION
The CI was experiencing sporadic failures with an unhelpful 'AggregateError' message that provided no details about the actual problem.

Root cause: BrowserSyncPlugin in webpack.config.js was attempting to start a development server on port 4000 during test runs. In CI environments, this resulted in connection timeouts (ETIMEDOUT on ::1:4000) and connection refused errors (ECONNREFUSED on 127.0.0.1:4000). These errors were wrapped in an AggregateError but only the string 'AggregateError' was logged.

Changed webpack.config.js to conditionally exclude BrowserSyncPlugin when running tests as BrowserSync is only needed for local development.

@asirvadAbrahamVarghese Please review. (Debugging session in #585 - https://github.com/ManageIQ/ui-components/actions/runs/25003068697/job/73222695896 was very enlightening)