### PR TITLE
Add automated locale update workflow

### DIFF
--- a/.github/workflows/locale_update.yaml
+++ b/.github/workflows/locale_update.yaml
@@ -1,0 +1,55 @@
+name: Locale Update
+on:
+  schedule:
+  - cron: '0 0 8,22 * *'
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  locale_update:
+    if: github.repository_owner == 'ManageIQ'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up system
+      run: bin/before_install
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: package.json
+        cache: yarn
+        registry-url: https://npm.manageiq.org/
+    - name: Install dependencies
+      run: yarn install
+    - name: Extract translations
+      run: yarn gettext:extract
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v8
+      with:
+        add-paths: |
+          locale/ui-components.pot
+        commit-message: Update English Translations
+        branch: update_english_translations
+        author: ManageIQ Bot <bot@manageiq.org>
+        committer: ManageIQ Bot <bot@manageiq.org>
+        delete-branch: true
+        assignees: jrafanie
+        labels: internationalization
+        push-to-fork: miq-bot/ui-components
+        title: Update English Translations
+        body: Update the English Translations in the ui-components.pot file.
+        token: "${{ secrets.PR_TOKEN }}"
+  on_failure:
+    needs: locale_update
+    if: always() && github.repository_owner == 'ManageIQ' && needs.locale_update.result != 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Notify on failure
+      uses: slackapi/slack-github-action@v3
+      with:
+        webhook: "${{ secrets.GHA_STATUS_SLACK_WEBHOOK_URL }}"
+        webhook-type: incoming-webhook
+        payload: 'text: ":red_circle: *GitHub Actions workflow ${{ needs.locale_update.result }}*\n${{ github.workflow_ref }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"'

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ yarn build-docs
 ```
 This will generate docs from JS docs and after running `yarn start` this documentation will be available on `localhost:4000/docs`
 
+#### Translations
+
+Translation strings are automatically extracted from the codebase and stored in `locale/ui-components.pot`. This process is automated via GitHub Actions:
+
+- **Automated Updates**: The [Locale Update workflow](.github/workflows/locale_update.yaml) runs twice per month (see cron schedule in workflow file)
+- **Manual Trigger**: Can be triggered manually via GitHub Actions UI
+- **Process**: Runs `yarn gettext:extract` and creates a PR with any changes to `locale/ui-components.pot`
+- **Integration**: ManageIQ's locale workflow pulls this pot file and merges it into the main `manageiq.pot`
+
+To manually extract translations locally:
+```
+yarn gettext:extract
+```
+
 #### Building a release
 
 In order to build a release you must first update the version number in the `package.json`.


### PR DESCRIPTION
Creates GitHub Actions workflow to automatically extract translation strings from ui-components and generate locale/ui-components.pot file.

- Runs twice per month one week before ManageIQ's locale updates
- Follows ManageIQ's locale_update_all.yaml pattern
- Creates PRs via miq-bot/ui-components fork

Fixes https://github.com/ManageIQ/manageiq/issues/23856

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
