### PR TITLE
Fix build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,26 +10,64 @@ pids
 # Users Environment Variables
 .lock-wscript
 
+# Demo files - not needed in package
+demo/
+
+# Build artifacts not needed in package
 dist/assets/
 dist/data/
 dist/docs/
 dist/**/demo-app.*
+dist/index.html
 .tmp/
 libs/
-node_modules/
-dist/index.html
 tsd/
 typings/
 vendor.js
 vendor.css
 
+# Dependencies
+node_modules/
+
+# OS files
 ._*
 .DS_Store
 
-# idea files
+# IDE files
 .idea/
 *.ipr
 *.iws
 *.iml
 
+# Testing
 coverage
+
+# Development/CI files
+.dockerignore
+.editorconfig
+.eslintrc.json
+.gitattributes
+.gitignore
+.whitesource
+.yarnrc.yml
+.github/
+.yarn/
+Dockerfile
+karma.conf.js
+Rakefile
+renovate.json
+tsconfig.json
+tslint.json
+jsdoc-conf.json
+
+# Build scripts
+bin/
+
+# Source files (only ship dist/)
+src/
+
+# Locale source files (only ship compiled if needed)
+locale/
+
+# Scripts
+scripts/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "yarn run install-vendor && webpack --watch",
     "test": "yarn run install-vendor && karma start",
-    "prepublish": "webpack || true",
+    "prepack": "yarn run build",
     "build": "yarn run install-vendor && webpack -p",
     "build-dev": "yarn run install-vendor && webpack",
     "gettext:extract": "yarn run build && angular-gettext-cli --files './+(src|dist)/**/+(*.html|ui-components.js)' --dest './locale/ui-components.pot' --marker-names '__,N_' --no-line-numbers && yarn run gettext:validate",


### PR DESCRIPTION
Since we are using yarn pack to build the .tgz file, we need to ensure we build using the prepack hook and not the prepublish hook.

@GilbertCherrie Please review.

After the package will contain the following (See https://github.com/ManageIQ/ui-components/actions/runs/25943024772/job/76264894945?pr=609#step:8:132 for the output)

```
package/CHANGELOG.md
package/LICENSE
package/MiQ-UI-Architecture.jpg
package/README.md
package/application-settings.js
package/dist/82ccace65d0fdab3e98b5e7b96166c5b.svg
package/dist/a89bdb5dace06b7d15aca49cf371ef57.eot
package/dist/ac7121e0a5f96bcdb453b8517fcf1538.ttf
package/dist/css/ui-components.css
package/dist/css/ui-components.css.map
package/dist/js/ui-components.js
package/dist/js/ui-components.js.map
package/package.json
package/pkg/.gitkeep
package/webpack.config.js
package/webpack.vendor.config.js
```