### PR TITLE
Give a better hint about how to use bin/publish

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -16,5 +16,6 @@ docker rm "$container_id"
 echo
 echo "Package '$package' has been built."
 echo
-echo "You can publish the package with bin/publish"
+echo "You can publish the package with"
+echo "  bin/publish pkg/$package"
 echo

--- a/bin/publish
+++ b/bin/publish
@@ -8,10 +8,8 @@ if [ -z "$1" ]; then
 fi
 package=$1
 
-pushd pkg >/dev/null
 npm login
 npm publish --access public $package
-popd >/dev/null
 
 echo
 echo "Package '$package' has been published."


### PR DESCRIPTION
@agrare Please review.

This was a minor change for clarity - when I went to publish, I did `bin/publish pkg/@manageiq-ui-components-1.7.0.tgz` from the root because that's where the file is (and I could use tab complete to get the name). However, that blew up because we `pushd pkg`, so it tried to publish `pkg/pkg/@manageiq-ui-components-1.7.0.tgz`. Instead I dropped the pushd/popd, then gave a cleaner hint in bin/build.